### PR TITLE
[Transition] Rename in-/outward css classes

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -724,7 +724,7 @@ $.fn.form = function(parameters) {
               if(!promptExists) {
                 if(settings.transition && $.fn.transition !== undefined && $module.transition('is supported')) {
                   module.verbose('Displaying error with css transition', settings.transition);
-                  $prompt.transition(settings.transition + ' in', settings.duration);
+                  $prompt.transition(settings.transition + ' inward', settings.duration);
                 }
                 else {
                   module.verbose('Displaying error with fallback javascript animation');
@@ -805,7 +805,7 @@ $.fn.form = function(parameters) {
             if(settings.inline && $prompt.is(':visible')) {
               module.verbose('Removing prompt for field', identifier);
               if(settings.transition && $.fn.transition !== undefined && $module.transition('is supported')) {
-                $prompt.transition(settings.transition + ' out', settings.duration, function() {
+                $prompt.transition(settings.transition + ' outward', settings.duration, function() {
                   $prompt.remove();
                 });
               }

--- a/src/definitions/behaviors/visibility.js
+++ b/src/definitions/behaviors/visibility.js
@@ -1257,7 +1257,7 @@ $.fn.visibility.settings = {
   zIndex                 : '10',
 
   // image only animation settings
-  transition             : 'fade in',
+  transition             : 'fade inward',
   duration               : 1000,
 
   // array of callbacks for percentage

--- a/src/definitions/modules/accordion.js
+++ b/src/definitions/modules/accordion.js
@@ -185,7 +185,7 @@ $.fn.accordion = function(parameters) {
               $activeContent
                 .children()
                   .transition({
-                    animation   : 'fade in',
+                    animation   : 'fade inward',
                     queue       : false,
                     useFailSafe : true,
                     debug       : settings.debug,
@@ -246,7 +246,7 @@ $.fn.accordion = function(parameters) {
                 $activeContent
                   .children()
                     .transition({
-                      animation   : 'fade out',
+                      animation   : 'fade outward',
                       queue       : false,
                       useFailSafe : true,
                       debug       : settings.debug,
@@ -316,7 +316,7 @@ $.fn.accordion = function(parameters) {
                 $openContents
                   .children()
                     .transition({
-                      animation   : 'fade out',
+                      animation   : 'fade outward',
                       useFailSafe : true,
                       debug       : settings.debug,
                       verbose     : settings.verbose,

--- a/src/definitions/modules/dimmer.js
+++ b/src/definitions/modules/dimmer.js
@@ -241,7 +241,7 @@ $.fn.dimmer = function(parameters) {
               $dimmer
                 .transition({
                   displayType : 'flex',
-                  animation   : settings.transition + ' in',
+                  animation   : settings.transition + ' inward',
                   queue       : false,
                   duration    : module.get.duration(),
                   useFailSafe : true,
@@ -286,7 +286,7 @@ $.fn.dimmer = function(parameters) {
               $dimmer
                 .transition({
                   displayType : 'flex',
-                  animation   : settings.transition + ' out',
+                  animation   : settings.transition + ' outward',
                   queue       : false,
                   duration    : module.get.duration(),
                   useFailSafe : true,

--- a/src/definitions/modules/dimmer.less
+++ b/src/definitions/modules/dimmer.less
@@ -135,7 +135,7 @@
   transform-origin: center center;
 }
 
-body.animating.in.dimmable,
+body.animating.inward.dimmable,
 body.dimmed.dimmable {
   overflow: hidden;
 }

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -3374,7 +3374,7 @@ $.fn.dropdown = function(parameters) {
               else if($.fn.transition !== undefined && $module.transition('is supported')) {
                 $currentMenu
                   .transition({
-                    animation  : transition + ' in',
+                    animation  : transition + ' inward',
                     debug      : settings.debug,
                     verbose    : settings.verbose,
                     duration   : settings.duration,
@@ -3422,7 +3422,7 @@ $.fn.dropdown = function(parameters) {
               else if($.fn.transition !== undefined && $module.transition('is supported')) {
                 $currentMenu
                   .transition({
-                    animation  : transition + ' out',
+                    animation  : transition + ' outward',
                     duration   : settings.duration,
                     debug      : settings.debug,
                     verbose    : settings.verbose,

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -342,7 +342,7 @@ $.fn.modal = function(parameters) {
                 $module
                   .transition({
                     debug       : settings.debug,
-                    animation   : settings.transition + ' in',
+                    animation   : settings.transition + ' inward',
                     queue       : settings.queue,
                     duration    : settings.duration,
                     useFailSafe : true,
@@ -388,7 +388,7 @@ $.fn.modal = function(parameters) {
               $module
                 .transition({
                   debug       : settings.debug,
-                  animation   : settings.transition + ' out',
+                  animation   : settings.transition + ' outward',
                   queue       : settings.queue,
                   duration    : settings.duration,
                   useFailSafe : true,

--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -425,7 +425,7 @@ $.fn.popup = function(parameters) {
               module.set.visible();
               $popup
                 .transition({
-                  animation  : settings.transition + ' in',
+                  animation  : settings.transition + ' inward',
                   queue      : false,
                   debug      : settings.debug,
                   verbose    : settings.verbose,
@@ -452,7 +452,7 @@ $.fn.popup = function(parameters) {
             if(settings.transition && $.fn.transition !== undefined && $module.transition('is supported')) {
               $popup
                 .transition({
-                  animation  : settings.transition + ' out',
+                  animation  : settings.transition + ' outward',
                   queue      : false,
                   duration   : settings.duration,
                   debug      : settings.debug,

--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -938,7 +938,7 @@ $.fn.search = function(parameters) {
               module.debug('Showing results with css animations');
               $results
                 .transition({
-                  animation  : settings.transition + ' in',
+                  animation  : settings.transition + ' inward',
                   debug      : settings.debug,
                   verbose    : settings.verbose,
                   duration   : settings.duration,
@@ -969,7 +969,7 @@ $.fn.search = function(parameters) {
               module.debug('Hiding results with css animations');
               $results
                 .transition({
-                  animation  : settings.transition + ' out',
+                  animation  : settings.transition + ' outward',
                   debug      : settings.debug,
                   verbose    : settings.verbose,
                   duration   : settings.duration,

--- a/src/definitions/modules/sidebar.less
+++ b/src/definitions/modules/sidebar.less
@@ -449,31 +449,31 @@ body.pushable > .pusher {
 ---------------*/
 
 /* Initial */
-.ui.slide.out.sidebar {
+.ui.slide.outward.sidebar {
   z-index: @bottomLayer;
 }
 
 /* Sidebar - Initial */
-.ui.left.slide.out.sidebar {
+.ui.left.slide.outward.sidebar {
   transform: translate3d(50%, 0, 0);
 }
-.ui.right.slide.out.sidebar {
+.ui.right.slide.outward.sidebar {
   transform: translate3d(-50%, 0, 0);
 }
-.ui.top.slide.out.sidebar {
+.ui.top.slide.outward.sidebar {
   transform: translate3d(0%, 50%, 0);
 }
-.ui.bottom.slide.out.sidebar {
+.ui.bottom.slide.outward.sidebar {
   transform: translate3d(0%, -50%, 0);
 }
 
 /* Animation */
-.ui.animating.slide.out.sidebar {
+.ui.animating.slide.outward.sidebar {
   transition: transform @duration @easing;
 }
 
 /* End */
-.ui.visible.slide.out.sidebar {
+.ui.visible.slide.outward.sidebar {
   transform: translate3d(0%, 0, 0);
 }
 

--- a/src/definitions/modules/transition.js
+++ b/src/definitions/modules/transition.js
@@ -1073,10 +1073,10 @@ $.fn.transition.settings = {
     animating  : 'animating',
     disabled   : 'disabled',
     hidden     : 'hidden',
-    inward     : 'in',
+    inward     : 'inward',
     loading    : 'loading',
     looping    : 'looping',
-    outward    : 'out',
+    outward    : 'outward',
     transition : 'transition',
     visible    : 'visible'
   },

--- a/src/definitions/modules/transition.js
+++ b/src/definitions/modules/transition.js
@@ -584,7 +584,7 @@ $.fn.transition = function() {
             animation = animation || settings.animation;
             if(typeof animation === 'string') {
               animation = animation.split(' ');
-              // search animation name for out/in class
+              // search animation name for outward/inward class
               $.each(animation, function(index, word){
                 if(word === className.inward) {
                   direction = className.inward;

--- a/src/themes/default/modules/transition.overrides
+++ b/src/themes/default/modules/transition.overrides
@@ -17,14 +17,14 @@
 .transition.browse {
   animation-duration: 500ms;
 }
-.transition.browse.in {
+.transition.browse.inward {
   animation-name: browseIn;
 }
-.transition.browse.out,
-.transition.browse.left.out {
+.transition.browse.outward,
+.transition.browse.left.outward {
   animation-name: browseOutLeft;
 }
-.transition.browse.right.out {
+.transition.browse.right.outward {
   animation-name: browseOutRight;
 }
 
@@ -98,10 +98,10 @@
   animation-duration: 400ms;
   animation-timing-function: cubic-bezier(0.34, 1.61, 0.7, 1);
 }
-.drop.transition.in {
+.drop.transition.inward {
   animation-name: dropIn;
 }
-.drop.transition.out {
+.drop.transition.outward {
   animation-name: dropOut;
 }
 
@@ -131,35 +131,35 @@
       Fade
 ---------------*/
 
-.transition.fade.in {
+.transition.fade.inward {
   animation-name: fadeIn;
 }
-.transition[class*="fade up"].in {
+.transition[class*="fade up"].inward {
   animation-name: fadeInUp;
 }
-.transition[class*="fade down"].in {
+.transition[class*="fade down"].inward {
   animation-name: fadeInDown;
 }
-.transition[class*="fade left"].in {
+.transition[class*="fade left"].inward {
   animation-name: fadeInLeft;
 }
-.transition[class*="fade right"].in {
+.transition[class*="fade right"].inward {
   animation-name: fadeInRight;
 }
 
-.transition.fade.out {
+.transition.fade.outward {
   animation-name: fadeOut;
 }
-.transition[class*="fade up"].out {
+.transition[class*="fade up"].outward {
   animation-name: fadeOutUp;
 }
-.transition[class*="fade down"].out {
+.transition[class*="fade down"].outward {
   animation-name: fadeOutDown;
 }
-.transition[class*="fade left"].out {
+.transition[class*="fade left"].outward {
   animation-name: fadeOutLeft;
 }
-.transition[class*="fade right"].out {
+.transition[class*="fade right"].outward {
   animation-name: fadeOutRight;
 }
 
@@ -267,20 +267,20 @@
      Flips
 ---------------*/
 
-.flip.transition.in,
-.flip.transition.out {
+.flip.transition.inward,
+.flip.transition.outward {
   animation-duration: 600ms;
 }
-.horizontal.flip.transition.in {
+.horizontal.flip.transition.inward {
   animation-name: horizontalFlipIn;
 }
-.horizontal.flip.transition.out {
+.horizontal.flip.transition.outward {
   animation-name: horizontalFlipOut;
 }
-.vertical.flip.transition.in {
+.vertical.flip.transition.inward {
   animation-name: verticalFlipIn;
 }
-.vertical.flip.transition.out {
+.vertical.flip.transition.outward {
   animation-name: verticalFlipOut;
 }
 
@@ -332,10 +332,10 @@
       Scale
 ---------------*/
 
-.scale.transition.in {
+.scale.transition.inward {
   animation-name: scaleIn;
 }
-.scale.transition.out {
+.scale.transition.outward {
   animation-name: scaleOut;
 }
 
@@ -372,36 +372,36 @@
   animation-duration: 0.6s;
   transition-timing-function: cubic-bezier(0.215, 0.610, 0.355, 1.000);
 }
-.transition.fly.in {
+.transition.fly.inward {
   animation-name: flyIn;
 }
-.transition[class*="fly up"].in {
+.transition[class*="fly up"].inward {
   animation-name: flyInUp;
 }
-.transition[class*="fly down"].in {
+.transition[class*="fly down"].inward {
   animation-name: flyInDown;
 }
-.transition[class*="fly left"].in {
+.transition[class*="fly left"].inward {
   animation-name: flyInLeft;
 }
-.transition[class*="fly right"].in {
+.transition[class*="fly right"].inward {
   animation-name: flyInRight;
 }
 
 /* Outward */
-.transition.fly.out {
+.transition.fly.outward {
   animation-name: flyOut;
 }
-.transition[class*="fly up"].out {
+.transition[class*="fly up"].outward {
   animation-name: flyOutUp;
 }
-.transition[class*="fly down"].out {
+.transition[class*="fly down"].outward {
   animation-name: flyOutDown;
 }
-.transition[class*="fly left"].out {
+.transition[class*="fly left"].outward {
   animation-name: flyOutLeft;
 }
-.transition[class*="fly right"].out {
+.transition[class*="fly right"].outward {
   animation-name: flyOutRight;
 }
 
@@ -571,38 +571,38 @@
      Slide
 ---------------*/
 
-.transition.slide.in,
-.transition[class*="slide down"].in {
+.transition.slide.inward,
+.transition[class*="slide down"].inward {
   animation-name: slideInY;
   transform-origin: top center;
 }
-.transition[class*="slide up"].in {
+.transition[class*="slide up"].inward {
   animation-name: slideInY;
   transform-origin: bottom center;
 }
-.transition[class*="slide left"].in {
+.transition[class*="slide left"].inward {
   animation-name: slideInX;
   transform-origin: center right;
 }
-.transition[class*="slide right"].in {
+.transition[class*="slide right"].inward {
   animation-name: slideInX;
   transform-origin: center left;
 }
 
-.transition.slide.out,
-.transition[class*="slide down"].out {
+.transition.slide.outward,
+.transition[class*="slide down"].outward {
   animation-name: slideOutY;
   transform-origin: top center;
 }
-.transition[class*="slide up"].out {
+.transition[class*="slide up"].outward {
   animation-name: slideOutY;
   transform-origin: bottom center;
 }
-.transition[class*="slide left"].out {
+.transition[class*="slide left"].outward {
   animation-name: slideOutX;
   transform-origin: center right;
 }
-.transition[class*="slide right"].out {
+.transition[class*="slide right"].outward {
   animation-name: slideOutX;
   transform-origin: center left;
 }
@@ -660,37 +660,37 @@
   animation-duration: 800ms;
 }
 
-.transition[class*="swing down"].in {
+.transition[class*="swing down"].inward {
   animation-name: swingInX;
   transform-origin: top center;
 }
-.transition[class*="swing up"].in {
+.transition[class*="swing up"].inward {
   animation-name: swingInX;
   transform-origin: bottom center;
 }
-.transition[class*="swing left"].in {
+.transition[class*="swing left"].inward {
   animation-name: swingInY;
   transform-origin: center right;
 }
-.transition[class*="swing right"].in {
+.transition[class*="swing right"].inward {
   animation-name: swingInY;
   transform-origin: center left;
 }
 
-.transition.swing.out,
-.transition[class*="swing down"].out {
+.transition.swing.outward,
+.transition[class*="swing down"].outward {
   animation-name: swingOutX;
   transform-origin: top center;
 }
-.transition[class*="swing up"].out {
+.transition[class*="swing up"].outward {
   animation-name: swingOutX;
   transform-origin: bottom center;
 }
-.transition[class*="swing left"].out {
+.transition[class*="swing left"].outward {
   animation-name: swingOutY;
   transform-origin: center right;
 }
-.transition[class*="swing right"].out {
+.transition[class*="swing right"].outward {
   animation-name: swingOutY;
   transform-origin: center left;
 }
@@ -780,10 +780,10 @@
       Zoom
 ---------------*/
 
-.transition.zoom.in {
+.transition.zoom.inward {
   animation-name: zoomIn;
 }
-.transition.zoom.out {
+.transition.zoom.outward {
   animation-name: zoomOut;
 }
 @keyframes zoomIn {


### PR DESCRIPTION
The 'in' class clashed with .linked-in.in icon, renamed 'out' correspondingly

Fixes Semantic-Org/Semantic-UI#6428

### BREAKING CHANGE
Manipulating the transition with css class .in must be updated to .inward