### PR TITLE
[Checkbox] Implements inverted mode for standalone checkboxes

### DIFF
--- a/src/definitions/modules/checkbox.less
+++ b/src/definitions/modules/checkbox.less
@@ -595,4 +595,68 @@
   width: @sliderWidth;
 }
 
+/*--------------
+     Inverted
+---------------*/
+.ui.inverted.checkbox label,
+.ui.inverted.checkbox + label {
+  color: @invertedTextColor !important;
+}
+
+/* Hover */
+.ui.inverted.checkbox .box:hover,
+.ui.inverted.checkbox label:hover {
+  color: @invertedHoveredTextColor !important;
+}
+
+/* Slider Line */
+.ui.inverted.slider.checkbox .box:before,
+.ui.inverted.slider.checkbox label:before {
+  background-color: @invertedTextColor !important;
+}
+
+/* Slider Hover */
+.ui.inverted.slider.checkbox .box:hover::before,
+.ui.inverted.slider.checkbox label:hover::before {
+  background: @invertedHoveredTextColor !important;
+}
+
+/* Slider Active */
+.ui.inverted.slider.checkbox input:checked ~ .box,
+.ui.inverted.slider.checkbox input:checked ~ label {
+  color: @invertedTextColor !important;
+}
+.ui.inverted.slider.checkbox input:checked ~ .box:before,
+.ui.inverted.slider.checkbox input:checked ~ label:before {
+  background-color: @invertedTextColor !important;
+}
+
+/* Slider Active Focus */
+.ui.inverted.slider.checkbox input:focus:checked ~ .box,
+.ui.inverted.slider.checkbox input:focus:checked ~ label {
+  color: @invertedTextColor !important;
+}
+.ui.inverted.slider.checkbox input:focus:checked ~ .box:before,
+.ui.inverted.slider.checkbox input:focus:checked ~ label:before {
+  background-color: @invertedTextColor !important;
+}
+
+/* Toggle Switch */
+.ui.inverted.toggle.checkbox .box:before,
+.ui.inverted.toggle.checkbox label:before {
+  background-color: @invertedTextColor !important;
+}
+
+/* Toggle Active */
+.ui.inverted.toggle.checkbox input:checked ~ .box,
+.ui.inverted.toggle.checkbox input:checked ~ label {
+  color: @invertedTextColor !important;
+}
+
+/* Toggle Active Focus */
+.ui.inverted.toggle.checkbox input:focus:checked ~ .box,
+.ui.inverted.toggle.checkbox input:focus:checked ~ label {
+  color: @invertedTextColor !important;
+}
+
 .loadUIOverrides();

--- a/src/definitions/modules/checkbox.less
+++ b/src/definitions/modules/checkbox.less
@@ -608,37 +608,47 @@
 .ui.inverted.checkbox label:hover {
   color: @invertedHoveredTextColor !important;
 }
+.ui.inverted.checkbox .box:hover::before,
+.ui.inverted.checkbox label:hover::before {
+  border-color: @strongSelectedBorderColor;
+}
+
+/*Slider Label */
+.ui.inverted.slider.checkbox .box,
+.ui.inverted.slider.checkbox label {
+  color: @invertedUnselectedTextColor;
+}
 
 /* Slider Line */
 .ui.inverted.slider.checkbox .box:before,
 .ui.inverted.slider.checkbox label:before {
-  background-color: @invertedTextColor !important;
+  background-color: @invertedUnselectedTextColor !important;
 }
 
 /* Slider Hover */
 .ui.inverted.slider.checkbox .box:hover::before,
 .ui.inverted.slider.checkbox label:hover::before {
-  background: @invertedHoveredTextColor !important;
+  background: @invertedLightTextColor !important;
 }
 
 /* Slider Active */
 .ui.inverted.slider.checkbox input:checked ~ .box,
 .ui.inverted.slider.checkbox input:checked ~ label {
-  color: @invertedTextColor !important;
+  color: @invertedSelectedTextColor !important;
 }
 .ui.inverted.slider.checkbox input:checked ~ .box:before,
 .ui.inverted.slider.checkbox input:checked ~ label:before {
-  background-color: @invertedTextColor !important;
+  background-color: @selectedWhiteBorderColor !important;
 }
 
 /* Slider Active Focus */
 .ui.inverted.slider.checkbox input:focus:checked ~ .box,
 .ui.inverted.slider.checkbox input:focus:checked ~ label {
-  color: @invertedTextColor !important;
+  color: @invertedSelectedTextColor !important;
 }
 .ui.inverted.slider.checkbox input:focus:checked ~ .box:before,
 .ui.inverted.slider.checkbox input:focus:checked ~ label:before {
-  background-color: @invertedTextColor !important;
+  background-color: @selectedWhiteBorderColor !important;
 }
 
 /* Toggle Switch */
@@ -647,16 +657,30 @@
   background-color: @invertedTextColor !important;
 }
 
+/* Toggle Hover */
+.ui.inverted.toggle.checkbox .box:hover::before,
+.ui.inverted.toggle.checkbox label:hover::before {
+  background: @invertedHoveredTextColor !important;
+}
+
 /* Toggle Active */
 .ui.inverted.toggle.checkbox input:checked ~ .box,
 .ui.inverted.toggle.checkbox input:checked ~ label {
-  color: @invertedTextColor !important;
+  color: @invertedSelectedTextColor !important;
+}
+.ui.inverted.toggle.checkbox input:checked ~ .box:before,
+.ui.inverted.toggle.checkbox input:checked ~ label:before {
+  background-color: @toggleOnLaneColor !important;
 }
 
 /* Toggle Active Focus */
 .ui.inverted.toggle.checkbox input:focus:checked ~ .box,
 .ui.inverted.toggle.checkbox input:focus:checked ~ label {
-  color: @invertedTextColor !important;
+  color: @invertedSelectedTextColor !important;
+}
+.ui.inverted.toggle.checkbox input:focus:checked ~ .box:before,
+.ui.inverted.toggle.checkbox input:focus:checked ~ label:before {
+  background-color: @toggleOnFocusLaneColor !important;
 }
 
 .loadUIOverrides();

--- a/src/themes/default/modules/checkbox.variables
+++ b/src/themes/default/modules/checkbox.variables
@@ -191,3 +191,6 @@
 /*-------------------
       Variations
 --------------------*/
+
+/* Inverted */
+@checkboxInvertedHoverBackground: @black;


### PR DESCRIPTION
This PR add inverted style for standalone checkboxes (eg. not tied to form...). It's working but needs to be polished on events (focus, hover...), help is really appreciated !

Fixes Semantic-Org/Semantic-UI#6471.

My test case:
```html
<div class="ui inverted segment">
  <div class="ui inverted checkbox">
    <input type="checkbox" name="example">
    <label>Make my profile visible</label>
  </div>
</div>

<div class="ui segment">
  <div class="ui checkbox">
    <input type="checkbox" name="example">
    <label>Make my profile visible</label>
  </div>
</div>

<div class="ui inverted segment">
  <div class="ui inverted slider checkbox">
    <input type="checkbox" name="example">
    <label>Make my profile visible</label>
  </div>
</div>

<div class="ui segment">
  <div class="ui slider checkbox">
    <input type="checkbox" name="example">
    <label>Make my profile visible</label>
  </div>
</div>

<div class="ui inverted segment">
  <div class="ui inverted toggle checkbox">
    <input type="checkbox" name="example">
    <label>Make my profile visible</label>
  </div>
</div>

<div class="ui segment">
  <div class="ui toggle checkbox">
    <input type="checkbox" name="example">
    <label>Make my profile visible</label>
  </div>
</div>
```