### PR TITLE
[Dependency] Fix compatibility issue with less >= 3.5 due to math changes

### DIFF
--- a/src/definitions/collections/grid.less
+++ b/src/definitions/collections/grid.less
@@ -139,7 +139,7 @@
   margin: (@rowSpacing / 2) (@gutterWidth / 2);
 }
 .ui.grid .column + .ui.vertical.divider {
-  height: ~"calc(50% - "(@rowSpacing/2)~")";
+  height: e(%("calc(50%% - %d)", @rowSpacing / 2));
 }
 
 /* Remove Border on Last Horizontal Segment */
@@ -1077,7 +1077,7 @@
   top: 0em;
   left: 0px;
 
-  width: ~"calc(100% - "@gutterWidth~")";
+  width: e(%("calc(100%% - %d)", @gutterWidth));
   height: 1px;
 
   margin: 0% (@gutterWidth / 2);
@@ -1112,12 +1112,12 @@
 .ui.relaxed[class*="vertically divided"].grid > .row:before {
   margin-left: (@relaxedGutterWidth / 2);
   margin-right: (@relaxedGutterWidth / 2);
-  width: ~"calc(100% - "@relaxedGutterWidth~")";
+  width: e(%("calc(100%% - %d)", @relaxedGutterWidth));
 }
 .ui[class*="very relaxed"][class*="vertically divided"].grid > .row:before {
   margin-left: @veryRelaxedGutterWidth;
   margin-right: @veryRelaxedGutterWidth;
-  width: ~"calc(100% - "@veryRelaxedGutterWidth~")";
+  width: e(%("calc(100%% - %d)", @veryRelaxedGutterWidth));
 }
 
 /*----------------------

--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -211,7 +211,7 @@
 
 /* Menu */
 .ui.menu .dropdown.item .menu {
-  min-width: ~"calc(100% - 1px)";
+  min-width: e("calc(100% - 1px)");
   border-radius: 0em 0em @dropdownMenuBorderRadius @dropdownMenuBorderRadius;
   background: @dropdownBackground;
   margin: @dropdownMenuDistance 0px 0px;

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -1121,7 +1121,7 @@ select.ui.dropdown {
 @media all and (-ms-high-contrast:none) {
   .ui.scrolling.dropdown .menu,
   .ui.dropdown .scrolling.menu {
-    min-width: ~"calc(100% - "@scrollbarWidth~")";
+    min-width: e(%("calc(100%% - %d)", @scrollbarWidth));
   }
 }
 @media only screen and (max-width : @largestMobileScreen) {

--- a/src/themes/default/collections/grid.variables
+++ b/src/themes/default/collections/grid.variables
@@ -19,7 +19,7 @@
 @gutterWidth: 2rem;
 @rowSpacing: 2rem;
 
-@tableWidth: ~"calc(100% + "@gutterWidth~")";
+@tableWidth: e(%("calc(100%% + %d)", @gutterWidth));
 @columnMaxImageWidth: 100%;
 
 @consecutiveGridDistance: (@rowSpacing / 2);

--- a/src/themes/default/collections/menu.variables
+++ b/src/themes/default/collections/menu.variables
@@ -321,7 +321,7 @@
 @tabularVerticalBackground: none @tabularBackgroundColor;
 
 @tabularFluidOffset: 1px;
-@tabularFluidWidth: ~"calc(100% + "(@tabularFluidOffset * 2)~")";
+@tabularFluidWidth: e(%("calc(100%% + %d)", @tabularFluidOffset * 2));
 
 @tabularActiveBackground: none @white;
 @tabularActiveColor: @selectedTextColor;
@@ -430,7 +430,7 @@
 @attachedTopOffset: 0px;
 @attachedBottomOffset: 0px;
 @attachedHorizontalOffset: -@borderWidth;
-@attachedWidth: ~"calc(100% + "-@attachedHorizontalOffset * 2~")";
+@attachedWidth: e(%("calc(100%% + %d)", -@attachedHorizontalOffset * 2));
 @attachedBoxShadow: none;
 @attachedBorder: @borderWidth solid @solidBorderColor;
 @attachedBottomBoxShadow:

--- a/src/themes/default/collections/table.variables
+++ b/src/themes/default/collections/table.variables
@@ -152,7 +152,7 @@
 @attachedTopOffset: 0px;
 @attachedBottomOffset: 0px;
 @attachedHorizontalOffset: -@borderWidth;
-@attachedWidth: ~"calc(100% + "-@attachedHorizontalOffset * 2~")";
+@attachedWidth: e(%("calc(100%% + %d)", -@attachedHorizontalOffset * 2));
 @attachedBoxShadow: none;
 @attachedBorder: @borderWidth solid @solidBorderColor;
 @attachedBottomBoxShadow:

--- a/src/themes/default/elements/container.variables
+++ b/src/themes/default/elements/container.variables
@@ -33,19 +33,19 @@
 @veryRelaxedGridGutterWidth: 5rem;
 
 @mobileGridWidth: @mobileWidth;
-@tabletGridWidth: ~"calc("@tabletWidth~" + "@gridGutterWidth~")";
-@computerGridWidth: ~"calc("@computerWidth~" + "@gridGutterWidth~")";
-@largeMonitorGridWidth: ~"calc("@largeMonitorWidth~" + "@gridGutterWidth~")";
+@tabletGridWidth: e(%("calc(%d + %d)", @tabletWidth, @gridGutterWidth));
+@computerGridWidth: e(%("calc(%d + %d)", @computerWidth, @gridGutterWidth));
+@largeMonitorGridWidth: e(%("calc(%d + %d)", @largeMonitorWidth, @gridGutterWidth));
 
 @mobileRelaxedGridWidth: @mobileWidth;
-@tabletRelaxedGridWidth: ~"calc("@tabletWidth~" + "@relaxedGridGutterWidth~")";
-@computerRelaxedGridWidth: ~"calc("@computerWidth~" + "@relaxedGridGutterWidth~")";
-@largeMonitorRelaxedGridWidth: ~"calc("@largeMonitorWidth~" + "@relaxedGridGutterWidth~")";
+@tabletRelaxedGridWidth: e(%("calc(%d + %d)", @tabletWidth, @relaxedGridGutterWidth));
+@computerRelaxedGridWidth: e(%("calc(%d + %d)", @computerWidth, @relaxedGridGutterWidth));
+@largeMonitorRelaxedGridWidth: e(%("calc(%d + %d)", @largeMonitorWidth, @relaxedGridGutterWidth));
 
 @mobileVeryRelaxedGridWidth: @mobileWidth;
-@tabletVeryRelaxedGridWidth: ~"calc("@tabletWidth~" + "@veryRelaxedGridGutterWidth~")";
-@computerVeryRelaxedGridWidth: ~"calc("@computerWidth~" + "@veryRelaxedGridGutterWidth~")";
-@largeMonitorVeryRelaxedGridWidth: ~"calc("@largeMonitorWidth~" + "@veryRelaxedGridGutterWidth~")";
+@tabletVeryRelaxedGridWidth: e(%("calc(%d + %d)", @tabletWidth, @veryRelaxedGridGutterWidth));
+@computerVeryRelaxedGridWidth: e(%("calc(%d + %d)", @computerWidth, @veryRelaxedGridGutterWidth));
+@largeMonitorVeryRelaxedGridWidth: e(%("calc(%d + %d)", @largeMonitorWidth, @veryRelaxedGridGutterWidth));
 
 /*-------------------
        Types

--- a/src/themes/default/elements/divider.variables
+++ b/src/themes/default/elements/divider.variables
@@ -36,10 +36,10 @@
 /* Horizontal / Vertical */
 @horizontalMargin: '';
 @horizontalDividerMargin: 1em;
-@horizontalRulerOffset: ~"calc(-50% - "(@horizontalDividerMargin)~")";
+@horizontalRulerOffset: e(%("calc(-50%% - %d)", @horizontalDividerMargin));
 
 @verticalDividerMargin: 1rem;
-@verticalDividerHeight: ~"calc(100% - "(@verticalDividerMargin)~")";
+@verticalDividerHeight: e(%("calc(100%% - %d)", @verticalDividerMargin));
 
 /* Inverted */
 @invertedTextColor: @white;

--- a/src/themes/default/elements/label.variables
+++ b/src/themes/default/elements/label.variables
@@ -130,18 +130,18 @@
 @ribbonShadowColor: rgba(0, 0, 0, 0.15);
 
 @ribbonMargin: 1rem;
-@ribbonOffset: ~"calc("-@ribbonMargin~" - "@ribbonTriangleSize~")";
-@ribbonDistance: ~"calc("@ribbonMargin~" + "@ribbonTriangleSize~")";
-@rightRibbonOffset:  ~"calc(100% + "@ribbonMargin~" + "@ribbonTriangleSize~")";
+@ribbonOffset: e(%("calc(%d - %d)", -@ribbonMargin, @ribbonTriangleSize));
+@ribbonDistance: e(%("calc(%d + %d)", @ribbonMargin, @ribbonTriangleSize));
+@rightRibbonOffset: e(%("calc(100%% + %d + %d)", @ribbonMargin, @ribbonTriangleSize));
 
 @ribbonImageTopDistance: 1rem;
 @ribbonImageMargin: -0.05rem; /* Rounding Offset on Triangle */
-@ribbonImageOffset: ~"calc("-@ribbonImageMargin~" - "@ribbonTriangleSize~")";
-@rightRibbonImageOffset:  ~"calc(100% + "@ribbonImageMargin~" + "@ribbonTriangleSize~")";
+@ribbonImageOffset: e(%("calc(%d - %d)", -@ribbonImageMargin, @ribbonTriangleSize));
+@rightRibbonImageOffset: e(%("calc(100%% + %d + %d)", @ribbonImageMargin, @ribbonTriangleSize));
 
 @ribbonTableMargin: @relativeMini; /* Rounding Offset on Triangle */
-@ribbonTableOffset: ~"calc("-@ribbonTableMargin~" - "@ribbonTriangleSize~")";
-@rightRibbonTableOffset:  ~"calc(100% + "@ribbonTableMargin~" + "@ribbonTriangleSize~")";
+@ribbonTableOffset: e(%("calc(%d - %d)", -@ribbonTableMargin, @ribbonTriangleSize));
+@rightRibbonTableOffset: e(%("calc(100%% + %d + %d)", @ribbonTableMargin, @ribbonTriangleSize));
 
 
 /* Colors */

--- a/src/themes/default/elements/rail.variables
+++ b/src/themes/default/elements/rail.variables
@@ -23,8 +23,8 @@
 @splitCloseDistance: (@closeDistance / 2);
 @splitVeryCloseDistance: (@veryCloseDistance / 2);
 
-@closeWidth: ~"calc("@width~" + "@splitCloseDistance~")";
-@veryCloseWidth: ~"calc("@width~" + "@splitVeryCloseDistance~")";
+@closeWidth: e(%("calc(%d + %d)", @width, @splitCloseDistance));
+@veryCloseWidth: e(%("calc(%d + %d)", @width, @splitVeryCloseDistance));
 
 /* Dividing */
 @dividingBorder: 1px solid @borderColor;

--- a/src/themes/default/elements/segment.variables
+++ b/src/themes/default/elements/segment.variables
@@ -88,7 +88,7 @@
 @attachedTopOffset: 0px;
 @attachedBottomOffset: 0px;
 @attachedHorizontalOffset: -@borderWidth;
-@attachedWidth: ~"calc(100% + "-@attachedHorizontalOffset * 2~")";
+@attachedWidth: e(%("calc(100%% + %d)", -@attachedHorizontalOffset * 2));
 @attachedBoxShadow: none;
 @attachedBorder: @borderWidth solid @solidBorderColor;
 @attachedBottomBoxShadow:

--- a/src/themes/default/elements/step.variables
+++ b/src/themes/default/elements/step.variables
@@ -95,7 +95,7 @@
 
 @attachedHorizontalOffset: -@borderWidth;
 @attachedVerticalOffset: 0;
-@attachedWidth: ~"calc(100% + "-@attachedHorizontalOffset * 2~")";
+@attachedWidth: e(%("calc(100%% + %d)", -@attachedHorizontalOffset * 2));
 
 @orderedFontFamily: inherit;
 @orderedFontWeight: @bold;

--- a/src/themes/default/globals/site.variables
+++ b/src/themes/default/globals/site.variables
@@ -507,7 +507,7 @@
 @headerLineHeightOffset : (@headerLineHeight - 1em) / 2;
 
 /* Header Spacing */
-@headerTopMargin    : ~"calc(2rem - "@headerLineHeightOffset~")";
+@headerTopMargin    : e(%("calc(2rem - %d)", @headerLineHeightOffset));
 @headerBottomMargin : 1rem;
 @headerMargin       : @headerTopMargin 0em @headerBottomMargin;
 

--- a/src/themes/default/modules/dimmer.variables
+++ b/src/themes/default/modules/dimmer.variables
@@ -20,8 +20,8 @@
 @textColor: @white;
 @overflow: hidden;
 
-@blurredStartFilter: ~"blur(0px) grayscale(0)";
-@blurredEndFilter: ~"blur(5px) grayscale(0.7)";
+@blurredStartFilter: e("blur(0px) grayscale(0)");
+@blurredEndFilter: e("blur(5px) grayscale(0.7)");
 @blurredTransition: 800ms filter @defaultEasing;
 
 @blurredBackgroundColor: rgba(0, 0, 0, 0.6);

--- a/src/themes/default/modules/dropdown.variables
+++ b/src/themes/default/modules/dropdown.variables
@@ -38,7 +38,7 @@
 @menuBoxShadow: @raisedShadow;
 @menuBorderRadius: @borderRadius;
 @menuTransition: opacity @defaultDuration @defaultEasing;
-@menuMinWidth: ~"calc(100% + "(@menuBorderWidth * 2)~")";
+@menuMinWidth: e(%("calc(100%% + %d)", @menuBorderWidth * 2));
 @menuZIndex: 11;
 
 /* Text */
@@ -316,7 +316,7 @@
 /* Scrolling */
 @scrollingMenuWidth: 100%;
 @scrollingMenuItemBorder: none;
-@scrollingMenuRightItemPadding: ~"calc("(@itemHorizontalPadding)~" + "(@scrollbarWidth)~")";
+@scrollingMenuRightItemPadding: e(%("calc(%d + %d)", @itemHorizontalPadding, @scrollbarWidth));
 
 @scrollingMobileMaxItems: 4;
 @scrollingTabletMaxItems: 6;

--- a/src/themes/default/modules/popup.variables
+++ b/src/themes/default/modules/popup.variables
@@ -106,7 +106,7 @@
 
 /* Grid Inside Popup */
 @nestedGridMargin: -0.7rem -0.875rem; /* (padding * @medium) */
-@nestedGridWidth: ~"calc(100% + 1.75rem)";
+@nestedGridWidth: e("calc(100% + 1.75rem)");
 
 /*-------------------
        States

--- a/src/themes/default/modules/search.variables
+++ b/src/themes/default/modules/search.variables
@@ -21,7 +21,7 @@
 @promptBoxShadow: 0em 0em 0em 0em transparent inset;
 
 /* Mobile */
-@mobileMaxWidth: ~"calc(100vw - 2rem)";
+@mobileMaxWidth: e("calc(100vw - 2rem)");
 
 /* Result Box */
 @resultsWidth: 18em;

--- a/src/themes/default/views/card.variables
+++ b/src/themes/default/views/card.variables
@@ -141,7 +141,7 @@
 
 /* Buttons */
 @buttonMargin: 0px -@borderWidth;
-@buttonWidth: ~"calc(100% + "(@borderWidth * 2)~")";
+@buttonWidth: e(%("calc(100%% + %d)", @borderWidth * 2));
 
 /*-------------------
       Variations
@@ -189,29 +189,29 @@
 
 @oneCard: @oneColumn;
 @oneCardOffset: 0em;
-@twoCard: ~"calc("@twoColumn~" - "(@twoCardSpacing * 2)~")";
+@twoCard: e(%("calc(%d - %d)", @twoColumn, @twoCardSpacing * 2));
 @twoCardOffset: -@twoCardSpacing;
-@threeCard: ~"calc("@threeColumn~" - "(@threeCardSpacing * 2)~")";
+@threeCard: e(%("calc(%d - %d)", @threeColumn, @threeCardSpacing * 2));
 @threeCardOffset: -@threeCardSpacing;
-@fourCard: ~"calc("@fourColumn~" - "(@fourCardSpacing * 2)~")";
+@fourCard: e(%("calc(%d - %d)", @fourColumn, @fourCardSpacing * 2));
 @fourCardOffset: -@fourCardSpacing;
-@fiveCard: ~"calc("@fiveColumn~" - "(@fiveCardSpacing * 2)~")";
+@fiveCard: e(%("calc(%d - %d)", @fiveColumn, @fiveCardSpacing * 2));
 @fiveCardOffset: -@fiveCardSpacing;
-@sixCard: ~"calc("@sixColumn~" - "(@sixCardSpacing * 2)~")";
+@sixCard: e(%("calc(%d - %d)", @sixColumn, @sixCardSpacing * 2));
 @sixCardOffset: -@sixCardSpacing;
-@sevenCard: ~"calc("@sevenColumn~" - "(@sevenCardSpacing * 2)~")";
+@sevenCard: e(%("calc(%d - %d)", @sevenColumn, @sevenCardSpacing * 2));
 @sevenCardOffset: -@sevenCardSpacing;
-@eightCard: ~"calc("@eightColumn~" - "(@sevenCardSpacing * 2)~")";
+@eightCard: e(%("calc(%d - %d)", @eightColumn, @sevenCardSpacing * 2));
 @eightCardOffset: -@sevenCardSpacing;
-@nineCard: ~"calc("@nineColumn~" - "(@nineCardSpacing * 2)~")";
+@nineCard: e(%("calc(%d - %d)", @nineColumn, @nineCardSpacing * 2));
 @nineCardOffset: -@nineCardSpacing;
-@tenCard: ~"calc("@tenColumn~" - "(@tenCardSpacing * 2)~")";
+@tenCard: e(%("calc(%d - %d)", @tenColumn, @tenCardSpacing * 2));
 @tenCardOffset: -@tenCardSpacing;
 
 /* Stackable */
 @stackableRowSpacing: 1em;
 @stackableCardSpacing: 1em;
-@stackableMargin: ~"calc("@oneColumn~" - "(@stackableCardSpacing * 2)~")";
+@stackableMargin: e(%("calc(%d - %d)", @oneColumn, @stackableCardSpacing * 2));
 
 /* Sizes */
 @medium: 1em;


### PR DESCRIPTION
Replaces all tilde string escaping with explicit function calls.
This was tested with gulp-less@3.5.0 and gulp-less@4.0.1

Reported in Semantic-Org/Semantic-UI#6512