### PR TITLE
[Accordion][Header] Header with content has display:none when in an accordion element

### DIFF
--- a/src/definitions/modules/accordion.less
+++ b/src/definitions/modules/accordion.less
@@ -183,8 +183,8 @@
    Not Active
 ---------------*/
 
-.ui.accordion .content:not(.active),
-.ui.accordion .accordion .content:not(.active) {
+.ui.accordion .title ~ .content:not(.active),
+.ui.accordion .accordion .title ~ .content:not(.active) {
   display: none;
 }
 


### PR DESCRIPTION
### Description
The changed rule for "not active" content in accordion mistakenly hides content inside the header as well

### Closed Issues
Closes #102
