### PR TITLE
[Calendar] Adds support for WeekNumbers in Day View

### DIFF
--- a/dist/components/calendar.css
+++ b/dist/components/calendar.css
@@ -58,6 +58,9 @@
 .ui.calendar .ui.table.day {
   min-width: 18em;
 }
+.ui.calendar .ui.table.day.andweek {
+  min-width: 22em;
+}
 .ui.calendar .ui.table.hour {
   min-width: 20em;
 }

--- a/dist/components/calendar.js
+++ b/dist/components/calendar.js
@@ -1,5 +1,5 @@
 /*!
- * # Semantic UI 2.5.0 - Dropdown
+ * # Semantic UI 2.5.0 - Calendar
  * http://github.com/semantic-org/semantic-ui/
  *
  *
@@ -19,6 +19,20 @@ window = (typeof window != 'undefined' && window.Math == Math)
     : Function('return this')()
 ;
 
+//support existing momentjs or date-fns library
+Date.prototype.getWeekOfYear = Date.prototype.week || Date.prototype.getWeek || function() {
+    // adapted from http://www.merlyn.demon.co.uk/weekcalc.htm
+    var ms1d = 864e5, // milliseconds in a day
+        ms7d = 7 * ms1d; // milliseconds in a week
+
+    return function() { // return a closure so constants get calculated only once
+        var DC3 = Date.UTC(this.getFullYear(), this.getMonth(), this.getDate() + 3) / ms1d, // an Absolute Day Number
+            AWN = Math.floor(DC3 / 7), // an Absolute Week Number
+            Wyr = new Date(AWN * ms7d).getUTCFullYear();
+
+        return AWN - Math.floor(Date.UTC(Wyr, 0, 7) / ms7d) + 1;
+    };
+}();
 $.fn.calendar = function(parameters) {
   var
     $allModules = $(this),
@@ -202,8 +216,8 @@ $.fn.calendar = function(parameters) {
             var startMonth = display.getMonth() + monthOffset;
             var year = display.getFullYear();
 
-            var columns = isDay ? 7 : isHour ? 4 : 3;
-            var columnsString = columns === 7 ? 'seven' : columns === 4 ? 'four' : 'three';
+            var columns = isDay ? settings.showWeekNumbers ? 8 : 7 : isHour ? 4 : 3;
+            var columnsString = columns === 8 ? 'eight' : columns === 7 ? 'seven' : columns === 4 ? 'four' : 'three';
             var rows = isDay || isHour ? 6 : 4;
             var pages = isDay ? multiMonth : 1;
 
@@ -238,8 +252,12 @@ $.fn.calendar = function(parameters) {
               var nextFirst = isYear ? new Date(Math.ceil(year / 10) * 10 + 1, 0, 1) :
                 isMonth ? new Date(year + 1, 0, 1) : isDay ? new Date(year, month + 1, 1) : new Date(year, month, day + 1);
 
-              var table = $('<table/>').addClass(className.table).addClass(columnsString + ' column').addClass(mode).appendTo(container);
-
+              var tempMode = mode;
+              if (isDay && settings.showWeekNumbers){
+                tempMode += ' andweek';
+              }
+              var table = $('<table/>').addClass(className.table).addClass(columnsString + ' column').addClass(tempMode).appendTo(container);
+              var textColumns = columns;
               //no header for time-only mode
               if (!isTimeOnly) {
                 var thead = $('<thead/>').appendTo(table);
@@ -268,10 +286,15 @@ $.fn.calendar = function(parameters) {
                   next.toggleClass(className.disabledCell, !module.helper.isDateInRange(nextFirst, mode));
                   $('<i/>').addClass(className.nextIcon).appendTo(next);
                 }
-
                 if (isDay) {
                   row = $('<tr/>').appendTo(thead);
-                  for (i = 0; i < columns; i++) {
+                  if(settings.showWeekNumbers) {
+                      cell = $('<th/>').appendTo(row);
+                      cell.text(settings.text.weekNo);
+                      cell.addClass(className.disabledCell);
+                      textColumns--;
+                  }
+                  for (i = 0; i < textColumns; i++) {
                     cell = $('<th/>').appendTo(row);
                     cell.text(formatter.dayColumnHeader((i + settings.firstDayOfWeek) % 7, settings));
                   }
@@ -282,7 +305,12 @@ $.fn.calendar = function(parameters) {
               i = isYear ? Math.ceil(year / 10) * 10 - 9 : isDay ? 1 - firstMonthDayColumn : 0;
               for (r = 0; r < rows; r++) {
                 row = $('<tr/>').appendTo(tbody);
-                for (c = 0; c < columns; c++, i++) {
+                if(isDay && settings.showWeekNumbers){
+                    cell = $('<th/>').appendTo(row);
+                    cell.text(new Date(year,month,i,hour,minute).getWeekOfYear());
+                    cell.addClass(className.disabledCell);
+                }
+                for (c = 0; c < textColumns; c++, i++) {
                   var cellDate = isYear ? new Date(i, month, 1, hour, minute) :
                     isMonth ? new Date(year, i, 1, hour, minute) : isDay ? new Date(year, month, i, hour, minute) :
                       isHour ? new Date(year, month, day, i) : new Date(year, month, day, hour, i * 5);
@@ -1007,7 +1035,7 @@ $.fn.calendar.settings = {
   startCalendar: null,  // jquery object or selector for another calendar that represents the start date of a date range
   endCalendar: null,    // jquery object or selector for another calendar that represents the end date of a date range
   multiMonth: 1,        // show multiple months when in 'day' mode
-
+  showWeekNumbers: null,// show Number of Week at the very first column of a dayView
   // popup options ('popup', 'on', 'hoverable', and show/hide callbacks are overridden)
   popupOptions: {
     position: 'bottom left',
@@ -1023,7 +1051,8 @@ $.fn.calendar.settings = {
     today: 'Today',
     now: 'Now',
     am: 'AM',
-    pm: 'PM'
+    pm: 'PM',
+    weekNo: 'Week'
   },
 
   formatter: {

--- a/dist/components/calendar.js
+++ b/dist/components/calendar.js
@@ -19,20 +19,6 @@ window = (typeof window != 'undefined' && window.Math == Math)
     : Function('return this')()
 ;
 
-//support existing momentjs or date-fns library
-Date.prototype.getWeekOfYear = Date.prototype.week || Date.prototype.getWeek || function() {
-    // adapted from http://www.merlyn.demon.co.uk/weekcalc.htm
-    var ms1d = 864e5, // milliseconds in a day
-        ms7d = 7 * ms1d; // milliseconds in a week
-
-    return function() { // return a closure so constants get calculated only once
-        var DC3 = Date.UTC(this.getFullYear(), this.getMonth(), this.getDate() + 3) / ms1d, // an Absolute Day Number
-            AWN = Math.floor(DC3 / 7), // an Absolute Week Number
-            Wyr = new Date(AWN * ms7d).getUTCFullYear();
-
-        return AWN - Math.floor(Date.UTC(Wyr, 0, 7) / ms7d) + 1;
-    };
-}();
 $.fn.calendar = function(parameters) {
   var
     $allModules = $(this),
@@ -306,7 +292,7 @@ $.fn.calendar = function(parameters) {
                 row = $('<tr/>').appendTo(tbody);
                 if(isDay && settings.showWeekNumbers){
                     cell = $('<th/>').appendTo(row);
-                    cell.text(new Date(year,month,i,hour,minute).getWeekOfYear());
+                    cell.text(module.get.weekOfYear(year,month,i+1-settings.firstDayOfWeek));
                     cell.addClass(className.disabledCell);
                 }
                 for (c = 0; c < textColumns; c++, i++) {
@@ -535,6 +521,19 @@ $.fn.calendar = function(parameters) {
         },
 
         get: {
+          weekOfYear: function(weekYear,weekMonth,weekDay) {
+              // adapted from http://www.merlyn.demon.co.uk/weekcalc.htm
+              var ms1d = 864e5, // milliseconds in a day
+                  ms7d = 7 * ms1d; // milliseconds in a week
+
+              return function() { // return a closure so constants get calculated only once
+                  var DC3 = Date.UTC(weekYear, weekMonth, weekDay + 3) / ms1d, // an Absolute Day Number
+                      AWN = Math.floor(DC3 / 7), // an Absolute Week Number
+                      Wyr = new Date(AWN * ms7d).getUTCFullYear();
+
+                  return AWN - Math.floor(Date.UTC(Wyr, 0, 7) / ms7d) + 1;
+              }();
+          },
           date: function () {
             return $module.data(metadata.date) || null;
           },

--- a/dist/components/calendar.js
+++ b/dist/components/calendar.js
@@ -217,7 +217,6 @@ $.fn.calendar = function(parameters) {
             var year = display.getFullYear();
 
             var columns = isDay ? settings.showWeekNumbers ? 8 : 7 : isHour ? 4 : 3;
-            var columnsString = columns === 8 ? 'eight' : columns === 7 ? 'seven' : columns === 4 ? 'four' : 'three';
             var rows = isDay || isHour ? 6 : 4;
             var pages = isDay ? multiMonth : 1;
 
@@ -256,7 +255,7 @@ $.fn.calendar = function(parameters) {
               if (isDay && settings.showWeekNumbers){
                 tempMode += ' andweek';
               }
-              var table = $('<table/>').addClass(className.table).addClass(columnsString + ' column').addClass(tempMode).appendTo(container);
+              var table = $('<table/>').addClass(className.table).addClass(tempMode).appendTo(container);
               var textColumns = columns;
               //no header for time-only mode
               if (!isTimeOnly) {

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -1,5 +1,5 @@
 /*!
- * # Semantic UI - Dropdown
+ * # Semantic UI - Calendar
  * http://github.com/semantic-org/semantic-ui/
  *
  *
@@ -19,6 +19,20 @@ window = (typeof window != 'undefined' && window.Math == Math)
     : Function('return this')()
 ;
 
+//support existing momentjs or date-fns library
+Date.prototype.getWeekOfYear = Date.prototype.week || Date.prototype.getWeek || function() {
+    // adapted from http://www.merlyn.demon.co.uk/weekcalc.htm
+    var ms1d = 864e5, // milliseconds in a day
+        ms7d = 7 * ms1d; // milliseconds in a week
+
+    return function() { // return a closure so constants get calculated only once
+        var DC3 = Date.UTC(this.getFullYear(), this.getMonth(), this.getDate() + 3) / ms1d, // an Absolute Day Number
+            AWN = Math.floor(DC3 / 7), // an Absolute Week Number
+            Wyr = new Date(AWN * ms7d).getUTCFullYear();
+
+        return AWN - Math.floor(Date.UTC(Wyr, 0, 7) / ms7d) + 1;
+    };
+}();
 $.fn.calendar = function(parameters) {
   var
     $allModules = $(this),
@@ -202,8 +216,8 @@ $.fn.calendar = function(parameters) {
             var startMonth = display.getMonth() + monthOffset;
             var year = display.getFullYear();
 
-            var columns = isDay ? 7 : isHour ? 4 : 3;
-            var columnsString = columns === 7 ? 'seven' : columns === 4 ? 'four' : 'three';
+            var columns = isDay ? settings.showWeekNumbers ? 8 : 7 : isHour ? 4 : 3;
+            var columnsString = columns === 8 ? 'eight' : columns === 7 ? 'seven' : columns === 4 ? 'four' : 'three';
             var rows = isDay || isHour ? 6 : 4;
             var pages = isDay ? multiMonth : 1;
 
@@ -238,8 +252,12 @@ $.fn.calendar = function(parameters) {
               var nextFirst = isYear ? new Date(Math.ceil(year / 10) * 10 + 1, 0, 1) :
                 isMonth ? new Date(year + 1, 0, 1) : isDay ? new Date(year, month + 1, 1) : new Date(year, month, day + 1);
 
-              var table = $('<table/>').addClass(className.table).addClass(columnsString + ' column').addClass(mode).appendTo(container);
-
+              var tempMode = mode;
+              if (isDay && settings.showWeekNumbers){
+                tempMode += ' andweek';
+              }
+              var table = $('<table/>').addClass(className.table).addClass(columnsString + ' column').addClass(tempMode).appendTo(container);
+              var textColumns = columns;
               //no header for time-only mode
               if (!isTimeOnly) {
                 var thead = $('<thead/>').appendTo(table);
@@ -268,10 +286,15 @@ $.fn.calendar = function(parameters) {
                   next.toggleClass(className.disabledCell, !module.helper.isDateInRange(nextFirst, mode));
                   $('<i/>').addClass(className.nextIcon).appendTo(next);
                 }
-
                 if (isDay) {
                   row = $('<tr/>').appendTo(thead);
-                  for (i = 0; i < columns; i++) {
+                  if(settings.showWeekNumbers) {
+                      cell = $('<th/>').appendTo(row);
+                      cell.text(settings.text.weekNo);
+                      cell.addClass(className.disabledCell);
+                      textColumns--;
+                  }
+                  for (i = 0; i < textColumns; i++) {
                     cell = $('<th/>').appendTo(row);
                     cell.text(formatter.dayColumnHeader((i + settings.firstDayOfWeek) % 7, settings));
                   }
@@ -282,7 +305,12 @@ $.fn.calendar = function(parameters) {
               i = isYear ? Math.ceil(year / 10) * 10 - 9 : isDay ? 1 - firstMonthDayColumn : 0;
               for (r = 0; r < rows; r++) {
                 row = $('<tr/>').appendTo(tbody);
-                for (c = 0; c < columns; c++, i++) {
+                if(isDay && settings.showWeekNumbers){
+                    cell = $('<th/>').appendTo(row);
+                    cell.text(new Date(year,month,i,hour,minute).getWeekOfYear());
+                    cell.addClass(className.disabledCell);
+                }
+                for (c = 0; c < textColumns; c++, i++) {
                   var cellDate = isYear ? new Date(i, month, 1, hour, minute) :
                     isMonth ? new Date(year, i, 1, hour, minute) : isDay ? new Date(year, month, i, hour, minute) :
                       isHour ? new Date(year, month, day, i) : new Date(year, month, day, hour, i * 5);
@@ -1007,7 +1035,7 @@ $.fn.calendar.settings = {
   startCalendar: null,  // jquery object or selector for another calendar that represents the start date of a date range
   endCalendar: null,    // jquery object or selector for another calendar that represents the end date of a date range
   multiMonth: 1,        // show multiple months when in 'day' mode
-
+  showWeekNumbers: null,// show Number of Week at the very first column of a dayView
   // popup options ('popup', 'on', 'hoverable', and show/hide callbacks are overridden)
   popupOptions: {
     position: 'bottom left',
@@ -1023,7 +1051,8 @@ $.fn.calendar.settings = {
     today: 'Today',
     now: 'Now',
     am: 'AM',
-    pm: 'PM'
+    pm: 'PM',
+    weekNo: 'Week'
   },
 
   formatter: {

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -19,20 +19,6 @@ window = (typeof window != 'undefined' && window.Math == Math)
     : Function('return this')()
 ;
 
-//support existing momentjs or date-fns library
-Date.prototype.getWeekOfYear = Date.prototype.week || Date.prototype.getWeek || function() {
-    // adapted from http://www.merlyn.demon.co.uk/weekcalc.htm
-    var ms1d = 864e5, // milliseconds in a day
-        ms7d = 7 * ms1d; // milliseconds in a week
-
-    return function() { // return a closure so constants get calculated only once
-        var DC3 = Date.UTC(this.getFullYear(), this.getMonth(), this.getDate() + 3) / ms1d, // an Absolute Day Number
-            AWN = Math.floor(DC3 / 7), // an Absolute Week Number
-            Wyr = new Date(AWN * ms7d).getUTCFullYear();
-
-        return AWN - Math.floor(Date.UTC(Wyr, 0, 7) / ms7d) + 1;
-    };
-}();
 $.fn.calendar = function(parameters) {
   var
     $allModules = $(this),
@@ -306,7 +292,7 @@ $.fn.calendar = function(parameters) {
                 row = $('<tr/>').appendTo(tbody);
                 if(isDay && settings.showWeekNumbers){
                     cell = $('<th/>').appendTo(row);
-                    cell.text(new Date(year,month,i,hour,minute).getWeekOfYear());
+                    cell.text(module.get.weekOfYear(year,month,i+1-settings.firstDayOfWeek));
                     cell.addClass(className.disabledCell);
                 }
                 for (c = 0; c < textColumns; c++, i++) {
@@ -535,6 +521,19 @@ $.fn.calendar = function(parameters) {
         },
 
         get: {
+          weekOfYear: function(weekYear,weekMonth,weekDay) {
+              // adapted from http://www.merlyn.demon.co.uk/weekcalc.htm
+              var ms1d = 864e5, // milliseconds in a day
+                  ms7d = 7 * ms1d; // milliseconds in a week
+
+              return function() { // return a closure so constants get calculated only once
+                  var DC3 = Date.UTC(weekYear, weekMonth, weekDay + 3) / ms1d, // an Absolute Day Number
+                      AWN = Math.floor(DC3 / 7), // an Absolute Week Number
+                      Wyr = new Date(AWN * ms7d).getUTCFullYear();
+
+                  return AWN - Math.floor(Date.UTC(Wyr, 0, 7) / ms7d) + 1;
+              }();
+          },
           date: function () {
             return $module.data(metadata.date) || null;
           },

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -217,7 +217,6 @@ $.fn.calendar = function(parameters) {
             var year = display.getFullYear();
 
             var columns = isDay ? settings.showWeekNumbers ? 8 : 7 : isHour ? 4 : 3;
-            var columnsString = columns === 8 ? 'eight' : columns === 7 ? 'seven' : columns === 4 ? 'four' : 'three';
             var rows = isDay || isHour ? 6 : 4;
             var pages = isDay ? multiMonth : 1;
 
@@ -256,7 +255,7 @@ $.fn.calendar = function(parameters) {
               if (isDay && settings.showWeekNumbers){
                 tempMode += ' andweek';
               }
-              var table = $('<table/>').addClass(className.table).addClass(columnsString + ' column').addClass(tempMode).appendTo(container);
+              var table = $('<table/>').addClass(className.table).addClass(tempMode).appendTo(container);
               var textColumns = columns;
               //no header for time-only mode
               if (!isTimeOnly) {

--- a/src/definitions/modules/calendar.less
+++ b/src/definitions/modules/calendar.less
@@ -63,6 +63,10 @@
   min-width: 18em;
 }
 
+.ui.calendar .ui.table.day.andweek {
+  min-width: 22em;
+}
+
 .ui.calendar .ui.table.hour {
   min-width: 20em;
 }


### PR DESCRIPTION
### Description
- An optional new setting "showWeekNumbers" in day-view adds a column to the left with the appropriate weeknumber 

```javascript
$('#date_calendar')
        .calendar({
            type: 'date',
            showWeekNumbers: true
        })
    ;
```
![image](https://user-images.githubusercontent.com/18379884/45174489-48c42a80-b20b-11e8-8a12-9912820185ec.png)
