### PR TITLE
[Modal] Fullscreen modal stuck to left edge of page

### DIFF
--- a/src/definitions/modules/modal.less
+++ b/src/definitions/modules/modal.less
@@ -424,9 +424,6 @@
   left: @fullScreenOffset !important;
   margin: @fullScreenMargin;
 }
-.ui.fullscreen.scrolling.modal {
-  left: 0em !important;
-}
 .ui.fullscreen.modal > .header {
   padding-right: @closeHitbox;
 }

--- a/src/themes/default/modules/modal.variables
+++ b/src/themes/default/modules/modal.variables
@@ -91,7 +91,7 @@
 @widescreenMonitorMargin: 0em 0em 0em 0em;
 
 @fullScreenWidth: 95%;
-@fullScreenOffset: 0em;
+@fullScreenOffset: (100% - @fullScreenWidth) / 2;
 @fullScreenMargin: 1em auto;
 
 /* Coupling */


### PR DESCRIPTION
Would be nice if someone could check the usage of `.ui.fullscreen.scrolling.modal` I didn't find any use-cases.

Closes #130 / Semantic-Org/Semantic-UI#6587