### PR TITLE
[Modal] Fullscreen modals are not working in IE11

### DIFF
--- a/src/definitions/modules/modal.less
+++ b/src/definitions/modules/modal.less
@@ -311,10 +311,10 @@
 }
 
 /* Resort to margin positioning if legacy */
-.ui.legacy.modal,
-.ui.legacy.page.dimmer > .ui.modal {
-  top: 50%;
-  left: 50%;
+.ui.legacy.legacy.modal,
+.ui.legacy.legacy.page.dimmer > .ui.modal {
+  top: 50% !important;
+  left: 50% !important;
 }
 
 .ui.legacy.page.dimmer > .ui.scrolling.modal,

--- a/src/definitions/modules/modal.less
+++ b/src/definitions/modules/modal.less
@@ -317,11 +317,11 @@
   left: 50% !important;
 }
 
-.ui.legacy.page.dimmer > .ui.scrolling.modal,
-.ui.page.dimmer > .ui.scrolling.legacy.modal,
-.ui.top.aligned.legacy.page.dimmer > .ui.modal,
-.ui.top.aligned.dimmer > .ui.legacy.modal {
-  top: auto;
+.ui.legacy.legacy.page.dimmer > .ui.scrolling.modal,
+.ui.page.dimmer > .ui.scrolling.legacy.legacy.modal,
+.ui.top.aligned.legacy.legacy.page.dimmer > .ui.modal,
+.ui.top.aligned.dimmer > .ui.legacy.legacy.modal {
+  top: auto !important;
 }
 
 /* Tablet and Mobile */


### PR DESCRIPTION
Increased the importance of legacy modal class definition

fullscreen modal class overrules the top / left definition of the legacy modals, which results in off-screen rendering of modals in IE11

Closes #134 / Semantic-Org/Semantic-UI#6597