### PR TITLE
[Dropdown] Multiple search keyboard + icon fix

### DIFF
--- a/dist/components/dropdown.css
+++ b/dist/components/dropdown.css
@@ -358,7 +358,7 @@
   min-height: 2.71428571em;
   background: #FFFFFF;
   display: inline-block;
-  padding: 0.78571429em 2.1em 0.78571429em 1em;
+  padding: 0.78571429em 3.2em 0.78571429em 1em;
   color: rgba(0, 0, 0, 0.87);
   -webkit-box-shadow: none;
           box-shadow: none;
@@ -581,13 +581,13 @@ select.ui.dropdown {
 /* Search Selection */
 .ui.search.selection.dropdown > input.search {
   line-height: 1.21428571em;
-  padding: 0.67857143em 2.1em 0.67857143em 1em;
+  padding: 0.67857143em 3.2em 0.67857143em 1em;
 }
 
 /* Used to size multi select input to character width */
 .ui.search.selection.dropdown > span.sizer {
   line-height: 1.21428571em;
-  padding: 0.67857143em 2.1em 0.67857143em 1em;
+  padding: 0.67857143em 3.2em 0.67857143em 1em;
   display: none;
   white-space: pre;
 }
@@ -668,7 +668,7 @@ select.ui.dropdown {
 
 /* Multiple Selection */
 .ui.multiple.dropdown {
-  padding: 0.22619048em 2.1em 0.22619048em 0.35714286em;
+  padding: 0.22619048em 3.2em 0.22619048em 0.35714286em;
 }
 .ui.multiple.dropdown .menu {
   cursor: auto;

--- a/dist/components/dropdown.js
+++ b/dist/components/dropdown.js
@@ -1451,6 +1451,7 @@ $.fn.dropdown = function(parameters) {
                     module.event.item.click.call($selectedItem, event);
                     if(module.is.searchSelection()) {
                       module.remove.searchTerm();
+                      $search.focus();
                     }
                   }
                   event.preventDefault();

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1451,6 +1451,7 @@ $.fn.dropdown = function(parameters) {
                     module.event.item.click.call($selectedItem, event);
                     if(module.is.searchSelection()) {
                       module.remove.searchTerm();
+                      $search.focus();
                     }
                   }
                   event.preventDefault();

--- a/src/themes/default/modules/dropdown.variables
+++ b/src/themes/default/modules/dropdown.variables
@@ -133,7 +133,7 @@
 @selectionMinHeight: @inputLineHeight + (@selectionVerticalPadding * 2) - @selectionBorderEmWidth;
 @selectionBackground: @inputBackground;
 @selectionDisplay: inline-block;
-@selectionIconDistance: @inputHorizontalPadding + @glyphWidth;
+@selectionIconDistance: @inputHorizontalPadding + (@glyphWidth * 2);
 @selectionPadding: @selectionVerticalPadding @selectionIconDistance @selectionVerticalPadding @selectionHorizontalPadding;
 @selectionZIndex: 10;
 


### PR DESCRIPTION
## Description

A multiple dropdown selection searchable box had

1. The close icon displayed over the search input field when many entries have been selected
2. Whenever an entry was selected via enter, it looses it's focus making quick keyboard selection impossible (you needed to click again into the search field

Before:
![multidd_before](https://user-images.githubusercontent.com/18379884/46304895-2cb86c80-c5b0-11e8-8ab5-83361ada21c3.gif)

After:
![multidd_after](https://user-images.githubusercontent.com/18379884/46304904-3641d480-c5b0-11e8-96c2-98eca6666fef.gif)
