### PR TITLE
force display:none on .placeholder.hidden.transition

### DIFF
--- a/src/definitions/modules/transition.less
+++ b/src/definitions/modules/transition.less
@@ -48,9 +48,10 @@
 }
 
 /* Hidden */
+.hidden.hidden.transition,
 .hidden.transition {
-  display: none !important;
-  visibility: hidden !important;
+  display: none;
+  visibility: hidden;
 }
 
 /* Visible */

--- a/src/definitions/modules/transition.less
+++ b/src/definitions/modules/transition.less
@@ -49,8 +49,8 @@
 
 /* Hidden */
 .hidden.transition {
-  display: none;
-  visibility: hidden;
+  display: none !important;
+  visibility: hidden !important;
 }
 
 /* Visible */


### PR DESCRIPTION
## Description
Using a hidden transition on a placeholder does not set display:none, because placeholder style will still override it. 
The Fix should make sure it wont happen to any other element having .hidden.transition

## Testcase
https://jsfiddle.net/zqfrjso1/4/ (from original issue)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6608
