### PR TITLE
[Dropdown] Fix the clearable setting that does'nt init a clearable dropdown

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1083,8 +1083,6 @@ $.fn.dropdown = function(parameters) {
                 } else {
                   module.blurSearch();
                 }
-              } else if($icon.hasClass(className.clear)) {
-                module.clear();
               } else {
                 module.toggle();
               }
@@ -3230,7 +3228,7 @@ $.fn.dropdown = function(parameters) {
             return $selectedMenu.hasClass(className.leftward);
           },
           clearable: function() {
-            return $module.hasClass(className.clearable);
+            return ($module.hasClass(className.clearable) || settings.clearable);
           },
           disabled: function() {
             return $module.hasClass(className.disabled);


### PR DESCRIPTION
### Description
This PR fixes the compatibility with semantic's clearable dropdown implementation. Setting clearable to `true` now display correctly the clear icon when there is a selected value.

Also, this PR does not clear the selection when you click on the toggle icon, as you might want to change a value without setting it empty in between.