### PR TITLE
[Progress] Improve performance for active progress bars

### DIFF
--- a/src/definitions/modules/progress.less
+++ b/src/definitions/modules/progress.less
@@ -246,17 +246,18 @@
   border-radius: @barBorderRadius;
 
   animation: progress-active @activePulseDuration @defaultEasing infinite;
+  transform-origin: left;
 }
 @keyframes progress-active {
   0% {
     opacity: @activePulseMaxOpacity;
-    width: 0;
+    transform: scale(0, 1);
   }
   90% {
   }
   100% {
     opacity: 0;
-    width: 100%;
+    transform: scale(1);
   }
 }
 


### PR DESCRIPTION
## Description
Instead of animating the "width" property, animate the transform (scale) property instead.
This improves the performance, because the property doesn't affect the layout.

## Testcase
https://jsfiddle.net/Korinu/sjpw54da/

## Screenshot (when possible)
Before
![image](https://user-images.githubusercontent.com/5517677/46858727-393c9080-ce0c-11e8-8e65-f3bc64881662.png)

After
![image](https://user-images.githubusercontent.com/5517677/46858734-3d68ae00-ce0c-11e8-8c19-32516af9225e.png)

## Closes
Possible closes Semantic-Org/Semantic-UI#2316
