### PR TITLE
[Toast] fix position for top and bottom centered container

### DIFF
--- a/src/definitions/modules/toast.less
+++ b/src/definitions/modules/toast.less
@@ -40,7 +40,6 @@
 }
 
 .ui.top.center.toast-container {
-    position: absolute;
     left: 50%;
     transform: translate(-50%, 0%);
     top: @toastContainerDistance;
@@ -59,7 +58,6 @@
 }
 
 .ui.bottom.center.toast-container {
-    position: absolute;
     left: 50%;
     transform: translate(-50%, 0%);
     bottom: @toastContainerDistance;


### PR DESCRIPTION
## Description
On scrolling body content the `top center` or `bottom center` positioning was broken
