### PR TITLE
[Toast] Added SUI usual color palette with inverted support

### DIFF
--- a/src/definitions/modules/toast.js
+++ b/src/definitions/modules/toast.js
@@ -48,9 +48,9 @@ $.fn.toast = function(parameters) {
         moduleNamespace = namespace + '-module',
 
         $module         = $(this),
-        $toastBox       = $('<div/>',{'class':settings.className.box+' '+settings.class}),
+        $toastBox       = $('<div/>',{'class':settings.className.box}),
         $toast          = $('<div/>'),
-        $progress       = $('<div/>',{'class':settings.className.progress}),
+        $progress       = $('<div/>',{'class':settings.className.progress+' '+settings.class}),
         $progressBar    = $('<div/>',{'class':'bar'}),
 
         $close          = $('<i/>',{'class':'close icon'}),
@@ -155,11 +155,15 @@ $.fn.toast = function(parameters) {
             if(settings.compact || $toast.hasClass('compact')) {
                 $toastBox.addClass('compact');
             }
+            if($toast.hasClass('toast') && !$toast.hasClass('inverted')){
+              $progress.addClass('inverted');
+            } else {
+              $progress.removeClass('inverted');
+            }
             $toast = $toastBox.append($toast);
             if(!!settings.showProgress && settings.displayTime > 0){
               $progress
                 .addClass(settings.showProgress)
-                .addClass(settings.class)
                 .append($progressBar);
               if ($progress.hasClass('top')) {
                   $toast.prepend($progress);

--- a/src/definitions/modules/toast.less
+++ b/src/definitions/modules/toast.less
@@ -142,22 +142,58 @@
     background-color: @toastErrorColor;
 }
 
-.info.toast-box .attached.progress .bar {
+.toast-box .info.attached.progress .bar {
     background: @toastInfoProgressColor !important;
 }
 
-.warning.toast-box .attached.progress .bar {
+.toast-box .warning.attached.progress .bar {
     background: @toastWarningProgressColor !important;
 }
 
-.success.toast-box .attached.progress .bar {
+.toast-box .success.attached.progress .bar {
     background: @toastSuccessProgressColor !important;
 }
 
-.error.toast-box .attached.progress .bar {
+.toast-box .error.attached.progress .bar {
     background: @toastErrorProgressColor !important;
 }
 
+/*--------------
+     Colors
+-------------- */
+
+.toastColor(@color; @lightColor;) {
+  @_toastColor: "@{color}";
+  @_toastInvertedColor: "@{lightColor}";
+  .@{color}.toast {
+    background-color: @@_toastColor;
+  }
+  .inverted.@{color}.toast,
+  .toast-box .inverted.@{color}.attached.progress .bar {
+    background-color: @@_toastInvertedColor;
+  }
+}
+
+.toastColor(~'red',~'lightRed');
+.toastColor(~'orange',~'lightOrange');
+.toastColor(~'yellow',~'lightYellow');
+.toastColor(~'olive',~'lightOlive');
+.toastColor(~'green',~'lightGreen');
+.toastColor(~'teal',~'lightTeal');
+.toastColor(~'blue',~'lightBlue');
+.toastColor(~'violet',~'lightViolet');
+.toastColor(~'purple',~'lightPurple');
+.toastColor(~'pink',~'lightPink');
+.toastColor(~'brown',~'lightBrown');
+.toastColor(~'grey',~'lightGrey');
+.toastColor(~'black',~'lightBlack');
+
+.inverted.yellow.toast,
+.inverted.olive.toast,
+.inverted.teal.toast,
+.inverted.grey.toast {
+  color: @fullBlack;
+}
 
 /*--------------
       Icon


### PR DESCRIPTION
## Description
Added the usual colors to default `ui toast` className. Also supports `inverted`

## Screenshots
`class: 'red|orange|yellow|olive|green|teal|blue|violet|purple|pink|brown|grey|black'`
![toast_colors](https://user-images.githubusercontent.com/18379884/46907537-404ec600-cf14-11e8-82c9-3977be696a1e.PNG)

`class: 'inverted red|orange|yellow|olive|green|teal|blue|violet|purple|pink|brown|grey|black'`
![toast_colors_inverted](https://user-images.githubusercontent.com/18379884/46907539-49d82e00-cf14-11e8-8379-973ecc8144ea.PNG)



