### PR TITLE
[Header] Top-attached headers missing top border

### DIFF
--- a/src/definitions/elements/header.less
+++ b/src/definitions/elements/header.less
@@ -703,20 +703,13 @@ a.ui.inverted.grey.header:hover {
 .ui.attached.block.header {
   background: @blockBackground;
 }
-
-.ui.attached:not(.top):not(.bottom).header {
+.ui.attached:not(.top).header {
   border-top: none;
 }
-.ui.top.attached.header:not(:first-child) {
-  border-top: none;
-}
-.ui.top.attached.header:first-child {
+.ui.top.attached.header {
   border-radius: @attachedBorderRadius @attachedBorderRadius 0em 0em;
 }
 .ui.bottom.attached.header {
-  border-top: none;
-}
-.ui.bottom.attached.header:last-child {
   border-radius: 0em 0em @attachedBorderRadius @attachedBorderRadius;
 }
 


### PR DESCRIPTION
## Description
Changed the attached header classes as following:
- All non-top attached headers have no border top
- All top attached headers have a border-radius top left / top right
- All bottom attached headers have a border-radius bottom left / bottom right

## Screenshot
![image](https://user-images.githubusercontent.com/5517677/47076218-8189f300-d1fe-11e8-81a7-6f407394d613.png)


## Closes
#180
