### PR TITLE
chore: add vscode folder into .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ nbproject
 *.sublime-workspace
 .build*
 .idea
+.vscode


### PR DESCRIPTION
This PR only add the vcode folder in the .gitignore file, allow preventing vscode users (and the dumbest one, a.k.a. myself) submitting unwanted files to the repo...