### PR TITLE
[Dimmer] Added support for using dimmers only partially on top,center,bottom

### DIFF
--- a/src/definitions/modules/dimmer.less
+++ b/src/definitions/modules/dimmer.less
@@ -332,10 +332,10 @@ body.dimmable > .dimmer {
     transform: translateY(-50%);
   }
   40% {
-    transform: translateY(calc(50% - 30px));
+    transform: translateY(calc(-50% - 30px));
   }
   60% {
-    transform: translateY(calc(50% - 15px));
+    transform: translateY(calc(-50% - 15px));
   }
 }
 .loadUIOverrides();

--- a/src/definitions/modules/dimmer.less
+++ b/src/definitions/modules/dimmer.less
@@ -270,6 +270,7 @@ body.dimmable > .dimmer {
 .ui[class*="center caption"].dimmer{
   top:50% !important;
   transform: translateY(-50%);
+  -webkit-transform: translateY(calc(-50% - .5px));
 }
 
 .ui[class*="center caption"].dimmer.transition[class*="fade up"].in {
@@ -291,45 +292,54 @@ body.dimmable > .dimmer {
   0% {
     opacity: 0;
     transform: translateY(-40%);
+    -webkit-transform: translateY(calc(-40% - .5px));
   }
   100% {
     opacity: 1;
     transform: translateY(-50%);
+    -webkit-transform: translateY(calc(-50% - .5px));
   }
 }
 @keyframes fadeInDownCenter {
   0% {
     opacity: 0;
     transform: translateY(-60%);
+    -webkit-transform: translateY(calc(-60% - .5px));
   }
   100% {
     opacity: 1;
     transform: translateY(-50%);
+    -webkit-transform: translateY(calc(-50% - .5px));
   }
 }
 @keyframes fadeOutUpCenter {
   0% {
     opacity: 1;
     transform: translateY(-50%);
+    -webkit-transform: translateY(calc(-50% - .5px));
   }
   100% {
     opacity: 0;
     transform: translateY(-45%);
+    -webkit-transform: translateY(calc(-45% - .5px));
   }
 }
 @keyframes fadeOutDownCenter {
   0% {
     opacity: 1;
     transform: translateY(-50%);
+    -webkit-transform: translateY(calc(-50% - .5px));
   }
   100% {
     opacity: 0;
     transform: translateY(-55%);
+    -webkit-transform: translateY(calc(-55% - .5px));
   }
 }
 @keyframes bounceCenter {
   0%, 20%, 50%, 80%, 100% {
     transform: translateY(-50%);
+    -webkit-transform: translateY(calc(-50% - .5px));
   }
   40% {
     transform: translateY(calc(-50% - 30px));

--- a/src/definitions/modules/dimmer.less
+++ b/src/definitions/modules/dimmer.less
@@ -348,4 +348,5 @@ body.dimmable > .dimmer {
     transform: translateY(calc(-50% - 15px));
   }
 }
+
 .loadUIOverrides();

--- a/src/definitions/modules/dimmer.less
+++ b/src/definitions/modules/dimmer.less
@@ -256,4 +256,86 @@ body.dimmable > .dimmer {
   background-color: @simpleInvertedEndBackgroundColor;
 }
 
+/*--------------
+     Captions
+---------------*/
+
+.caption.dimmer {
+  height: auto;
+}
+.ui[class*="bottom caption"].dimmer{
+  top: auto !important;
+  bottom: 0;
+}
+.ui[class*="center caption"].dimmer{
+  top:50% !important;
+  transform: translateY(-50%);
+}
+
+.ui[class*="center caption"].dimmer.transition[class*="fade up"].in {
+  animation-name: fadeInUpCenter;
+}
+.ui[class*="center caption"].dimmer.transition[class*="fade down"].in {
+  animation-name: fadeInDownCenter;
+}
+.ui[class*="center caption"].dimmer.transition[class*="fade up"].out {
+  animation-name: fadeOutUpCenter;
+}
+.ui[class*="center caption"].dimmer.transition[class*="fade down"].out {
+  animation-name: fadeOutDownCenter;
+}
+.ui[class*="center caption"].dimmer.bounce.transition {
+  animation-name: bounceCenter;
+}
+@keyframes fadeInUpCenter {
+  0% {
+    opacity: 0;
+    transform: translateY(-40%);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(-50%);
+  }
+}
+@keyframes fadeInDownCenter {
+  0% {
+    opacity: 0;
+    transform: translateY(-60%);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(-50%);
+  }
+}
+@keyframes fadeOutUpCenter {
+  0% {
+    opacity: 1;
+    transform: translateY(-50%);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-45%);
+  }
+}
+@keyframes fadeOutDownCenter {
+  0% {
+    opacity: 1;
+    transform: translateY(-50%);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-55%);
+  }
+}
+@keyframes bounceCenter {
+  0%, 20%, 50%, 80%, 100% {
+    transform: translateY(-50%);
+  }
+  40% {
+    transform: translateY(calc(50% - 30px));
+  }
+  60% {
+    transform: translateY(calc(50% - 15px));
+  }
+}
 .loadUIOverrides();

--- a/src/definitions/modules/dimmer.less
+++ b/src/definitions/modules/dimmer.less
@@ -257,35 +257,49 @@ body.dimmable > .dimmer {
 }
 
 /*--------------
-     Captions
----------------*/
+     Partially
+----------------*/
 
-.caption.dimmer {
+.ui[class*="top dimmer"],
+.ui[class*="center dimmer"],
+.ui[class*="bottom dimmer"] {
   height: auto;
 }
-.ui[class*="bottom caption"].dimmer{
+.ui[class*="bottom dimmer"] {
   top: auto !important;
   bottom: 0;
 }
-.ui[class*="center caption"].dimmer{
+.ui[class*="center dimmer"] {
   top:50% !important;
   transform: translateY(-50%);
   -webkit-transform: translateY(calc(-50% - .5px));
 }
 
-.ui[class*="center caption"].dimmer.transition[class*="fade up"].in {
+.ui.segment > .ui[class*="top dimmer"] {
+    border-bottom-left-radius: 0 !important;
+    border-bottom-right-radius: 0 !important;
+}
+.ui.segment > .ui[class*="center dimmer"] {
+    border-radius: 0 !important;
+}
+.ui.segment > .ui[class*="bottom dimmer"] {
+    border-top-left-radius: 0 !important;
+    border-top-right-radius: 0 !important;
+}
+
+.ui[class*="center dimmer"].transition[class*="fade up"].in {
   animation-name: fadeInUpCenter;
 }
-.ui[class*="center caption"].dimmer.transition[class*="fade down"].in {
+.ui[class*="center dimmer"].transition[class*="fade down"].in {
   animation-name: fadeInDownCenter;
 }
-.ui[class*="center caption"].dimmer.transition[class*="fade up"].out {
+.ui[class*="center dimmer"].transition[class*="fade up"].out {
   animation-name: fadeOutUpCenter;
 }
-.ui[class*="center caption"].dimmer.transition[class*="fade down"].out {
+.ui[class*="center dimmer"].transition[class*="fade down"].out {
   animation-name: fadeOutDownCenter;
 }
-.ui[class*="center caption"].dimmer.bounce.transition {
+.ui[class*="center dimmer"].bounce.transition {
   animation-name: bounceCenter;
 }
 @keyframes fadeInUpCenter {


### PR DESCRIPTION
## Description

This adds the possibility to use any dimmer only partially and limited only to the overall height of its content and not over the whole to be covered area. This can be used for example as a caption on any element of choice by simply using
 `top dimmer`, `center dimmer` or `bottom dimmer`

Works also very well with transitions 'fade up' or 'fade down'


## Testcase

#### Static without Javascript (just add `active` to the dimmer as usual)

```html
<div class="ui medium image">
  <div class="ui active top dimmer">
    <div class="content">
      <h3>Look!</h3>
      ui top dimmer
    </div>
  </div>
  <img src="assets/images/avatar/nan.jpg">
</div>
```
#### Animation triggered via Javascript

```html
<div class="ui medium image">
  <div class="ui center dimmer">
    <div class="content">
      <h3>Look!</h3>
      ui center dimmer
    </div>
  </div>
  <img src="assets/images/avatar/nan.jpg">
</div>
```
```javascript
$('.center.dimmer').dimmer({
    transition: 'fade down',
    on: 'hover'
});
```
## Screenshot
![image](https://user-images.githubusercontent.com/18379884/47228799-69fd6680-d3c6-11e8-8896-951c38d82ae9.png)


## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/3459
https://github.com/Semantic-Org/Semantic-UI/pull/6621 
