### PR TITLE
[Dimmer] Fix content text color in inverted dimmer

### DIFF
--- a/src/definitions/modules/dimmer.less
+++ b/src/definitions/modules/dimmer.less
@@ -208,6 +208,7 @@ body.dimmable > .dimmer {
 .ui.inverted.dimmer {
   background-color: @invertedBackgroundColor;
 }
+.ui.inverted.dimmer > .content,
 .ui.inverted.dimmer > .content > * {
   color: @invertedTextColor;
 }

--- a/src/themes/default/modules/dimmer.variables
+++ b/src/themes/default/modules/dimmer.variables
@@ -48,7 +48,7 @@
 
 /* Inverted */
 @invertedBackgroundColor: rgba(255, 255, 255, 0.85);
-@invertedTextColor: @textColor;
+@invertedTextColor: @fullBlack;
 
 /* Simple */
 @simpleZIndex: 1;


### PR DESCRIPTION
## Description
The text color in an inverted dimmer had the same color (white) as in a normal dimmer making it unreadable

## Testcase
```html
<div class="ui medium image">
    <div class="ui inverted medium dimmer">
      <div class="content">
        <h3>Look!</h3>
        Can you still read me?
      </div>
    </div>
  <img src="assets/images/avatar/nan.jpg">
</div>
```

## Screenshot
Before -> After (using `ui inverted medium dimmer`, but normal `ui inverted dimmer` would make it look even worse)
![image](https://user-images.githubusercontent.com/18379884/47216699-22ff7900-d3a6-11e8-82a5-9f99445e8384.png)


## Closes
https://github.com/Semantic-Org/Semantic-UI/pull/4631

