### PR TITLE
[Dropdown] Stop Events after clicking outside of module

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1629,6 +1629,7 @@ $.fn.dropdown = function(parameters) {
             if(inDocument && !inModule) {
               module.verbose('Triggering event', callback);
               callback();
+              event.preventDefault();
               return true;
             }
             else {

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1170,7 +1170,9 @@ $.fn.dropdown = function(parameters) {
               event.stopPropagation();
             },
             hide: function(event) {
-              module.determine.eventInModule(event, module.hide);
+              if(module.determine.eventInModule(event, module.hide)){
+                  event.preventDefault();
+              }
             }
           },
           select: {
@@ -1629,7 +1631,6 @@ $.fn.dropdown = function(parameters) {
             if(inDocument && !inModule) {
               module.verbose('Triggering event', callback);
               callback();
-              event.preventDefault();
               return true;
             }
             else {


### PR DESCRIPTION
## Description
When clicking on a label of a select-dropdown it behaves like it would open the dropdown again after closing it. Indeed toggle() is called, but the previous event was hiding it before


## Testcase
https://jsfiddle.net/d0aosr6q/1 

- Click on the label above the dropdown. It opens the dropdown.
- Clicking again closes it, but opens it again.

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6638
