### PR TITLE
[Dropdown] Fix IE11 submenu selection triggered menu opening

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1262,9 +1262,7 @@ $.fn.dropdown = function(parameters) {
                 isBubbledEvent = ($subMenu.find($target).length > 0)
               ;
               // prevents IE11 bug where menu receives focus even though `tabindex=-1`
-              if(module.has.menuSearch()) {
-                $(document.activeElement).blur();
-              }
+              $(document.activeElement).blur();
               if(!isBubbledEvent && (!hasSubMenu || settings.allowCategorySelection)) {
                 if(module.is.searchSelection()) {
                   if(settings.allowAdditions) {


### PR DESCRIPTION
## Description

If a submenu entry was selected from a dropdown, the Element got focus on IE11 and reopened the dropdown again. This was basically already fixed in case the dropdown had a searchmenu, but now it works anytime.

## Testcase
https://jsbin.com/yofawovahi/edit?html,js,output

## Screenshot (with applied fix)
![ie11_submenu_focus_fix](https://user-images.githubusercontent.com/18379884/47288987-f42d1100-d5f8-11e8-9d69-2a96846a1200.gif)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6565
