### PR TITLE
[Dropdown] Prevent close/open bubbling on keyselect via enter

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1671,10 +1671,7 @@ $.fn.dropdown = function(parameters) {
             ;
             if( module.can.activate( $(element) ) ) {
               module.set.selected(value, $(element));
-              if(module.is.multiple() && !module.is.allFiltered()) {
-                return;
-              }
-              else {
+              if(!module.is.multiple()) {
                 module.hideAndClear();
               }
             }
@@ -1687,10 +1684,7 @@ $.fn.dropdown = function(parameters) {
             ;
             if( module.can.activate( $(element) ) ) {
               module.set.value(value, text, $(element));
-              if(module.is.multiple() && !module.is.allFiltered()) {
-                return;
-              }
-              else {
+              if(!module.is.multiple()) {
                 module.hideAndClear();
               }
             }


### PR DESCRIPTION
## Description
Since implementing #143, whenever one selected an item on multiple search via enter, the DropDown-List was closing/opening immediatly making it look ugly.
This PR fixes that. It simply does not hide the List on multiple anymore.

## Screenshot
Before:
![multidd_after](https://user-images.githubusercontent.com/18379884/47296239-f354a900-d611-11e8-9a2c-5edd6483ab59.gif)

After:
![multidd_after_fixed_bubbling](https://user-images.githubusercontent.com/18379884/47296247-f9e32080-d611-11e8-859f-16f5c2e16c0a.gif)

## Closes
#143 
