### PR TITLE
[Dropdown] showOnFocus:false prevented click to open dropdown

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1048,7 +1048,7 @@ $.fn.dropdown = function(parameters) {
               if(module.is.multiple()) {
                 module.remove.activeLabel();
               }
-              if(settings.showOnFocus) {
+              if(settings.showOnFocus || event.type !== 'focus') {
                 module.search();
               }
             },
@@ -1079,7 +1079,11 @@ $.fn.dropdown = function(parameters) {
             click: function(event) {
               if(module.has.search()) {
                 if(!module.is.active()) {
-                  module.focusSearch();
+                    if(settings.showOnFocus){
+                      module.focusSearch();
+                    } else {
+                      module.toggle();
+                    }
                 } else {
                   module.blurSearch();
                 }


### PR DESCRIPTION
## Description
If a dropdown had `showOnFocus` set to false, the dropdown icon and the dropdown itself was not clickable anymore to open the whole list of options

## Testcase
https://jsfiddle.net/ibelar/eokn6yv8/

## Screenshot
![showonfocus_onclick_fix](https://user-images.githubusercontent.com/18379884/47307239-df6b7000-d62e-11e8-8da5-7e7ad05be2e7.gif)


## Closes
#191
