### PR TITLE
[Dropdown] Prevent downshifting on multiselection

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -676,7 +676,6 @@ select.ui.dropdown {
 .ui.multiple.dropdown > .label {
   user-select: none;
   display: inline-block;
-  vertical-align: top;
   white-space: normal;
   font-size: @labelSize;
   padding: @labelPadding;


### PR DESCRIPTION
## Description
- Open the fiddle
- Select an item from the right dropdown field
- At least on Chrome the dropdown shifts a few pixels down
- To see the fix, uncomment the CSS part in the fiddle and run again

## Testcase
https://jsfiddle.net/n5gz8vx6/1/

## Screenshots
Before
![image](https://user-images.githubusercontent.com/18379884/47377249-08eecf00-d6f5-11e8-8ba3-3685b366368f.png)

After
![image](https://user-images.githubusercontent.com/18379884/47377319-36d41380-d6f5-11e8-9b3d-64cd24898aa0.png)


## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5699
