### PR TITLE
[Progress] Display dark text on light inverted backgrounds

### DIFF
--- a/src/definitions/modules/progress.less
+++ b/src/definitions/modules/progress.less
@@ -462,6 +462,12 @@
   background-color: @lightBlack;
 }
 
+.ui.yellow.inverted.progress .bar>.progress,
+.ui.olive.inverted.progress .bar>.progress,
+.ui.teal.inverted.progress .bar>.progress,
+.ui.grey.inverted.progress .bar>.progress {
+  color: @fullBlack;
+}
 /*--------------
      Sizes
 ---------------*/

--- a/src/definitions/modules/progress.less
+++ b/src/definitions/modules/progress.less
@@ -462,12 +462,6 @@
   background-color: @lightBlack;
 }
 
-.ui.yellow.inverted.progress .bar>.progress,
-.ui.olive.inverted.progress .bar>.progress,
-.ui.teal.inverted.progress .bar>.progress,
-.ui.grey.inverted.progress .bar>.progress {
-  color: @fullBlack;
-}
 /*--------------
      Sizes
 ---------------*/

--- a/src/themes/default/modules/progress.variables
+++ b/src/themes/default/modules/progress.variables
@@ -103,7 +103,7 @@
 @invertedBackground: @transparentWhite;
 @invertedBorder: none;
 @invertedBarBackground: @barBackground;
-@invertedProgressColor: @offWhite;
+@invertedProgressColor: @black;
 @invertedLabelColor: @white;
 
 /* Sizing */


### PR DESCRIPTION
## Description
Some progress text is unreadable on inverted progress bars, because their background color is too light.
This PR changes the text colors from white to black on `inverted yellow|olive|teal|grey progress`

## Screenshot
### Before
![image](https://user-images.githubusercontent.com/18379884/47394783-6cdcbc00-d724-11e8-96c7-33acf96ffd82.png)


### After
![image](https://user-images.githubusercontent.com/18379884/47394766-559dce80-d724-11e8-87b2-7dbd17d83eb7.png)
