### PR TITLE
[Calendar] Add ability to disable days of week

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -315,7 +315,7 @@ $.fn.calendar = function(parameters) {
                   cell.text(cellText);
                   cell.data(metadata.date, cellDate);
                   var adjacent = isDay && cellDate.getMonth() !== ((month + 12) % 12);
-                  var disabled = adjacent || !module.helper.isDateInRange(cellDate, mode) || settings.isDisabled(cellDate, mode);
+                  var disabled = adjacent || !module.helper.isDateInRange(cellDate, mode) || settings.isDisabled(cellDate, mode) || (mode === 'day' && settings.disabledDaysOfWeek.includes(cellDate.getDay()));
                   var active = module.helper.dateEqual(cellDate, date, mode);
                   var isToday = module.helper.dateEqual(cellDate, today, mode);
                   cell.toggleClass(className.adjacentCell, adjacent);
@@ -495,7 +495,7 @@ $.fn.calendar = function(parameters) {
                 //enter
                 var mode = module.get.mode();
                 var date = module.get.focusDate();
-                if (date && !settings.isDisabled(date, mode)) {
+                if (date && !settings.isDisabled(date, mode) && !(mode === 'day' && settings.disabledDaysOfWeek.includes(date.getDay())) ) {
                   module.selectDate(date);
                 }
                 //disable form submission:
@@ -1051,28 +1051,29 @@ $.fn.calendar.settings = {
   verbose: false,
   performance: false,
 
-  type           : 'datetime', // picker type, can be 'datetime', 'date', 'time', 'month', or 'year'
-  firstDayOfWeek : 0,          // day for first day column (0 = Sunday)
-  constantHeight : true,       // add rows to shorter months to keep day calendar height consistent (6 rows)
-  today          : false,      // show a 'today/now' button at the bottom of the calendar
-  closable       : true,       // close the popup after selecting a date/time
-  monthFirst     : true,       // month before day when parsing/converting date from/to text
-  touchReadonly  : true,       // set input to readonly on touch devices
-  inline         : false,      // create the calendar inline instead of inside a popup
-  on             : null,       // when to show the popup (defaults to 'focus' for input, 'click' for others)
-  initialDate    : null,       // date to display initially when no date is selected (null = now)
-  startMode      : false,      // display mode to start in, can be 'year', 'month', 'day', 'hour', 'minute' (false = 'day')
-  minDate        : null,       // minimum date/time that can be selected, dates/times before are disabled
-  maxDate        : null,       // maximum date/time that can be selected, dates/times after are disabled
-  ampm           : true,       // show am/pm in time mode
-  disableYear    : false,      // disable year selection mode
-  disableMonth   : false,      // disable month selection mode
-  disableMinute  : false,      // disable minute selection mode
-  formatInput    : true,       // format the input text upon input blur and module creation
-  startCalendar  : null,       // jquery object or selector for another calendar that represents the start date of a date range
-  endCalendar    : null,       // jquery object or selector for another calendar that represents the end date of a date range
-  multiMonth     : 1,          // show multiple months when in 'day' mode
-  showWeekNumbers: null,       // show Number of Week at the very first column of a dayView
+  type               : 'datetime', // picker type, can be 'datetime', 'date', 'time', 'month', or 'year'
+  firstDayOfWeek     : 0,          // day for first day column (0 = Sunday)
+  constantHeight     : true,       // add rows to shorter months to keep day calendar height consistent (6 rows)
+  today              : false,      // show a 'today/now' button at the bottom of the calendar
+  closable           : true,       // close the popup after selecting a date/time
+  monthFirst         : true,       // month before day when parsing/converting date from/to text
+  touchReadonly      : true,       // set input to readonly on touch devices
+  inline             : false,      // create the calendar inline instead of inside a popup
+  on                 : null,       // when to show the popup (defaults to 'focus' for input, 'click' for others)
+  initialDate        : null,       // date to display initially when no date is selected (null = now)
+  startMode          : false,      // display mode to start in, can be 'year', 'month', 'day', 'hour', 'minute' (false = 'day')
+  minDate            : null,       // minimum date/time that can be selected, dates/times before are disabled
+  maxDate            : null,       // maximum date/time that can be selected, dates/times after are disabled
+  ampm               : true,       // show am/pm in time mode
+  disableYear        : false,      // disable year selection mode
+  disableMonth       : false,      // disable month selection mode
+  disableMinute      : false,      // disable minute selection mode
+  formatInput        : true,       // format the input text upon input blur and module creation
+  startCalendar      : null,       // jquery object or selector for another calendar that represents the start date of a date range
+  endCalendar        : null,       // jquery object or selector for another calendar that represents the end date of a date range
+  multiMonth         : 1,          // show multiple months when in 'day' mode
+  showWeekNumbers    : null,       // show Number of Week at the very first column of a dayView
+  disabledDaysOfWeek : [],         // day(s) which won't be selectable(s) (0 = Sunday)
   // popup options ('popup', 'on', 'hoverable', and show/hide callbacks are overridden)
   popupOptions: {
     position: 'bottom left',


### PR DESCRIPTION
## Description
This PR add the ability to disable some days of the week from selection. By setting `disabledDaysOfWeek` to array of numbers (0= Sunday, 1=Monday...), you can now disallow users from selecting these days.

## Screenshot
`disabledDaysOfWeek: [0, 3, 6]`
[![e83d8246564d523526c4c6bc5a4b7f1b.png](http://tof.cx/images/2018/10/24/e83d8246564d523526c4c6bc5a4b7f1b.png)](http://tof.cx/image/NG7v7)
