### PR TITLE
[Dropdown] Item of 'simple dropdown' in existing menus or 'simple floating' vanish preventing click

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -1085,7 +1085,7 @@ select.ui.dropdown {
 }
 
 /*--------------
-     Simple
+     Scrolling
 ---------------*/
 
 /*  Selection Menu */
@@ -1179,6 +1179,7 @@ select.ui.dropdown {
   width: 0;
   height: 0;
   transition: @simpleTransition;
+  margin-top: 0 !important;
 }
 
 .ui.simple.active.dropdown,


### PR DESCRIPTION
## Description
Items in a simple dropdown within an existing menu cannot be clicked, because the submenu vanishes right before clicking

Sidenote: this PR also fixes wrong comment block header in less file

## Testcase
http://jsfiddle.net/pjga38wv/

Uncomment the CSS Part to see the fix

## Screenshot
The right dropdown is the important one.

#### Before
![simple_dd_bad](https://user-images.githubusercontent.com/18379884/47513126-e0461100-d87d-11e8-9f31-bedbba0d1f55.gif)

#### After
![simple_dd_good](https://user-images.githubusercontent.com/18379884/47513259-27cc9d00-d87e-11e8-890c-143e3c5a8025.gif)

### Also fixes `simple pointing dropdown`
#### Before 
![simple_pointing_dd_bad](https://user-images.githubusercontent.com/18379884/47529469-2f08a080-d8a8-11e8-94e0-1e38523bc641.gif)

#### After
![simple_pointing_dd_good](https://user-images.githubusercontent.com/18379884/47529489-3fb91680-d8a8-11e8-93f8-b5c4c05c8bf9.gif)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/2444
https://github.com/Semantic-Org/Semantic-UI/issues/5322