### PR TITLE
[Modal] Basic Modal and inverted modal on inverted dimmer had wrong close icon color

### DIFF
--- a/src/definitions/modules/modal.less
+++ b/src/definitions/modules/modal.less
@@ -171,6 +171,9 @@
 .ui.modal .actions > .button {
   margin-left: @buttonDistance;
 }
+.ui.basic.modal > .actions {
+  border-top:none;
+}
 
 /*-------------------
        Responsive
@@ -301,6 +304,7 @@
 .ui.basic.modal > .close {
   top: @basicModalCloseTop;
   right: @basicModalCloseRight;
+  color: @basicInnerCloseColor;
 }
 
 .ui.inverted.dimmer > .basic.modal {
@@ -324,12 +328,6 @@
   top: auto !important;
 }
 
-/* Tablet and Mobile */
-@media only screen and (max-width : @largestTabletScreen) {
-  .ui.basic.modal > .close {
-    color: @basicInnerCloseColor;
-  }
-}
 
 
 /*******************************
@@ -432,8 +430,9 @@
   right: @innerCloseRight;
   color: @innerCloseColor;
 }
-
-
+.ui.basic.fullscreen.modal > .close {
+  color: @basicInnerCloseColor;
+}
 /*--------------
       Size
 ---------------*/
@@ -607,13 +606,13 @@
   border-top: @invertedActionBorder;
 }
 
-.ui.fullscreen.inverted.modal > .close {
-  color: @invertedInnerCloseColor;
+.ui.inverted.dimmer > .modal > .close {
+  color: @invertedDimmerCloseColor;
 }
 
 
 @media only screen and (max-width: @largestTabletScreen) {
-  .ui.inverted.modal > .close {
+  .ui.dimmer .inverted.modal > .close {
     color: @invertedCloseColor;
   }
 }
@@ -622,9 +621,7 @@
   color: @invertedCloseColor;
 }
 
-.ui.inverted.dimmer > .modal > .close {
-  color: @invertedDimmerCloseColor;
-}
+
 
 
 .loadUIOverrides();

--- a/src/themes/default/modules/modal.variables
+++ b/src/themes/default/modules/modal.variables
@@ -200,5 +200,4 @@
 @invertedHeaderBackgroundColor: @darkTextColor;
 @invertedActionBackground: #191A1B;
 @invertedActionBorder: 1px solid rgba(34, 36, 38, 0.85);
-@invertedInnerCloseColor: rgba(255, 255, 255, 0.13);
 @invertedDimmerCloseColor: rgba(0,0,0,.85);


### PR DESCRIPTION
## Description
- Basic Fullscreen Modal had black close icon on black dimmer
- Basic Modal on inverted dimmer had grey borders on action and header
- Basic Modal on usual black dimmer had the borders aswell (although nearly invisible)
- inverted modal on inverted dimmer in small viewports had black close icon on black modal

#### Black close icon when using `basic fullscreen modal`
Before:
![image](https://user-images.githubusercontent.com/18379884/47596701-5a62bc80-d988-11e8-9f3e-ac2f103bc412.png)
After:
![image](https://user-images.githubusercontent.com/18379884/47596731-95fd8680-d988-11e8-9f7d-1786e3f031ec.png)

#### Border lines when using `basic modal` in `inverted dimmer`
Before:
![image](https://user-images.githubusercontent.com/18379884/47596787-145a2880-d989-11e8-83a2-f616bf160184.png)

After:
![image](https://user-images.githubusercontent.com/18379884/47596801-381d6e80-d989-11e8-91dd-3c54245afb98.png)

#### Black (thus invisible) close icon on small screen when using `inverted modal` in `inverted dimmer` 
Before:
![image](https://user-images.githubusercontent.com/18379884/47596814-56836a00-d989-11e8-9149-0b2439231b39.png)

After:
![image](https://user-images.githubusercontent.com/18379884/47596831-82065480-d989-11e8-9466-6276488eb519.png)


## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5831
