### PR TITLE
[Modal] image content images can go out of content and description does not wrap

### DIFF
--- a/src/definitions/modules/modal.less
+++ b/src/definitions/modules/modal.less
@@ -114,6 +114,7 @@
 .ui.modal > .image.content {
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
 }
 
 /* Image */
@@ -122,6 +123,7 @@
   flex: 0 1 auto;
   width: @imageWidth;
   align-self: @imageVerticalAlign;
+  max-width: 100%;
 }
 .ui.modal > [class*="top aligned"] {
   align-self: top;


### PR DESCRIPTION
## Description
Using images within `image content` as suggested in the docs, which are too large, they overlay the modal and the description does not wrap

Original Fix provided by @GammaGames

## Testcase
https://jsfiddle.net/j7qsb24n/

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6636
