### PR TITLE
[Calendar] Add ability to disable specific date(s)

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -801,7 +801,7 @@ $.fn.calendar = function(parameters) {
 
         helper: {
           isDisabled: function(date, mode) {
-            return mode === 'day' && (settings.disabledDaysOfWeek.includes(date.getDay()) || settings.disabledDates.some(function(d){
+            return mode === 'day' && ((settings.disabledDaysOfWeek.indexOf(date.getDay()) !== -1) || settings.disabledDates.some(function(d){
               if (d instanceof Date) {
                 return module.helper.dateEqual(date, d, mode);
               }

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -216,6 +216,7 @@ $.fn.calendar = function(parameters) {
             var pages = isDay ? multiMonth : 1;
 
             var container = $container;
+            var tooltipPosition = container.hasClass("left") ? "right center" : "left center";
             container.empty();
             if (pages > 1) {
               pageGrid = $('<div/>').addClass(className.grid).appendTo(container);
@@ -320,6 +321,7 @@ $.fn.calendar = function(parameters) {
                     var disabledReason = module.helper.disabledReason(cellDate, mode);
                     if (disabledReason !== null) {
                       cell.attr("data-tooltip", disabledReason[metadata.message]);
+                      cell.attr("data-position", tooltipPosition);
                     }
                   }
                   var active = module.helper.dateEqual(cellDate, date, mode);

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -315,7 +315,7 @@ $.fn.calendar = function(parameters) {
                   cell.text(cellText);
                   cell.data(metadata.date, cellDate);
                   var adjacent = isDay && cellDate.getMonth() !== ((month + 12) % 12);
-                  var disabled = adjacent || !module.helper.isDateInRange(cellDate, mode) || settings.isDisabled(cellDate, mode) || (mode === 'day' && settings.disabledDaysOfWeek.includes(cellDate.getDay()));
+                  var disabled = adjacent || !module.helper.isDateInRange(cellDate, mode) || settings.isDisabled(cellDate, mode) || module.helper.isDisabled(cellDate, mode);
                   var active = module.helper.dateEqual(cellDate, date, mode);
                   var isToday = module.helper.dateEqual(cellDate, today, mode);
                   cell.toggleClass(className.adjacentCell, adjacent);
@@ -495,7 +495,7 @@ $.fn.calendar = function(parameters) {
                 //enter
                 var mode = module.get.mode();
                 var date = module.get.focusDate();
-                if (date && !settings.isDisabled(date, mode) && !(mode === 'day' && settings.disabledDaysOfWeek.includes(date.getDay())) ) {
+                if (date && !settings.isDisabled(date, mode) && !module.helper.isDisabled(date, mode)) {
                   module.selectDate(date);
                 }
                 //disable form submission:
@@ -789,6 +789,9 @@ $.fn.calendar = function(parameters) {
         },
 
         helper: {
+          isDisabled: function(date, mode) {
+            return (mode === 'day' && settings.disabledDaysOfWeek.includes(date.getDay()))
+          },
           sanitiseDate: function (date) {
             if (!date) {
               return undefined;

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -319,7 +319,7 @@ $.fn.calendar = function(parameters) {
                   if (disabled) {
                     var disabledReason = module.helper.disabledReason(cellDate, mode);
                     if (disabledReason !== null) {
-                      cell.attr("data-tooltip", disabledReason[metadata.title]);
+                      cell.attr("data-tooltip", disabledReason[metadata.message]);
                     }
                   }
                   var active = module.helper.dateEqual(cellDate, date, mode);
@@ -814,7 +814,7 @@ $.fn.calendar = function(parameters) {
                 var d = settings.disabledDates[i];
                 if (d !== null && typeof d === 'object' && module.helper.dateEqual(date, d[metadata.date], mode)) {
                   var reason = {};
-                  reason[metadata.title] = d[metadata.title];
+                  reason[metadata.message] = d[metadata.message];
                   return reason;
                 }
               }
@@ -1467,7 +1467,6 @@ $.fn.calendar.settings = {
     maxDate: 'maxDate',
     mode: 'mode',
     monthOffset: 'monthOffset',
-    title: 'title',
     message: 'message'
   }
 };

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -319,8 +319,7 @@ $.fn.calendar = function(parameters) {
                   if (disabled) {
                     var disabledReason = module.helper.disabledReason(cellDate, mode);
                     if (disabledReason !== null) {
-                      cell.data(metadata.title, disabledReason.title);
-                      cell.data(metadata.message, disabledReason.message);
+                      cell.attr("data-tooltip", disabledReason[metadata.title]);
                     }
                   }
                   var active = module.helper.dateEqual(cellDate, date, mode);
@@ -385,7 +384,7 @@ $.fn.calendar = function(parameters) {
               var inRange = !rangeDate ? false :
                 ((!!startDate && module.helper.isDateInRange(cellDate, mode, startDate, rangeDate)) ||
                 (!!endDate && module.helper.isDateInRange(cellDate, mode, rangeDate, endDate)));
-              cell.toggleClass(className.focusCell, focused && (!isTouch || isTouchDown) && !adjacent);
+              cell.toggleClass(className.focusCell, focused && (!isTouch || isTouchDown) && !adjacent && !disabled);
               cell.toggleClass(className.rangeCell, inRange && !active && !disabled);
             });
           }
@@ -453,6 +452,9 @@ $.fn.calendar = function(parameters) {
             event.stopPropagation();
             isTouchDown = false;
             var target = $(event.target);
+            if (target.hasClass("disabled")) {
+              return;
+            }
             var parent = target.parent();
             if (parent.data(metadata.date) || parent.data(metadata.focusDate) || parent.data(metadata.mode)) {
               //clicked on a child element, switch to parent (used when clicking directly on prev/next <i> icon element)
@@ -813,7 +815,6 @@ $.fn.calendar = function(parameters) {
                 if (d !== null && typeof d === 'object' && module.helper.dateEqual(date, d[metadata.date], mode)) {
                   var reason = {};
                   reason[metadata.title] = d[metadata.title];
-                  reason[metadata.message] = d[metadata.message];
                   return reason;
                 }
               }

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -806,7 +806,7 @@ $.fn.calendar = function(parameters) {
                 return module.helper.dateEqual(date, d, mode);
               }
               if (d !== null && typeof d === 'object') {
-                return module.helper.dateEqual(date, d[metadata.date], mode)
+                return module.helper.dateEqual(date, d[metadata.date], mode);
               }
             }));
           },

--- a/src/definitions/modules/calendar.less
+++ b/src/definitions/modules/calendar.less
@@ -126,7 +126,8 @@
 }
 
 .ui.calendar .ui.table tr .disabled {
-  pointer-events: none;
+  pointer-events: auto;
+  cursor: default;
   color: @disabledTextColor;
 }
 


### PR DESCRIPTION
## Description
Add an option `disabledDates` to the Calendar module.
This option should hold an array of `Date` or structured <del>`{date: Date, title: string, message: string}`</del>`{date: Date, message: string}`.
This option allows users to disable the specific date(s) such as national holiday or something like that.

## Screenshot
![calendar-disabled-dates](https://user-images.githubusercontent.com/127635/47611254-f550b900-daa4-11e8-8a69-8e9c7fbfc4ff.gif)

Oct 15, 16 and 27 are disabled.
Oct 27 has CSS-only tooltip to explain why it is disabled.

## Closes
#200

