### PR TITLE
[Header] Fix corner icon size in icon header

### DIFF
--- a/src/definitions/elements/header.less
+++ b/src/definitions/elements/header.less
@@ -274,6 +274,9 @@ h5.ui.header .sub.header {
   margin: 0em auto @iconHeaderMargin;
   opacity: @iconHeaderOpacity;
 }
+.ui.icon.header .corner.icon {
+  font-size: @cornerIconHeaderSize;
+}
 .ui.icon.header .content {
   display: block;
   padding: 0em;

--- a/src/themes/default/elements/header.variables
+++ b/src/themes/default/elements/header.variables
@@ -94,6 +94,7 @@
 @iconHeaderMargin: 0.5rem;
 @circularHeaderIconSize: 2em;
 @squareHeaderIconSize: 2em;
+@cornerIconHeaderSize: calc(@iconHeaderSize * 0.45);
 
 /* No Line Height Offset */
 @iconHeaderTopMargin: 2rem;


### PR DESCRIPTION
## Description
Fix [corner icon (SUI)](https://semantic-ui.com/elements/icon.html#corner-icon) does not look like corner in [icon header (SUI)](https://semantic-ui.com/elements/header.html#icon-headers)



## Testcase
https://codepen.io/anon/pen/ajaEaj

## Screenshot
| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/127635/47613651-a28ff500-dad6-11e8-8721-25ec36321867.png) | ![image](https://user-images.githubusercontent.com/127635/47613661-bf2c2d00-dad6-11e8-9245-664fb391af9c.png) |

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6525
