### PR TITLE
[Icon] Fix the "th large" icon with 

### DIFF
--- a/src/themes/default/elements/icon.overrides
+++ b/src/themes/default/elements/icon.overrides
@@ -777,6 +777,15 @@ i.icon.text.height:before { content: "\f034"; }
 i.icon.text.width:before { content: "\f035"; }
 i.icon.th:before { content: "\f00a"; }
 i.icon.th.large:before { content: "\f009"; }
+i.icon.th.large:not(.list) { font-size: @medium; vertical-align: baseline; }
+i.icon.th.large.mini { font-size: @mini; vertical-align: baseline; }
+i.icon.th.large.tiny { font-size: @tiny; vertical-align: baseline; }
+i.icon.th.large.small { font-size: @small; vertical-align: baseline; }
+i.icon.th.large[class*="th large large"],
+i.icon.th.large[class*="large th large"] { font-size: @large; vertical-align: middle;}
+i.icon.th.large.big { font-size: @big; vertical-align: middle; }
+i.icon.th.large.huge { font-size: @huge; vertical-align: middle; }
+i.icon.th.large.massive { font-size: @massive; vertical-align: middle; }
 i.icon.th.list:before { content: "\f00b"; }
 i.icon.theater.masks:before { content: "\f630"; }
 i.icon.thermometer:before { content: "\f491"; }


### PR DESCRIPTION
## Description
The `th large` icon size should reflect the size passed as another class (e.g. 'mini').

## Testcase
https://jsfiddle.net/agrwpkvh/

## Screenshot
### Before
![th-large-before](https://user-images.githubusercontent.com/127635/47653768-b3229700-dbcc-11e8-9cb7-8a8ec6641302.jpg)
### After
![th-large-ater](https://user-images.githubusercontent.com/127635/47653772-b584f100-dbcc-11e8-9aa3-65724399d89d.jpg)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6499

## Note
It is hard to discriminate the `th icon` with `large` from `th large icon` (marked as red). Thi s issue is reported in https://github.com/Semantic-Org/Semantic-UI/issues/6336.
Perhaps it is better to rename `th large` to `th-large` as similar as `sign-in` icon, `th quadrant` or something like that ? 🤔 
If it is renamed, we don't need a workaround in this PR.