### PR TITLE
[menu] Dropdown inside menu should not reflect menu styling.

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -928,6 +928,9 @@ Floated Menu / Item
   border-bottom-width: @secondaryPointingBorderWidth;
   transition: @secondaryItemTransition;
 }
+.ui.secondary.pointing.menu .ui.dropdown .menu .item {
+  border-bottom-width: 0;
+}
 
 /* Item Types */
 .ui.secondary.pointing.menu .header.item {
@@ -1826,6 +1829,10 @@ Floated Menu / Item
   border: none;
   border-top: @arrowBorder;
   border-right: @arrowBorder;
+}
+.ui.pointing.menu .ui.dropdown .menu .item:after,
+.ui.vertical.pointing.menu .ui.dropdown .menu .item:after {
+  border: 0;
 }
 
 /* Active */

--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -1832,7 +1832,7 @@ Floated Menu / Item
 }
 .ui.pointing.menu .ui.dropdown .menu .item:after,
 .ui.vertical.pointing.menu .ui.dropdown .menu .item:after {
-  border: 0;
+  display: none;
 }
 
 /* Active */


### PR DESCRIPTION
## Description
Dropdown item inside `.pointing.menu` or `.secondary.pointing.menu` should not reflect menu item styling.

## Testcase
https://jsfiddle.net/bjup1fd5/

## Screenshot 
### 🐛 Pointing (Before)
![pointing-before](https://user-images.githubusercontent.com/127635/47657999-8c1c9300-dbd5-11e8-9489-bd5c311326c7.jpg)

### 🌟 Pointing (After)
![image](https://user-images.githubusercontent.com/127635/47705865-16fb9d00-dc6b-11e8-9b9e-356f7df75bb4.png)

### 🐛 Secondary Pointing (Before)
![secondary-pointing-before](https://user-images.githubusercontent.com/127635/47657998-8c1c9300-dbd5-11e8-9012-ea16da4d8b0b.jpg)

### 🌟 Secondary Pointing (After)
![secondary-pointing-after](https://user-images.githubusercontent.com/127635/47657997-8c1c9300-dbd5-11e8-89a6-be097b22bc10.jpg)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6463