### PR TITLE
[List] data-value on <div> list items is ignored

### DIFF
--- a/src/definitions/elements/list.less
+++ b/src/definitions/elements/list.less
@@ -648,8 +648,8 @@ ol.ui.inverted.list li:before,
 }
 
 /* Value */
-.ui.ordered.list > .list > .item[data-value],
-.ui.ordered.list > .item[data-value] {
+.ui.ordered.list .list > .item[data-value]:before,
+.ui.ordered.list > .item[data-value]:before {
   content: attr(data-value);
 }
 ol.ui.list li[value]:before {


### PR DESCRIPTION
## Description

List style bullets given via `data-value` were ignored on`div` tags because the a) pseudo class was missing and b) nesting was not supported

## Testcase
https://jsfiddle.net/6ohwqmxe/2/

Uncomment the CSS part to see the fix

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5911
