### PR TITLE
[Icon] Fix icons alignment

### DIFF
--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -519,7 +519,6 @@ i.icons .icon:first-child {
   height: auto;
   vertical-align: top;
   transform: none;
-  margin-right: @distanceFromText;
 }
 
 /* Corner Icon */


### PR DESCRIPTION
## Description

Remove uncessesary margin so 2 icon in [`.icons`](https://fomantic-ui.com/elements/icon.html#icons) looks center-aligned.

I suppose the margin-right is not much needed, from the commit histories. 
> b21a5669189999fc878f25d6708bfd66abc55b82 | Thu Apr 02 08:23:23 JST 2015 | jlukic | https://github.com/Semantic-Org/Semantic-UI/issues/2046 First pass of grouped icons

It seems just follows `i.icon` definition.
```css
i.icon {
  display: inline-block;
  opacity: @opacity;
  margin: 0em @distanceFromText 0em 0em;
```

## Testcase
http://jsfiddle.net/z2yLmw67/5/

## Screenshot (when possible)
### Before
inner/corner icons are slightly right-aligned
![before](https://user-images.githubusercontent.com/127635/47718186-196def00-dc8b-11e8-89cb-30cf2796d472.jpg)

### After:
![after](https://user-images.githubusercontent.com/127635/47718187-196def00-dc8b-11e8-9781-5ef5517c5253.jpg)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5861