### PR TITLE
feat(statistic): add stackable variation

### DIFF
--- a/src/definitions/views/statistic.less
+++ b/src/definitions/views/statistic.less
@@ -459,6 +459,23 @@
   margin-bottom: 0em;
 }
 
+/*--------------
+    Stackable
+---------------*/
+
+@media only screen and (max-width: @largestMobileScreen) {
+  .ui.stackable.statistics {
+    width: auto;
+    margin-left: 0em !important;
+    margin-right: 0em !important;
+  }
+  .ui.stackable.statistics > .statistic {
+    width: 100% !important;
+    margin: 0em 0em !important;
+    padding: (@stackableRowSpacing / 2) (@stackableGutter / 2) !important;
+  }
+}
+
 
 /*--------------
      Sizes

--- a/src/themes/default/views/statistic.variables
+++ b/src/themes/default/views/statistic.variables
@@ -73,6 +73,10 @@
 @itemGroupMargin: 0em 0em -@rowSpacing;
 @itemMargin: 0em 0em @rowSpacing;
 
+/* Stackable */
+@stackableRowSpacing: 2rem;
+@stackableGutter: 2rem;
+
 /* Size */
 @miniTextValueSize: 1rem;
 @miniValueSize: 1.5rem;


### PR DESCRIPTION
## Description
This PR add a `stackable` variation for the `statistics` group, allowing a single statistic per line display on mobile devices.

## Screenshot
[![01b9908e0617b839c5bb579c7df21c0d.png](http://tof.cx/images/2018/11/05/01b9908e0617b839c5bb579c7df21c0d.png)](http://tof.cx/image/SMyQN)

## Closes
#152
