### PR TITLE
[Form] Dropdown width in form

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -214,6 +214,7 @@
 
 /* Block */
 .ui.form .field > .selection.dropdown {
+  min-width: auto;
   width: 100%;
 }
 .ui.form .field > .selection.dropdown > .dropdown.icon {


### PR DESCRIPTION
## Description
Override `min-width` of `dropdown` inside `field` of `form`, so the dropdown can fit to width of the field.


## Testcase
https://jsfiddle.net/31d6y7mn/117/

## Screenshot 
### Before
![image](https://user-images.githubusercontent.com/127635/48035752-b5768980-e1a8-11e8-8292-0c869d770623.png)

### After
![image](https://user-images.githubusercontent.com/127635/48035676-72b4b180-e1a8-11e8-8c88-69c212e2ba6d.png)

## Closes
#228 
