### PR TITLE
[Theme] Add brand colors and update some

### DIFF
--- a/src/definitions/elements/button.less
+++ b/src/definitions/elements/button.less
@@ -564,7 +564,7 @@
 
 /* VK */
 .ui.vk.button {
-  background-color: #4D7198;
+  background-color: @vkColor;
   color: @white;
   background-image: @coloredBackgroundImage;
   box-shadow: @coloredBoxShadow;
@@ -575,6 +575,38 @@
 }
 .ui.vk.button:active {
   background-color: @vkDownColor;
+  color: @white;
+}
+
+/* WhatsApp */
+.ui.whatsapp.button {
+  background-color: @whatsAppColor;
+  color: @white;
+  background-image: @coloredBackgroundImage;
+  box-shadow: @coloredBoxShadow;
+}
+.ui.whatsapp.button:hover {
+  background-color: @whatsAppHoverColor;
+  color: @white;
+}
+.ui.whatsapp.button:active {
+  background-color: @whatsAppDownColor;
+  color: @white;
+}
+
+/* Telegram */
+.ui.telegram.button {
+  background-color: @telegramColor;
+  color: @white;
+  background-image: @coloredBackgroundImage;
+  box-shadow: @coloredBoxShadow;
+}
+.ui.telegram.button:hover {
+  background-color: @telegramHoverColor;
+  color: @white;
+}
+.ui.telegram.button:active {
+  background-color: @telegramDownColor;
   color: @white;
 }
 

--- a/src/themes/default/globals/site.variables
+++ b/src/themes/default/globals/site.variables
@@ -456,13 +456,15 @@
 --------------------*/
 
 @facebookColor   : #3B5998;
-@twitterColor    : #55ACEE;
+@twitterColor    : #1DA1F2;
 @googlePlusColor : #DD4B39;
-@linkedInColor   : #1F88BE;
+@linkedInColor   : #0077B5;
 @youtubeColor    : #FF0000;
 @pinterestColor  : #BD081C;
-@vkColor         : #4D7198;
+@vkColor         : #45668E;
 @instagramColor  : #49769C;
+@telegramColor   : #0088CC;
+@whatsAppColor   : #25D366;
 
 /*-------------------
       Borders
@@ -781,6 +783,8 @@
 @instagramHoverColor      : saturate(darken(@instagramColor, 5), 10, relative);
 @pinterestHoverColor      : saturate(darken(@pinterestColor, 5), 10, relative);
 @vkHoverColor             : saturate(darken(@vkColor, 5), 10, relative);
+@telegramHoverColor       : saturate(darken(@telegramColor, 5), 10, relative);
+@whatsAppHoverColor       : saturate(darken(@whatsAppColor, 5), 10, relative);
 
 /*---  Dark Tones  ---*/
 @fullBlackHover           : lighten(@fullBlack, 5);
@@ -841,6 +845,8 @@
 @instagramFocusColor      : saturate(darken(@instagramColor, 8), 20, relative);
 @pinterestFocusColor      : saturate(darken(@pinterestColor, 8), 20, relative);
 @vkFocusColor             : saturate(darken(@vkColor, 8), 20, relative);
+@telegramFocusColor       : saturate(darken(@telegramColor, 8), 20, relative);
+@whatsAppFocusColor       : saturate(darken(@whatsAppColor, 8), 20, relative);
 
 /*---  Dark Tones  ---*/
 @fullBlackFocus           : lighten(@fullBlack, 8);
@@ -902,6 +908,8 @@
 @instagramDownColor      : darken(@instagramColor, 10);
 @pinterestDownColor      : darken(@pinterestColor, 10);
 @vkDownColor             : darken(@vkColor, 10);
+@telegramDownColor       : darken(@telegramColor, 10);
+@whatsAppDownColor       : darken(@whatsAppColor, 10);
 
 /*---  Dark Tones  ---*/
 @fullBlackDown           : lighten(@fullBlack, 10);
@@ -963,6 +971,8 @@
 @instagramActiveColor      : saturate(darken(@instagramColor, 5), 15, relative);
 @pinterestActiveColor      : saturate(darken(@pinterestColor, 5), 15, relative);
 @vkActiveColor             : saturate(darken(@vkColor, 5), 15, relative);
+@telegramActiveColor       : saturate(darken(@telegramColor, 5), 15, relative);
+@whatsAppActiveColor       : saturate(darken(@whatsAppColor, 5), 15, relative);
 
 /*---  Dark Tones  ---*/
 @fullBlackActive           : darken(@fullBlack, 5);


### PR DESCRIPTION
## Description
This PR adds brand colors for WhatsApp and Telegram, and update colors of Twitter, LinkedIn and VK.

Before I update the Instagram colors, we need to discuss if we should use the gradient color scheme or the b/w one, as recommended by Instagram (please see original PR Semantic-Org/Semantic-UI#6153).

## Closes
#217
