### PR TITLE
[Popup/Transition/Placeholder] Old Fix was disturbing Popup position calculations

### DIFF
--- a/src/definitions/elements/placeholder.less
+++ b/src/definitions/elements/placeholder.less
@@ -64,6 +64,10 @@
   background-color: @white;
 }
 
+.ui.placeholder.hidden {
+  display:none;
+}
+
 /* Image */
 .ui.placeholder .image:not(.header):not(.ui) {
   height: @placeholderImageHeight;

--- a/src/definitions/modules/transition.less
+++ b/src/definitions/modules/transition.less
@@ -48,7 +48,6 @@
 }
 
 /* Hidden */
-.hidden.hidden.transition,
 .hidden.transition {
   display: none;
   visibility: hidden;


### PR DESCRIPTION
## Description
The  old generic fix to completely hide a hidden placeholder was disturbing popup position calculations, because offsets for popups now always resulted in top:0,left:0.
This PR reverts #148 and fixes it again directly in placeholder definition

As a side effect the popup position calculations are working as before 2.6.3 again

## Testcase
https://jsfiddle.net/zqfrjso1/7/

## Closes
#148
#240
https://github.com/Semantic-Org/Semantic-UI/issues/6608
