### PR TITLE
[List] - Icon and wrapped image were not inline and wrapped or wrongly aligned

### DIFF
--- a/src/definitions/elements/list.less
+++ b/src/definitions/elements/list.less
@@ -318,12 +318,16 @@ ol.ui.list ol li,
   margin: 0em;
   padding: 0em @horizontalIconDistance 0em 0em;
 }
+.ui.horizontal.list > .item > .image + .content,
 .ui.horizontal.list > .item > .icon,
 .ui.horizontal.list > .item > .icon + .content {
   float: none;
   display: inline-block;
+  width: auto;
 }
-
+.ui.horizontal.list > .item > .image {
+  display:inline-block;
+}
 
 /*******************************
              States


### PR DESCRIPTION
## Description
An `icon` aswell as wrapped `image` is not aligned properly within a horizontal list. A wrapped `a.image > img` was even breaking the whole horizontal list at all

## Testcase
https://jsfiddle.net/Lk1n7gwh/1/

## Screenshot 
#### Before (when a wrapped `a.image > img` was used)
![image](https://user-images.githubusercontent.com/18379884/48298921-bc154180-e4c5-11e8-8871-faeebc8ba92b.png)

#### Before (when a usual `img.image` was used (like the example from the original SUI PR))
![image](https://user-images.githubusercontent.com/18379884/48298945-1a422480-e4c6-11e8-8957-deaa9578c19e.png)

#### After
![image](https://user-images.githubusercontent.com/18379884/48298910-90925700-e4c5-11e8-90fb-1d722ba6554d.png)


## Closes
https://github.com/Semantic-Org/Semantic-UI/pull/6653
