### PR TITLE
[Dropdown] Fix to make PR #189 and #190 work together (Menu list bubbling)

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1268,7 +1268,9 @@ $.fn.dropdown = function(parameters) {
                 isBubbledEvent = ($subMenu.find($target).length > 0)
               ;
               // prevents IE11 bug where menu receives focus even though `tabindex=-1`
-              $(document.activeElement).blur();
+              if (!module.has.search() || !document.activeElement.isEqualNode($search[0])) {
+                $(document.activeElement).blur();
+              }
               if(!isBubbledEvent && (!hasSubMenu || settings.allowCategorySelection)) {
                 if(module.is.searchSelection()) {
                   if(settings.allowAdditions) {


### PR DESCRIPTION
## Description
After merging the IE11 focus fix #189 ,the previous merge #190 for Dropdown Menu bubbling was not working anymore, because blurring was taking place all the time now. This is now fixed for both PRs working together. The blurring only takes place when the activeElement is not the search input itself

## Closes
#189 #190
