### PR TITLE
[Dropdown] Clearing user additions prevented Dropdown List

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -2227,6 +2227,7 @@ $.fn.dropdown = function(parameters) {
           else {
             module.remove.activeItem();
             module.remove.selectedItem();
+            module.remove.filteredItem();
           }
           module.set.placeholderText();
           module.clearValue();


### PR DESCRIPTION
## Description
When a searchable dropdown allows for user additions and clearable icon, the dropdown trigger was not working after clearing. That's because the general clear-method did not remove the `.filtered` class of all items in that case.

## Testcase (from original SUI issue)
https://jsfiddle.net/gjwLaqem/

## Screenshots
### Before
![clearable_addition_buggy](https://user-images.githubusercontent.com/18379884/48303204-bccec780-e507-11e8-8a5c-8c4d373b452c.gif)

### After
![clearable_addition](https://user-images.githubusercontent.com/18379884/48303181-5d70b780-e507-11e8-8900-bddf8ab0ec51.gif)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6665
