### PR TITLE
[Dropdown] Prevent user selection

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -29,6 +29,7 @@
   outline: none;
   text-align: left;
   transition: @transition;
+  user-select: none;
 
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
@@ -672,7 +673,6 @@ select.ui.dropdown {
 
 /* Selection Label */
 .ui.multiple.dropdown > .label {
-  user-select: none;
   display: inline-block;
   white-space: normal;
   font-size: @labelSize;


### PR DESCRIPTION
## Description
This PR prevents user selection of whole dropdown (as it is done in mostly all other components aswell)
I especially tested this, because i had doubts it might block the search or filter input fields. And they still work fine. :+1: 
Infact, for every `button dropdown` this was already implemented, because `button` sets `user-select:none` by default since ages :slightly_smiling_face: 

Original PR by @chaaya

## Testcase
https://fomantic-ui.com/modules/dropdown.html
- Search Dropdown & Search In-Menu Dropdown already have this applied (cannot mark by mouse, because they are `button`)
- 2nd Search In-Menu is not a button, so you can currently mark everything of it by the mouse

## Screenshot
![dropdown_user_select](https://user-images.githubusercontent.com/18379884/48315705-fec83e00-e5d9-11e8-9d5f-d81510ec87b7.gif)

## Closes
https://github.com/Semantic-Org/Semantic-UI/pull/6629
