### PR TITLE
[Placeholder] Respect a possible 'image icon' not occupying the same space

### DIFF
--- a/src/definitions/elements/placeholder.less
+++ b/src/definitions/elements/placeholder.less
@@ -69,7 +69,7 @@
 }
 
 /* Image */
-.ui.placeholder .image:not(.header):not(.ui) {
+.ui.placeholder .image:not(.header):not(.ui):not(.icon) {
   height: @placeholderImageHeight;
 }
 .ui.placeholder .square.image:not(.header) {


### PR DESCRIPTION
## Description
An image icon withing a placeholder was handled as a normal `image` gaining the wrong height.

## Testcase
https://jsfiddle.net/70q5er49/1/
Change `image` to for example `pdf`to see the current behavior

## Screenshot
#### Before
![image](https://user-images.githubusercontent.com/18379884/48538232-37a33400-e8b4-11e8-9903-647f5f1a78b5.png)

#### After
![image](https://user-images.githubusercontent.com/18379884/48538273-51447b80-e8b4-11e8-98e6-24bf0ac6d511.png)


## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6671
