### PR TITLE
[Table] images in tables did not display properly

### DIFF
--- a/src/definitions/collections/table.less
+++ b/src/definitions/collections/table.less
@@ -209,10 +209,8 @@
 *******************************/
 
 /* UI Image */
-.ui.table th .image,
-.ui.table th .image img,
-.ui.table td .image,
-.ui.table td .image img {
+.ui.table .collapsing .image,
+.ui.table .collapsing .image img {
   max-width: none;
 }
 


### PR DESCRIPTION
## Description
__This one needs a bit of explanation:__
The main cause of this bug was introduced in 2014 by https://github.com/Semantic-Org/Semantic-UI/commit/400949ce41a382807e284aec0e3f98601f0421b8
It was related to issue https://github.com/Semantic-Org/Semantic-UI/issues/1510, where it seemed to be fixed but the main cause was the `collapsing` class set to the cell column, which causes the width to be reduced to 1px to force the browser to reduce its width until the main occupied content got the minimum width.
So, this PR actually reverts the fix for https://github.com/Semantic-Org/Semantic-UI/issues/1510 and fixes the main cause correctly now.

Once done, the bug mentioned in https://github.com/fomantic/Fomantic-UI/issues/227 does not appear anymore, because basically max-width:100% is set by default for every image and is totally fine in the given jsfiddle example.

## Testcase
- Undo-fix for https://github.com/Semantic-Org/Semantic-UI/issues/1510, so the bug in #227 does not appear anymore
_Uncomment the appropriate Line in CSS to see the fix_
https://jsfiddle.net/vnmgt6y9/8/

- Example from the Original SUI issue 
_Uncomment the appropriate Line in CSS to see the fix_
https://jsfiddle.net/vnmgt6y9/9/

## Closes
#227 
https://github.com/Semantic-Org/Semantic-UI/issues/5781
https://github.com/Semantic-Org/Semantic-UI/issues/1510

