### PR TITLE
[Search] Wrap result into object when original result is received as array

### DIFF
--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -687,6 +687,11 @@ $.fn.search = function(parameters) {
 
         parse: {
           response: function(response, searchTerm) {
+            if(Array.isArray(response)){
+                var o={};
+                o[fields.results]=response;
+                response = o;
+            }
             var
               searchHTML = module.generateResults(response)
             ;


### PR DESCRIPTION
## Description
When the api on a search request returns an array it always returned "no results", because it was expecting a json object with a given result-parameter.

This is now easily covered by wrapping the result into an object when the result is an array.
No need to change the `fields.results` parameter (infact, it needs to hold a string, so just omit it while calling the api, so it`s using the default value, but do not set it to false (as suggested by @hammy2899 ))

This way, all of the original search-code remains untouched :smiley: 


## Testcase
The same jsfiddle from @hammy2899 but injecting the fixed search.js directly from the PR-Branch on github :grin: 
https://jsfiddle.net/wka6xsdp/1/

## Closes
#263 
