### PR TITLE
fix(form validation): broken `remove rules` behavior

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -781,14 +781,7 @@ $.fn.form = function(parameters) {
           },
           // alias
           rules: function(field, rules) {
-            if($.isArray(field)) {
-              $.each(fields, function(index, field) {
-                module.remove.rule(field, rules);
-              });
-            }
-            else {
-              module.remove.rule(field, rules);
-            }
+            module.remove.rule(field, rules);
           },
           fields: function(fields) {
             module.remove.field(fields);


### PR DESCRIPTION
### Description
As discovered by @lubber-de, the lint PR trigerred an `unused variable` warning in the `remove rules` behavior from the form validation module. After investigation, turns out that the code was pretty bad and useless, since it allowed removing the same set of rules for multiple fields, which is a nonsense. It's now simplified.