### PR TITLE
fix(security): changed event-stream version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1329,8 +1329,8 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "event-stream": {
-      "version": "3.0.20",
-      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.0.20.tgz",
+      "version": "3.3.4",
+      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-A4u7LqnqkDhbJvvBhU0LU58qvqM=",
       "requires": {
         "duplexer": "~0.1.1",
@@ -4959,7 +4959,7 @@
       "resolved": "https://registry.npmjs.org/prompt-sui/-/prompt-sui-3.2.1.tgz",
       "integrity": "sha512-dldrpeYMq4c8oGpHoZIzJnCya96eBECHl167PqpPsrnjdo9795gV/hxvJo0RuiKj28cMlhlqZgOYhXHfXtofHQ==",
       "requires": {
-        "event-stream": "~3.0.20",
+        "event-stream": "3.3.4",
         "inquirer": "3.2.x"
       }
     },


### PR DESCRIPTION
## Description
Change the `event-stream` version in the `package-lock` file since we don't have control over `prompt-sui`.

Refs:
  https://github.com/dominictarr/event-stream/issues/116
  https://github.com/dominictarr/event-stream/issues/115

## Closes
#268 
