### PR TITLE
[Dropdown] Clearable dropdown initialized with a select always showed remove icon

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -2147,9 +2147,9 @@ $.fn.dropdown = function(parameters) {
               module.set.selected();
             }
             if(module.get.item()) {
-              $input.removeClass('noselection');
+              $input.removeClass(className.noselection);
             } else {
-              $input.addClass('noselection');
+              $input.addClass(className.noselection);
             }
             module.remove.initialLoad();
           },
@@ -2520,9 +2520,9 @@ $.fn.dropdown = function(parameters) {
           },
           value: function(value, text, $selected) {
             if(value !== undefined && value !== '' && !(Array.isArray(value) && value.length === 0)) {
-              $input.removeClass('noselection');
+              $input.removeClass(className.noselection);
             } else {
-              $input.addClass('noselection');
+              $input.addClass(className.noselection);
             }
             var
               escapedValue = module.escape.value(value),
@@ -3955,7 +3955,8 @@ $.fn.dropdown.settings = {
     upward      : 'upward',
     leftward    : 'left',
     visible     : 'visible',
-    clearable   : 'clearable'
+    clearable   : 'clearable',
+    noselection : 'noselection'
   }
 
 };

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -2146,6 +2146,11 @@ $.fn.dropdown = function(parameters) {
             else {
               module.set.selected();
             }
+            if(module.get.item()) {
+              $input.removeClass('noselection');
+            } else {
+              $input.addClass('noselection');
+            }
             module.remove.initialLoad();
           },
           remoteValues: function() {
@@ -2514,6 +2519,11 @@ $.fn.dropdown = function(parameters) {
             $element.addClass(className.leftward);
           },
           value: function(value, text, $selected) {
+            if(value !== undefined && value !== '' && !(Array.isArray(value) && value.length === 0)) {
+              $input.removeClass('noselection');
+            } else {
+              $input.addClass('noselection');
+            }
             var
               escapedValue = module.escape.value(value),
               hasInput     = ($input.length > 0),

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -632,6 +632,7 @@ select.ui.dropdown {
 
 /* Clearable Selection */
 .ui.dropdown .remove.icon {
+  cursor: pointer;
   font-size: @dropdownIconSize;
   margin: @selectionIconMargin;
   padding: @selectionIconPadding;
@@ -647,6 +648,7 @@ select.ui.dropdown {
   margin-right: 1.5em;
 }
 
+.ui.dropdown select.noselection ~ .remove.icon,
 .ui.dropdown input[value=''] ~ .remove.icon,
 .ui.dropdown input:not([value]) ~ .remove.icon,
 .ui.dropdown.loading .remove.icon {


### PR DESCRIPTION
## Description
A clearable Dropdown initiated via an existing `select` tag always showed the clearable icon.
Thats because it's unfortunately not possible to either check an empty value via css on a `select` tag and there also is no clear/easy indication for CSS from the generated DOM if any value was selected.
So i added a class `noselection`  which is set to the hidden input/select html element on runtime if nothing is/was selected to be able to easily fetch empty values via css and finally fix the issue :wink: 


In addition i also fixed the cursor for the clearable icon which, on multiple search dropdowns, was set to text, and the indication to click on it was missing.

## Testcase
Same as @prudho but injects the fixed dropdown.js from the github branch :slightly_smiling_face: 
https://jsfiddle.net/zw349kst/1/

## Closes
#271 
