### PR TITLE
[Modal] Touch Scrolling (dropdown, content, focussed input) fixed

### DIFF
--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -501,7 +501,7 @@ $.fn.modal = function(parameters) {
 
         hideDimmer: function() {
           if( $dimmable.dimmer('is animating') || ($dimmable.dimmer('is active')) ) {
-           module.unbind.scrollLock();
+            module.unbind.scrollLock();
             $dimmable.dimmer('hide', function() {
               module.remove.clickaway();
               module.remove.screenHeight();

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -252,7 +252,9 @@ $.fn.modal = function(parameters) {
             });
           },
           preventScroll: function(event) {
-            event.preventDefault();
+            if(event.target.className.indexOf('dimmer') !== -1) {
+              event.preventDefault();
+            }
           },
           deny: function() {
             if(ignoreRepeatedEvents || settings.onDeny.call(element, $(this)) === false) {
@@ -386,7 +388,7 @@ $.fn.modal = function(parameters) {
             else {
               if( settings.allowMultiple ) {
                 if ( module.others.active() ) {
-                  $otherModals.filter('.' + className.active).find(selector.dimmer).addClass('active')
+                  $otherModals.filter('.' + className.active).find(selector.dimmer).addClass('active');
                 }
 
                 if ( settings.detachable ) {
@@ -461,15 +463,16 @@ $.fn.modal = function(parameters) {
                     }
                   },
                   onComplete : function() {
+                    module.unbind.scrollLock();
                     if ( settings.allowMultiple ) {
                       $previousModal.addClass(className.top);
                       $module.removeClass(className.top);
       
                       if ( hideOthersToo ) {
-                        $allModals.find(selector.dimmer).removeClass('active')
+                        $allModals.find(selector.dimmer).removeClass('active');
                       }
                       else {
-                        $previousModal.find(selector.dimmer).removeClass('active')
+                        $previousModal.find(selector.dimmer).removeClass('active');
                       }
                     }
                     settings.onHidden.call(element);
@@ -498,7 +501,7 @@ $.fn.modal = function(parameters) {
 
         hideDimmer: function() {
           if( $dimmable.dimmer('is animating') || ($dimmable.dimmer('is active')) ) {
-            module.unbind.scrollLock();
+           module.unbind.scrollLock();
             $dimmable.dimmer('hide', function() {
               module.remove.clickaway();
               module.remove.screenHeight();
@@ -790,7 +793,7 @@ $.fn.modal = function(parameters) {
           },
           active: function() {
             $module.addClass(className.active + ' ' + className.top);
-            $otherModals.filter('.' + className.active).removeClass(className.top)
+            $otherModals.filter('.' + className.active).removeClass(className.top);
           },
           scrolling: function() {
             $dimmable.addClass(className.scrolling);


### PR DESCRIPTION
## Description
This PR fixes lots of issues if touchscroll is not working in modals on mobile devices anymore.
All components within modals which are supposed to be scrollable (for example dropdowns) by touchmove were not working because the touch events were cancelled. This behaviour was invented because of background scrolling issues when a modal was opened. I now simply check if the touch event occurs within the modal (were it is wanted) and only cancel the event, when it is outside.
This PR also fixes lost background scrolling if a modal with focussed input was closed having an open mobile keyboard.

## Testcase
To test this, i have prepared a little mobile test suite. Just follow the short mentioned steps there
**Open the following links in a real mobile browser to reproduce the issues and fixes**

### Fixed Version
http://jsfiddle.net/q3ptLkz6/11/show

### Unfixed Version
http://jsfiddle.net/q3ptLkz6/12/show

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6633
https://github.com/Semantic-Org/Semantic-UI/issues/6675
https://github.com/Semantic-Org/Semantic-UI/issues/6449 (was already partly fixed in FUI)
https://github.com/Semantic-Org/Semantic-UI/issues/6509 (duplicate of 6449)
https://github.com/Semantic-Org/Semantic-UI/issues/6477 (duplicate of 6449)
https://github.com/Semantic-Org/Semantic-UI/issues/6656 (was already working in FUI, but the change fixes it in SUI aswell)

### Probably also fixes
https://github.com/Semantic-Org/Semantic-UI/issues/6686 (testcase is missing)
https://github.com/Semantic-Org/Semantic-UI/issues/4089
