### PR TITLE
[Input, Textarea] Support for corner label and icon in textarea

### DIFF
--- a/src/definitions/elements/input.less
+++ b/src/definitions/elements/input.less
@@ -273,6 +273,7 @@
 .ui.icon.input > i.icon:not(.link) {
   pointer-events: none;
 }
+.ui.icon.input > textarea,
 .ui.icon.input > input {
   padding-right: @iconMargin !important;
 }
@@ -304,12 +305,14 @@
   right: auto;
   left: @circularIconHorizontalOffset;
 }
+.ui[class*="left icon"].input > textarea,
 .ui[class*="left icon"].input > input {
   padding-left: @iconMargin !important;
   padding-right: @horizontalPadding !important;
 }
 
 /* Focus */
+.ui.icon.input > textarea:focus ~ i.icon,
 .ui.icon.input > input:focus ~ i.icon {
   opacity: 1;
 }
@@ -367,9 +370,11 @@
 }
 
 /* Spacing with corner label */
+.ui[class*="corner labeled"]:not([class*="left corner labeled"]).labeled.input > textarea,
 .ui[class*="corner labeled"]:not([class*="left corner labeled"]).labeled.input > input {
   padding-right: @labeledMargin !important;
 }
+.ui[class*="corner labeled"].icon.input:not([class*="left corner labeled"]) > textarea,
 .ui[class*="corner labeled"].icon.input:not([class*="left corner labeled"]) > input {
   padding-right: @labeledIconInputMargin !important;
 }
@@ -378,14 +383,19 @@
 }
 
 /* Left Labeled */
+.ui[class*="left corner labeled"].labeled.input > textarea,
 .ui[class*="left corner labeled"].labeled.input > input {
   padding-left: @labeledMargin !important;
 }
+.ui[class*="left corner labeled"].icon.input > textarea,
 .ui[class*="left corner labeled"].icon.input > input {
   padding-left: @labeledIconInputMargin !important;
 }
 .ui[class*="left corner labeled"].icon.input > .icon {
   margin-left: @labeledIconMargin;
+}
+.ui.icon.input > textarea ~ .icon {
+  height: @textareaIconHeight;
 }
 
 /* Corner Label Position  */

--- a/src/themes/default/elements/input.variables
+++ b/src/themes/default/elements/input.variables
@@ -44,6 +44,8 @@
 @transparentIconWidth: @glyphWidth;
 @transparentIconMargin: 2em;
 
+@textareaIconHeight: 3em;
+
 /* Circular Icon Input */
 @circularIconVerticalOffset: 0.35em;
 @circularIconHorizontalOffset: 0.5em;


### PR DESCRIPTION
## Description
This PR supports `corner label` and `icon` for `textarea` when using the `input` class

## Testcase
 All possible features can be seen here
- left/right corner label
- left/right icon
- both in combination
http://jsfiddle.net/0pske8u1/1/

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/49308608-1314a200-f4d9-11e8-8dec-17416d89ef1f.png)


## Closes
#276 
