### PR TITLE
[Popup] Fix correct usage for addTouchEvents=false

### DIFF
--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -28,7 +28,6 @@ $.fn.popup = function(parameters) {
 
     moduleSelector = $allModules.selector || '',
 
-    hasTouch       = (true),
     time           = new Date().getTime(),
     performance    = [],
 
@@ -983,7 +982,7 @@ $.fn.popup = function(parameters) {
                 .on('click' + eventNamespace, module.toggle)
               ;
             }
-            if(settings.on == 'hover' && hasTouch) {
+            if(settings.on == 'hover' && settings.addTouchEvents) {
               $module
                 .on('touchstart' + eventNamespace, module.event.touchstart)
               ;

--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -184,7 +184,7 @@ $.fn.popup = function(parameters) {
                 : settings.delay
             ;
             clearTimeout(module.hideTimer);
-            if(!openedWithTouch) {
+            if(!openedWithTouch || (openedWithTouch && settings.addTouchEvents) ) {
               module.showTimer = setTimeout(module.show, delay);
             }
           },
@@ -199,7 +199,9 @@ $.fn.popup = function(parameters) {
           },
           touchstart: function(event) {
             openedWithTouch = true;
-            module.show();
+            if(settings.addTouchEvents) {
+              module.show();
+            }
           },
           resize: function() {
             if( module.is.visible() ) {
@@ -982,7 +984,7 @@ $.fn.popup = function(parameters) {
                 .on('click' + eventNamespace, module.toggle)
               ;
             }
-            if(settings.on == 'hover' && settings.addTouchEvents) {
+            if(settings.on == 'hover') {
               $module
                 .on('touchstart' + eventNamespace, module.event.touchstart)
               ;


### PR DESCRIPTION
## Description
The setting `addTouchEvents` was not even implemented.
The idea behind this setting should always have been to disable hover popups on mobile, when `addTouchEvents:false`, which works now.
Infact popup now always allows the touchevent, but primary only to find out if the device is a touch device or not (touchstart is triggered before mouseenter). The addTouchEvents parameter is now used to decide if the popoup should be shown on hover on touch devices or not.

## Testcase
**Open the following links in a real mobile browser to reproduce the issue and the fix**

Click somewhere in the Message Area (works best, when you click in empty areas around the text):
- Unfixed Version; The popup appears just as it would in a desktop browser
- Fixed Version: Popup does not appear, touch event is successfully prevented

#### Unfixed version
http://jsfiddle.net/2hm3nmLx/5/show
#### Fixed version
http://jsfiddle.net/2hm3nmLx/7/show

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/3382
