### PR TITLE
[Message] fixed compact icon message width

### DIFF
--- a/src/definitions/collections/message.less
+++ b/src/definitions/collections/message.less
@@ -179,6 +179,7 @@
 }
 .ui.compact.icon.message {
   display: inline-flex;
+  width: auto;
 }
 
 


### PR DESCRIPTION
## Description
`compact icon message` still had 100% width. Fixed by adding `auto`

## Testcase
http://jsfiddle.net/95kzk6mr/2/

## Screenshot 
### Before
![image](https://user-images.githubusercontent.com/18379884/49327700-af37bb00-f564-11e8-885c-2f0fb775e80e.png)

### After
![image](https://user-images.githubusercontent.com/18379884/49327692-97f8cd80-f564-11e8-823a-1e9ebec69749.png)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/4759
https://github.com/Semantic-Org/Semantic-UI-React/issues/2280