### PR TITLE
[Dropdown] Fixed Submenu positioning

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -2493,8 +2493,13 @@ $.fn.dropdown = function(parameters) {
           },
           direction: function($menu) {
             if(settings.direction == 'auto') {
-              // reset position
-              module.remove.upward();
+              // reset position, remove upward if it's base menu
+              if (!$menu) {
+                module.remove.upward();
+              } else if ($menu.hasClass('upward')) {
+                //we need make sure when make assertion openDownward for $menu, $menu does not have upward class
+                $menu.removeClass('upward');
+              }
 
               if(module.can.openDownward($menu)) {
                 module.remove.upward($menu);

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -2496,9 +2496,9 @@ $.fn.dropdown = function(parameters) {
               // reset position, remove upward if it's base menu
               if (!$menu) {
                 module.remove.upward();
-              } else if ($menu.hasClass('upward')) {
+              } else if (module.is.upward($menu)) {
                 //we need make sure when make assertion openDownward for $menu, $menu does not have upward class
-                $menu.removeClass('upward');
+                module.remove.upward($menu);
               }
 
               if(module.can.openDownward($menu)) {


### PR DESCRIPTION
# Description
If a menu with submenus was too narrow to the bottom of the screen, the submenu positioning was broken making the dropdown unusable

Thanks to @sillicon for the original PR

## Testcase
### Unfixed
http://jsfiddle.net/47wtpcy8
### Fixed
http://jsfiddle.net/47wtpcy8/2/

## Screenshots
### Unfixed
![submenu_position_wrong](https://user-images.githubusercontent.com/18379884/49380671-72a9c200-f712-11e8-9c37-18dcf55a2d49.gif)

### Fixed
![submenu_position_good](https://user-images.githubusercontent.com/18379884/49380679-76d5df80-f712-11e8-8bd1-fda6d9a1c565.gif)


## Closes
#194 
https://github.com/Semantic-Org/Semantic-UI/issues/6007
https://github.com/Semantic-Org/Semantic-UI/issues/3505
https://github.com/Semantic-Org/Semantic-UI/issues/6700

