### PR TITLE
[Dropdown] Preselected values are ignored when data has individual value-name

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -982,9 +982,11 @@ $.fn.dropdown = function(parameters) {
             module.setup.menu({values: values});
             $.each(values, function(index, item) {
               if(item.selected == true) {
-                module.debug('Setting initial selection to', item.value);
-                module.set.selected(item.value);
-                return true;
+                module.debug('Setting initial selection to', item[fields.value]);
+                module.set.selected(item[fields.value]);
+                if(!module.is.multiple()) {
+                  return false;
+                }
               }
             });
           }


### PR DESCRIPTION
## Description
When a datastore has a different name for the `value` field, all probably preselected values will not be assigned initially to the dropdown. That's because it was always expecting its name being called `value` instead of respecting a probably changed name in `settings.field.value`.

Thanks @patilkiranm for the original PR

## Testcase
### Fixed Version
https://jsfiddle.net/pf2ae8cn/
### Unfixed Version
https://jsfiddle.net/pf2ae8cn/1/

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6682
