### PR TITLE
[Dropdown] Filter already selected items when using remote api as datastore

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -741,6 +741,11 @@ $.fn.dropdown = function(parameters) {
                 if(settings.filterRemoteData) {
                   module.filterItems(searchTerm);
                 }
+                $.each($input.val(),function(index,value){
+                  $item.filter('[data-value="'+value+'"]')
+                      .addClass(className.filtered)
+                  ;
+                });
                 afterFiltered();
               });
             }


### PR DESCRIPTION
## Description
When the remoteApi was used in a dropdown to retrieve the items according to some searchterm, the list of items was always renewed, but already selected items from the previous list where not filtered again, so they appeared again.

## Testcase
- Click the dropdown and select anything you want 
- close the drop down, reopen it by clicking into it again

### Unfixed
-  The same values incuding the previously selected ones are listed again
https://jsfiddle.net/e1onupd6/8/

### Fixed 
- Each new list does not contain the already selected ones anymore
https://jsfiddle.net/e1onupd6/9/

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6388
