### PR TITLE
[Modal] Dimmer-Click closed Modal when allowMultiple=true even if onHide()=false 

### DIFF
--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -287,6 +287,10 @@ $.fn.modal = function(parameters) {
               module.debug('Dimmer clicked but mouse down was initially registered inside the modal');
               return;
             }
+            if(settings.onHide.call(element, $(this)) === false) {
+              module.verbose('Hide callback returned false cancelling hide');
+              return false;
+            }
             var
               $target   = $(event.target),
               isInModal = ($target.closest(selector.modal).length > 0),

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -299,8 +299,8 @@ $.fn.modal = function(parameters) {
                   return;
                 }
               }
-              else {
-                module.hide();
+              else if(!module.hide()){
+                  return;
               }
               module.remove.clickaway();
             }

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -289,7 +289,7 @@ $.fn.modal = function(parameters) {
             }
             if(settings.onHide.call(element, $(this)) === false) {
               module.verbose('Hide callback returned false cancelling hide');
-              return false;
+              return;
             }
             var
               $target   = $(event.target),


### PR DESCRIPTION
## Description
Trying to close a modal by clicking in the dimmer area but having `return false` at the `onHide`-Method did still close the modal if `allowMultiple` was set to true

## Testcase
### Unfixed
https://jsfiddle.net/ibelar/h8a3se4o/

### Fixed
https://jsfiddle.net/bagwd05n/

## Closes
#284 
