### PR TITLE
[API ] New option to be able to handle Respond-Arrays in onResponse handler

### DIFF
--- a/src/definitions/behaviors/api.js
+++ b/src/definitions/behaviors/api.js
@@ -485,7 +485,7 @@ $.api = $.fn.api = function(parameters) {
                 elapsedTime        = (new Date().getTime() - requestStartTime),
                 timeLeft           = (settings.loadingDuration - elapsedTime),
                 translatedResponse = ( $.isFunction(settings.onResponse) )
-                  ? module.is.expectingJSON()
+                  ? module.is.expectingJSON() && !settings.rawResponse
                     ? settings.onResponse.call(context, $.extend(true, {}, response))
                     : settings.onResponse.call(context, response)
                   : false
@@ -1100,6 +1100,9 @@ $.api.settings = {
   // aliases for mock
   response          : false,
   responseAsync     : false,
+
+// whether onResponse should work with response value without force converting into an object
+  rawResponse       : false,
 
   // callbacks before request
   beforeSend  : function(settings) { return settings; },


### PR DESCRIPTION
## Description
Added a new option `rawResponse` (default `false` to stay backward compatible) to be able to handle raw Array Objects in the `onResponse` event handler, even if the datatype is json,. without force converting it into an object first.

Just to stay backward compatible and because it could still be wanted behaviour for existing projects i decided against explicit checking for an Array in favour of an additional option


## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6604
