### PR TITLE
[Checkbox] Support onChange for cursor keynav

### DIFF
--- a/src/definitions/modules/checkbox.js
+++ b/src/definitions/modules/checkbox.js
@@ -175,6 +175,11 @@ $.fn.checkbox = function(parameters) {
         },
 
         event: {
+          change: function(event) {
+            if( !module.should.ignoreCallbacks() ) {
+              settings.onChange.call(input);
+            }
+          },
           click: function(event) {
             var
               $target = $(event.target)
@@ -550,6 +555,7 @@ $.fn.checkbox = function(parameters) {
             module.verbose('Attaching checkbox events');
             $module
               .on('click'   + eventNamespace, module.event.click)
+              .on('change'  + eventNamespace, module.event.change)
               .on('keydown' + eventNamespace, selector.input, module.event.keydown)
               .on('keyup'   + eventNamespace, selector.input, module.event.keyup)
             ;

--- a/src/definitions/modules/checkbox.js
+++ b/src/definitions/modules/checkbox.js
@@ -221,7 +221,11 @@ $.fn.checkbox = function(parameters) {
               checkIndex = rIndex === rLen-1 ? 0 : rIndex+1;
             }
 
-            if (checkIndex !== false) {
+            if (!module.should.ignoreCallbacks() && checkIndex !== false) {
+              if(!settings.beforeUnchecked.apply(input)) {
+                module.verbose('Option not allowed to be unchecked, cancelling key navigation');
+                return false;
+              }
               if (!settings.beforeChecked.apply($(r[checkIndex]).children(selector.input)[0])) {
                 module.verbose('Next option should not allow check, cancelling key navigation');
                 return false;

--- a/src/definitions/modules/checkbox.js
+++ b/src/definitions/modules/checkbox.js
@@ -202,9 +202,32 @@ $.fn.checkbox = function(parameters) {
               keyCode = {
                 enter  : 13,
                 space  : 32,
-                escape : 27
+                escape : 27,
+                left   : 37,
+                up     : 38,
+                right  : 39,
+                down   : 40
               }
             ;
+
+            var r = module.get.radios(),
+                rIndex = r.index($module),
+                rLen = r.length,
+                checkIndex = false;
+
+            if(key == keyCode.left || key == keyCode.up) {
+              checkIndex = (rIndex === 0 ? rLen : rIndex) - 1;
+            } else if(key == keyCode.right || key == keyCode.down) {
+              checkIndex = rIndex === rLen-1 ? 0 : rIndex+1;
+            }
+
+            if (checkIndex !== false) {
+              if (!settings.beforeChecked.apply($(r[checkIndex]).children(selector.input)[0])) {
+                module.verbose('Next option should not allow check, cancelling key navigation');
+                return false;
+              }
+            }
+
             if(key == keyCode.escape) {
               module.verbose('Escape key pressed blurring field');
               $input.blur();


### PR DESCRIPTION
## Description
Changing Radio-Button Selections via Cursor Key-Navigation was not triggering the onChange Event

## Testcase
- Click an option of the Radio Button Group
- User cursor keys to switch between the options

### Unfixed
- Message is not updated, because onChange event is not fired
https://jsfiddle.net/n9sLf81w/

### Fixed
- Message gets updated just as you would have clicked on another option
https://jsfiddle.net/ujkdreqs/

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6676
