### PR TITLE
[Visibility] rename placeholder class

### DIFF
--- a/src/definitions/behaviors/visibility.js
+++ b/src/definitions/behaviors/visibility.js
@@ -1301,7 +1301,7 @@ $.fn.visibility.settings = {
 
   className: {
     fixed       : 'fixed',
-    placeholder : 'placeholder',
+    placeholder : 'constraint',
     visible     : 'visible'
   },
 


### PR DESCRIPTION
## Description
Rename the placeholder class to constraint to stop the conflict with the placeholder component

## Testcase
Broken: https://jsfiddle.net/djpw7ket/
Fixed: https://jsfiddle.net/yge5fm2c/

## Screenshot (when possible)
Broken:
![image](https://user-images.githubusercontent.com/11588822/49802506-f54f0480-fd44-11e8-93fe-6636515caa27.png)

Fixed:
![image](https://user-images.githubusercontent.com/11588822/49802524-04ce4d80-fd45-11e8-96ca-7f6060b4cf41.png)

## Closes
#296 
