### PR TITLE
[Search,Dropdown,XSS] prevent JS execution from manual entries or untrusted remote data

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -3597,11 +3597,27 @@ $.fn.dropdown = function(parameters) {
             text =  String(text);
             return text.replace(regExp.escape, '\\$&');
           },
-          htmlEntities: function(text){
-             return text.replace(/[\u00A0-\u9999<>\&]/g, function(i) {
-               return '&#'+i.charCodeAt(0)+';';
-             });
-           }
+          htmlEntities: function(string) {
+              var
+                  badChars     = /[&<>"'`]/g,
+                  shouldEscape = /[&<>"'`]/,
+                  escape       = {
+                      "&": "&amp;",
+                      "<": "&lt;",
+                      ">": "&gt;",
+                      '"': "&quot;",
+                      "'": "&#x27;",
+                      "`": "&#x60;"
+                  },
+                  escapedChar  = function(chr) {
+                      return escape[chr];
+                  }
+              ;
+              if(shouldEscape.test(string)) {
+                  return string.replace(badChars, escapedChar);
+              }
+              return string;
+          }
         },
 
         setting: function(name, value) {

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -729,7 +729,7 @@ $.fn.dropdown = function(parameters) {
                 module.remove.message();
               }
               if(settings.allowAdditions) {
-                module.add.userSuggestion(query);
+                module.add.userSuggestion(module.escape.htmlEntities(query));
               }
               if(module.is.searchSelection() && module.can.show() && module.is.focusedOnSearch() ) {
                 module.show();
@@ -3596,7 +3596,12 @@ $.fn.dropdown = function(parameters) {
           string: function(text) {
             text =  String(text);
             return text.replace(regExp.escape, '\\$&');
-          }
+          },
+          htmlEntities: function(text){
+             return text.replace(/[\u00A0-\u9999<>\&]/g, function(i) {
+               return '&#'+i.charCodeAt(0)+';';
+             });
+           }
         },
 
         setting: function(name, value) {

--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -1020,7 +1020,7 @@ $.fn.search = function(parameters) {
               }
             }
             if($.isFunction(template)) {
-              html = template(response, fields);
+              html = template(response, fields, settings.preserveHTML);
             }
             else {
               module.error(error.noTemplate, false);
@@ -1278,6 +1278,9 @@ $.fn.search.settings = {
   // whether no results errors should be shown
   showNoResults  : true,
 
+  // preserve possible html of resultset values
+  preserveHTML   : true,
+
   // transition settings
   transition     : 'scale',
   duration       : 200,
@@ -1355,7 +1358,10 @@ $.fn.search.settings = {
   },
 
   templates: {
-    escape: function(string) {
+    escape: function(string, preserveHTML) {
+      if (preserveHTML){
+        return string;
+      }
       var
         badChars     = /[&<>"'`]/g,
         shouldEscape = /[&<>"'`]/,
@@ -1394,7 +1400,7 @@ $.fn.search.settings = {
       }
       return html;
     },
-    category: function(response, fields) {
+    category: function(response, fields, preserveHTML) {
       var
         html = '',
         escape = $.fn.search.settings.templates.escape
@@ -1408,14 +1414,14 @@ $.fn.search.settings = {
             html  += '<div class="category">';
 
             if(category[fields.categoryName] !== undefined) {
-              html += '<div class="name">' + category[fields.categoryName] + '</div>';
+              html += '<div class="name">' + escape(category[fields.categoryName], preserveHTML) + '</div>';
             }
 
             // each item inside category
             html += '<div class="results">';
             $.each(category.results, function(index, result) {
               if(result[fields.url]) {
-                html  += '<a class="result" href="' + result[fields.url] + '">';
+                html  += '<a class="result" href="' + result[fields.url].replace(/"/g,"") + '">';
               }
               else {
                 html  += '<a class="result">';
@@ -1423,19 +1429,19 @@ $.fn.search.settings = {
               if(result[fields.image] !== undefined) {
                 html += ''
                   + '<div class="image">'
-                  + ' <img src="' + result[fields.image] + '">'
+                  + ' <img src="' + result[fields.image].replace(/"/g,"") + '">'
                   + '</div>'
                 ;
               }
               html += '<div class="content">';
               if(result[fields.price] !== undefined) {
-                html += '<div class="price">' + result[fields.price] + '</div>';
+                html += '<div class="price">' + escape(result[fields.price], preserveHTML) + '</div>';
               }
               if(result[fields.title] !== undefined) {
-                html += '<div class="title">' + result[fields.title] + '</div>';
+                html += '<div class="title">' + escape(result[fields.title], preserveHTML) + '</div>';
               }
               if(result[fields.description] !== undefined) {
-                html += '<div class="description">' + result[fields.description] + '</div>';
+                html += '<div class="description">' + escape(result[fields.description], preserveHTML) + '</div>';
               }
               html  += ''
                 + '</div>'
@@ -1452,12 +1458,12 @@ $.fn.search.settings = {
           if(fields.actionURL === false) {
             html += ''
             + '<div class="action">'
-            +   response[fields.action][fields.actionText]
+            +   escape(response[fields.action][fields.actionText], preserveHTML)
             + '</div>';
           } else {
             html += ''
-            + '<a href="' + response[fields.action][fields.actionURL] + '" class="action">'
-            +   response[fields.action][fields.actionText]
+            + '<a href="' + response[fields.action][fields.actionURL].replace(/"/g,"") + '" class="action">'
+            +   escape(response[fields.action][fields.actionText], preserveHTML)
             + '</a>';
           }
         }
@@ -1465,16 +1471,17 @@ $.fn.search.settings = {
       }
       return false;
     },
-    standard: function(response, fields) {
+    standard: function(response, fields, preserveHTML) {
       var
-        html = ''
+        html = '',
+        escape = $.fn.search.settings.templates.escape
       ;
       if(response[fields.results] !== undefined) {
 
         // each result
         $.each(response[fields.results], function(index, result) {
           if(result[fields.url]) {
-            html  += '<a class="result" href="' + result[fields.url] + '">';
+            html  += '<a class="result" href="' + result[fields.url].replace(/"/g,"") + '">';
           }
           else {
             html  += '<a class="result">';
@@ -1482,19 +1489,19 @@ $.fn.search.settings = {
           if(result[fields.image] !== undefined) {
             html += ''
               + '<div class="image">'
-              + ' <img src="' + result[fields.image] + '">'
+              + ' <img src="' + result[fields.image].replace(/"/g,"") + '">'
               + '</div>'
             ;
           }
           html += '<div class="content">';
           if(result[fields.price] !== undefined) {
-            html += '<div class="price">' + result[fields.price] + '</div>';
+            html += '<div class="price">' + escape(result[fields.price], preserveHTML) + '</div>';
           }
           if(result[fields.title] !== undefined) {
-            html += '<div class="title">' + result[fields.title] + '</div>';
+            html += '<div class="title">' + escape(result[fields.title], preserveHTML) + '</div>';
           }
           if(result[fields.description] !== undefined) {
-            html += '<div class="description">' + result[fields.description] + '</div>';
+            html += '<div class="description">' + escape(result[fields.description], preserveHTML) + '</div>';
           }
           html  += ''
             + '</div>'
@@ -1505,12 +1512,12 @@ $.fn.search.settings = {
           if(fields.actionURL === false) {
             html += ''
             + '<div class="action">'
-            +   response[fields.action][fields.actionText]
+            +   escape(response[fields.action][fields.actionText], preserveHTML)
             + '</div>';
           } else {
             html += ''
-            + '<a href="' + response[fields.action][fields.actionURL] + '" class="action">'
-            +   response[fields.action][fields.actionText]
+            + '<a href="' + response[fields.action][fields.actionURL].replace(/"/g,"") + '" class="action">'
+            +   escape(response[fields.action][fields.actionText], preserveHTML)
             + '</a>';
           }
         }


### PR DESCRIPTION
## Description
This PR sanitizes the probably fetched and vulnerable HTML Data for dropdown user additions aswell as for search response values.

For `search` an additional option `preserveHTML` (default `true`) (adopted from dropdown where this is already available). When this is set to `false` every result value from the response stream will be sanitized in the default templates.


## Testcase
unfixed dropdown 
https://jsfiddle.net/9x8tqdam/

fixed dropdown
https://jsfiddle.net/9x8tqdam/1/

To test search you need to setup something locally to fake evil remote api data:

```html
<div class="ui search">
  <div class="ui left icon input">
    <input class="prompt" type="text" placeholder="Search GitHub">
    <i class="github icon"></i>
  </div>
</div>
```

Initialize the search specifying a url which points to some evil prepared `fakeapi.json`-file to simulate a vulnerable remote api site
```javascript
$('.ui.search')
  .search({
	preserveHTML: false, //add this to be safe to untrusted remote data
	apiSettings: {
	  url: 'fakeapi.json'
	},
	fields: {
	  title: 'name' //,
	},
	searchFields: [
	  'name'
	]
  })
;
```

The evil `fakeapi.json` could look like
```json
{
  "success": true,
  "results": [{
    "name": "<script>alert('gotcha')</script>African Elephant",
    "value": "african-elephant"
  }, {
    "name": "African Wild Dog",
    "value": "african-wild dog"
  }, {
    "name": "Albacore Tuna",
    "value": "albacore-tuna"
  }]
}
```

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/4498
https://github.com/Semantic-Org/Semantic-UI/issues/6571

## Relates to
https://github.com/Semantic-Org/Semantic-UI/issues/6570
https://github.com/Semantic-Org/Semantic-UI/issues/5376
https://github.com/Semantic-Org/Semantic-UI/pull/1033

To fulfill the demands of the above mentioned issues i will add appropriate security-informations to the docs once this PR is approved and merged
