### PR TITLE
[DropDown] Filter Preselected entries from #287 was not working for div-dropdowns

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -745,7 +745,11 @@ $.fn.dropdown = function(parameters) {
                 if(settings.filterRemoteData) {
                   module.filterItems(searchTerm);
                 }
-                $.each($input.val(),function(index,value){
+                var preSelected = $input.val();
+                if(!Array.isArray(preSelected)) {
+                    preSelected = preSelected!=="" ? preSelected.split(",") : [];
+                }
+                $.each(preSelected,function(index,value){
                   $item.filter('[data-value="'+value+'"]')
                       .addClass(className.filtered)
                   ;

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -747,7 +747,7 @@ $.fn.dropdown = function(parameters) {
                 }
                 var preSelected = $input.val();
                 if(!Array.isArray(preSelected)) {
-                    preSelected = preSelected!=="" ? preSelected.split(",") : [];
+                    preSelected = preSelected!=="" ? preSelected.split(settings.delimiter) : [];
                 }
                 $.each(preSelected,function(index,value){
                   $item.filter('[data-value="'+value+'"]')


### PR DESCRIPTION
## Description
The PR #287 to filter remote dropdown values with already preselected values was broken when the dropdown was initiated out of a div-tag and resulted in console error, because those dropdowns use input-fields, thus strings for storing selections. Select-fields, which was used in the PR, stored value are retrieved as arrays where it was working before.
This PR now takes care of that and always generates an array, making the functionality work for all types of dropdowns now. 

## Fixes
#287
