### PR TITLE
[Dropdown] Show "no results" when filterRemoteData is false and response is empty

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -4055,7 +4055,7 @@ $.fn.dropdown.settings.templates = {
   menu: function(response, fields, preserveHTML) {
     var
       values = response[fields.values] || [],
-      html   = ''
+      html   = '',
       escape = $.fn.dropdown.settings.templates.escape
     ;
     $.each(values, function(index, option) {

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -792,7 +792,7 @@ $.fn.dropdown = function(parameters) {
                   values: values
                 });
 
-                if(values.length===0) {
+                if(values.length===0 && !settings.allowAdditions) {
                   module.add.message(message.noResults);
                 }
                 callback();
@@ -4009,7 +4009,7 @@ $.fn.dropdown.settings.templates = {
   // generates just menu from select
   menu: function(response, fields) {
     var
-      values = response[fields.values] || {},
+      values = response[fields.values] || [],
       html   = ''
     ;
     $.each(values, function(index, option) {

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -782,16 +782,17 @@ $.fn.dropdown = function(parameters) {
               },
               onSuccess : function(response) {
                 var
-                  values          = response[fields.remoteValues],
-                  hasRemoteValues = (Array.isArray(values) && values.length > 0)
+                  values          = response[fields.remoteValues]
                 ;
-                if(hasRemoteValues) {
-                  module.remove.message();
-                  module.setup.menu({
-                    values: response[fields.remoteValues]
-                  });
+                if (!Array.isArray(values)){
+                    values = [];
                 }
-                else {
+                module.remove.message();
+                module.setup.menu({
+                  values: values
+                });
+
+                if(values.length===0) {
                   module.add.message(message.noResults);
                 }
                 callback();


### PR DESCRIPTION
## Description
When a remoteApi returns no results according to the search query, the dropdown was still showing the previous filtered list when `filterRemoteData` was false (which is default)

Also fixed the behavior in combination that "no results" prevented possible allowed useradditions. So if `allowAdditions` is true, then "No results" will not be shown (this is how it already behaves when remote Api data was not used)

> **Hint**:  If you try to test the `allowAdditions:true` feature in the following fiddles and it does not work, then jsdelivr still caches an old commit. If in doubt, tell me, i'll put the whole JS in the fiddle then)

## Testcase
- Follow the 2 steps in the fiddles
### Unfixed
https://jsfiddle.net/c092thvs/

### Fixed
https://jsfiddle.net/c092thvs/1/

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6603
