### PR TITLE
[Modal] Fix top border radius when allowMultiple is true

### DIFF
--- a/src/definitions/modules/modal.less
+++ b/src/definitions/modules/modal.less
@@ -40,8 +40,10 @@
   will-change: top, left, margin, transform, opacity;
 }
 
-.ui.modal > :first-child:not(.icon),
-.ui.modal > .icon:first-child + * {
+.ui.modal > :first-child:not(.icon):not(.dimmer),
+.ui.modal > .icon:first-child + *,
+.ui.modal > .dimmer:first-child + *:not(.icon),
+.ui.modal > .dimmer:first-child + .icon + * {
   border-top-left-radius: @borderRadius;
   border-top-right-radius: @borderRadius;
 }


### PR DESCRIPTION
## Description
When a modal had `allowMultiple:true` set, the top border radius was not set anymore.
This regression happens since an additional dimmer was introduced in #119 to prevent the ability to interact with modals that are not the focused one.
This PR now takes care of a possible existing extra dimmer and shows top border radius correctly again

## Testcase
 Comment out the CSS Code to see the issue
http://jsfiddle.net/co3gaj8q/

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/50103874-eb3b7300-0228-11e9-8ee0-195086ba6e1d.png)

## Closes
#308 
