### PR TITLE
[Dropdown, Input, Loader] Elastic Animation Style had wrong color

### DIFF
--- a/src/definitions/elements/loader.less
+++ b/src/definitions/elements/loader.less
@@ -303,6 +303,7 @@ each(@colors, {
   .ui.@{color}.basic.elastic.loading.button:after,
   .ui.@{color}.elastic.loading.loading.loading:not(.segment):before,
   .ui.@{color}.elastic.loading.loading.loading .input > i.icon:before,
+  .ui.@{color}.elastic.loading.loading.loading.loading > i.icon:before,
   .ui.@{color}.loading.loading.loading.loading:not(.usual):not(.button):after,
   .ui.@{color}.loading.loading.loading.loading .input > i.icon:after,
   .ui.@{color}.loading.loading.loading.loading > i.icon:after,
@@ -332,11 +333,11 @@ each(@colors, {
   border-color: currentColor;
 }
 .ui.elastic.loading.loading.loading.loading.button:not(.inverted):not(.basic):before {
-  color: @white;
+  color: @invertedLoaderLineColor;
 }
 .ui.elastic.basic.loading.button:before,
 .ui.elastic.basic.loading.button:after {
-  color: @grey;
+  color: @loaderLineColor;
 }
 .ui.double.loading.loading.loading.loading.button:after {
   border-bottom-color: currentColor;
@@ -395,10 +396,10 @@ each(@colors, {
 --------------------*/
 
 .ui.dimmer .ui.elastic.loader {
-  color: @white;
+  color: @invertedLoaderLineColor;
 }
 .ui.inverted.dimmer .ui.elastic.loader {
-  color: @grey;
+  color: @loaderLineColor;
 }
 .ui.elastic.loading.loading:not(.form):not(.segment):after,
 .ui.elastic.loading.loading .input > i.icon:after,


### PR DESCRIPTION
## Description
- Elastic Loader in dropdown/input misses correct color setting in :before tag.
- Also changed the static `@grey` or `@white` variables to the loader specific variables `@loaderLineColor`and `@invertedLoaderLineColor` instead. Infact the color is the same on the default theme, but using the loader specific variables is now more safe regarding the new central color mixin usage from #261 

## Testcase
https://fomantic-ui.com/modules/dropdown.html#loading
https://fomantic-ui.com/elements/input.html#loading

#### Fix
Comment out the css part to see the issue again
http://jsfiddle.net/015dbk4t/1/

## Screenshot
#### Before
![elastic_dropdown_loading](https://user-images.githubusercontent.com/18379884/50386473-73b58a00-06e7-11e9-9823-e5d746dffca6.gif)

#### After
![elastic_dropdown_loading_fix](https://user-images.githubusercontent.com/18379884/50386476-7fa14c00-06e7-11e9-9549-f08571eab9ff.gif)

## Version
2.7.0
