### PR TITLE
[Input] Support error class on input action buttons

### DIFF
--- a/src/definitions/elements/input.less
+++ b/src/definitions/elements/input.less
@@ -404,14 +404,17 @@
   left: @borderWidth;
 }
 
-/* Labeled input error */
+/* Labeled and action input error */
+.ui.action.input.error > .ui.button,
 .ui.labeled.input.error:not([class*="corner labeled"]) > .ui.label {
   border-top: @borderWidth solid @errorBorder;
   border-bottom: @borderWidth solid @errorBorder;
 }
+.ui.left.action.input.error > .ui.button,
 .ui.labeled.input.error:not(.right):not([class*="corner labeled"]) > .ui.label {
   border-left: @borderWidth solid @errorBorder;
 }
+.ui.action.input.error:not(.left) > input + .ui.button,
 .ui.right.labeled.input.error:not([class*="corner labeled"]) > input + .ui.label {
   border-right: @borderWidth solid @errorBorder;
 }


### PR DESCRIPTION
## Description
In addtion to the enhancement from @prudho , this PR also adds support for input action buttons being surrounded by the error border

## Testcase
https://jsfiddle.net/o0c6mk6u/2/

## Screenshot
#### Before
![image](https://user-images.githubusercontent.com/18379884/50514442-87257400-0a9e-11e9-96ba-cbf1219939c0.png)

#### After
![image](https://user-images.githubusercontent.com/18379884/50514415-534a4e80-0a9e-11e9-8c66-b4f7e76143f2.png)

## Related
https://github.com/fomantic/Fomantic-UI/pull/270

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5670
