### PR TITLE
[Button] Attached buttons were shown above dropdown menu list

### DIFF
--- a/src/themes/default/elements/button.variables
+++ b/src/themes/default/elements/button.variables
@@ -378,7 +378,7 @@
 @attachedOffset: -1px;
 @attachedBoxShadow: 0 0 0 1px @borderColor;
 @attachedHorizontalPadding: 0.75em;
-@attachedZIndex: 2;
+@attachedZIndex: auto;
 
 /* Floated */
 @floatedMargin: 0.25em;


### PR DESCRIPTION
## Description
The static z-index of `attached buttons` prevented dropdown Menu list to be shown above, when a dropdown was created in another attached buttons container.

## Testcase
- Open the top dropdown, works fine
- Remove the CSS part, re-run the fiddle and open the upper dropdown button again to see the issue 
https://jsfiddle.net/w2jayvsf/

## Screenshot
![semantic](https://cloud.githubusercontent.com/assets/1103788/25880729/acc82ca2-356b-11e7-8e1a-593e75ca27a1.gif)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5355
