### PR TITLE
[Button] Increased size specificity to work with menu item buttons

### DIFF
--- a/src/definitions/elements/button.less
+++ b/src/definitions/elements/button.less
@@ -663,17 +663,17 @@
 
 .ui.mini.buttons .button,
 .ui.mini.buttons .or,
-.ui.mini.button {
+.ui.ui.ui.ui.mini.button {
   font-size: @mini;
 }
 .ui.tiny.buttons .button,
 .ui.tiny.buttons .or,
-.ui.tiny.button {
+.ui.ui.ui.ui.tiny.button {
   font-size: @tiny;
 }
 .ui.small.buttons .button,
 .ui.small.buttons .or,
-.ui.small.button {
+.ui.ui.ui.ui.small.button {
   font-size: @small;
 }
 .ui.buttons .button,
@@ -683,22 +683,22 @@
 }
 .ui.large.buttons .button,
 .ui.large.buttons .or,
-.ui.large.button {
+.ui.ui.ui.ui.large.button {
   font-size: @large;
 }
 .ui.big.buttons .button,
 .ui.big.buttons .or,
-.ui.big.button {
+.ui.ui.ui.ui.big.button {
   font-size: @big;
 }
 .ui.huge.buttons .button,
 .ui.huge.buttons .or,
-.ui.huge.button {
+.ui.ui.ui.ui.huge.button {
   font-size: @huge;
 }
 .ui.massive.buttons .button,
 .ui.massive.buttons .or,
-.ui.massive.button {
+.ui.ui.ui.ui.massive.button {
   font-size: @massive;
 }
 


### PR DESCRIPTION
## Description
Buttons in menu items had its own font-size assigned via @buttonSize . If somebody now wants to have smaller or higher buttons  somewhere by adding any of the button size classes (like `mini`), it does not work.

## Testcase
https://jsfiddle.net/bfojrmqs/
Remove the CSS Part to see the isse (both buttons are the same size then and `mini` is ignored)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5374
