### PR TITLE
[Sidebar] Respect a change of closable setting

### DIFF
--- a/src/definitions/modules/sidebar.js
+++ b/src/definitions/modules/sidebar.js
@@ -175,12 +175,10 @@ $.fn.sidebar = function(parameters) {
         bind: {
           clickaway: function() {
             module.verbose('Adding clickaway events to context', $context);
-            if(settings.closable) {
-              $context
-                .on('click'    + elementNamespace, module.event.clickaway)
-                .on('touchend' + elementNamespace, module.event.clickaway)
-              ;
-            }
+            $context
+              .on('click'    + elementNamespace, module.event.clickaway)
+              .on('touchend' + elementNamespace, module.event.clickaway)
+            ;
           },
           scrollLock: function() {
             if(settings.scrollLock) {

--- a/src/definitions/modules/sidebar.js
+++ b/src/definitions/modules/sidebar.js
@@ -411,7 +411,7 @@ $.fn.sidebar = function(parameters) {
             ? callback
             : function(){}
           ;
-          if(module.is.visible() || module.is.animating()) {
+          if(settings.closable && (module.is.visible() || module.is.animating())) {
             module.debug('Hiding sidebar', callback);
             module.refreshSidebars();
             module.pullPage(function() {


### PR DESCRIPTION
## Description
The `closable` setting is ignored in sidebar when the setting was changed after initialization.

## Testcase
- Keep the red sidebar open
- Click on "Fix sidebar"
- Click on "Toggle sidebar"
-> Sidebar should not close

#### Unfixed (original SUI issue)
https://jsfiddle.net/r7fws0nn

#### Fixed
https://jsfiddle.net/r7fws0nn/23/

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5329
