### PR TITLE
[List,Icon] List Item Icon Rotates Around Wrong Point when using Loading class

### DIFF
--- a/src/definitions/elements/list.less
+++ b/src/definitions/elements/list.less
@@ -109,9 +109,11 @@ ol.ui.list ol li,
   display: table-cell;
   margin: 0;
   padding-top: @iconOffset;
-  padding-right: @iconDistance;
-  vertical-align: @iconContentVerticalAlign;
   transition: @iconTransition;
+  &:not(.loading) {
+    padding-right: @iconDistance;
+    vertical-align: @iconContentVerticalAlign;
+  }
 }
 .ui.list .list > .item > i.icon:only-child,
 .ui.list > .item > i.icon:only-child {
@@ -158,6 +160,10 @@ ol.ui.list ol li,
   width: 100%;
   padding: 0 0 0 @contentDistance;
   vertical-align: @contentVerticalAlign;
+}
+.ui.list .list > .item > .loading.icon + .content,
+.ui.list > .item > .loading.icon + .content {
+  padding-left: e(%("calc(%d + %d)", @iconDistance, @contentDistance));
 }
 .ui.list .list > .item > img.image + .content,
 .ui.list > .item > img.image + .content {


### PR DESCRIPTION
## Description
When adding  the `loading` class to an icon in a list item, the entire icon rotates around a wrong point rather than rotating about it's own center.

## Testcase
http://jsfiddle.net/pn75L2tj/
- first list item shows the issue
- second item is fixed
- third one is normal item without loading class (to show alignment)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6717
