### PR TITLE
[Label] Adjust image height of image labels in menu items

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -328,6 +328,10 @@
   background: @labelBackground;
   color: @labelTextColor;
 }
+.ui.menu .item > .image.label img {
+  margin: @imageLabelImageMargin;
+  height: @imageLabelHeight;
+}
 /*--------------
      Images
 ---------------*/

--- a/src/definitions/elements/label.less
+++ b/src/definitions/elements/label.less
@@ -69,7 +69,7 @@ a.ui.label {
 .ui.label > img {
   width: auto !important;
   vertical-align: middle;
-  height: @imageHeight !important;
+  height: @imageHeight;
 }
 
 /* Icon */

--- a/src/themes/default/collections/menu.variables
+++ b/src/themes/default/collections/menu.variables
@@ -124,6 +124,12 @@
 @labelAndIconFloat: none;
 @labelAndIconMargin: 0 0.5em 0 0;
 
+/* Image Label */
+@imageLabelTextDistance: 0.8em;
+@imageLabelVerticalPadding: 0.2833em; /* Calculates as: @verticalLabel (from label.less) - @labelVerticalPadding (from here) */
+@imageLabelHeight: (1em + @imageLabelVerticalPadding * 2);  /* Logic adopted from label.less */
+@imageLabelImageMargin: -@imageLabelVerticalPadding @imageLabelTextDistance -@imageLabelVerticalPadding -@imageLabelTextDistance;
+
 /* Dropdown in Menu */
 @dropdownMenuBoxShadow: 0 1px 3px 0 rgba(0, 0, 0, 0.08);
 


### PR DESCRIPTION
## Description
Images in `image label` had wrong height when they were used within a menu item.

## Testcase
http://jsfiddle.net/n75faL4y/8/

## Screenshot
#### Before
![image](https://user-images.githubusercontent.com/18379884/50565703-c61f2800-0d31-11e9-9d21-cad4b3adbeff.png)

#### After
![image](https://user-images.githubusercontent.com/18379884/50565711-d2a38080-0d31-11e9-9d51-1ce91a66c461.png)



## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5247
