### PR TITLE
[Header] Attached inverted variant should have same background color as other inverted components

### DIFF
--- a/src/themes/default/elements/header.variables
+++ b/src/themes/default/elements/header.variables
@@ -146,7 +146,7 @@
 @invertedSubHeaderColor: @invertedMutedTextColor;
 @invertedDividedBorderColor: @whiteBorderColor;
 @invertedBlockBackground: @lightBlack @subtleGradient;
-@invertedAttachedBackground: @invertedBlockBackground;
+@invertedAttachedBackground: @black;
 
 /* Floated */
 @floatedMargin: 0.5em;


### PR DESCRIPTION
## Description
This PR sets the default background color for `inverted attached header` to the same as it already is for `inverted attached segment` or `inverted attached menu`

## Testcase
http://jsfiddle.net/9hhkqwf8/2/
Remove CSS to see previous behavior.

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5435
