### PR TITLE
[Dropdown] Fix simple dropdown positioning in vertical menus

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -284,7 +284,7 @@
 }
 .ui.vertical.menu .dropdown.item .menu {
   left: 100%;
-  min-width: 0;
+  min-width: max-content;
   margin: 0 0 0 @dropdownMenuDistance;
   box-shadow: @dropdownVerticalMenuBoxShadow;
   border-radius: 0 @dropdownMenuBorderRadius @dropdownMenuBorderRadius @dropdownMenuBorderRadius;

--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -284,6 +284,8 @@
 }
 .ui.vertical.menu .dropdown.item .menu {
   left: 100%;
+  /* IE needs 0, all others support max-content to show dropdown icon inline, so keep both settings! */
+  min-width: 0;
   min-width: max-content;
   margin: 0 0 0 @dropdownMenuDistance;
   box-shadow: @dropdownVerticalMenuBoxShadow;
@@ -1464,6 +1466,8 @@ each(@colors, {
   vertical-align: middle;
 }
 .ui.compact.vertical.menu {
+/* IE hack to make dropdown icons appear inline */
+  display: -ms-inline-flexbox !important;
   display: inline-block;
 }
 .ui.compact.menu .item:last-child {

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -1158,6 +1158,8 @@ select.ui.dropdown {
 }
 .ui.simple.dropdown .menu {
   position: absolute;
+  /* IE hack to make dropdown icons appear inline */
+  display: -ms-inline-flexbox !important;
   display: block;
   overflow: hidden;
   top: -9999px;

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -1160,7 +1160,7 @@ select.ui.dropdown {
   position: absolute;
   display: block;
   overflow: hidden;
-  top: -9999px !important;
+  top: -9999px;
   opacity: 0;
   width: 0;
   height: 0;
@@ -1179,7 +1179,7 @@ select.ui.dropdown {
   overflow: visible;
   width: auto;
   height: auto;
-  top: 100% !important;
+  top: 100%;
   opacity: 1;
 }
 .ui.simple.dropdown > .menu > .item:active > .menu,


### PR DESCRIPTION
## Description
 A simple dropdown in a vertical menu had wrong positioning, thus nearly unusable.
Also a submenu had second submenu dropdown icon misplaced

## Testcase
http://jsfiddle.net/Lnba5udj/1/
The fix cannot be applied directly in the fiddle CSS here, because you need to remove the !important flags from the original library manually in the debugger console (which i did for testing and below screenshot)
I added the JS-Dropdown Menus in the fiddle to test and make sure the changes do not affect non-simple dropdowns.

## Screenshot
### Unfixed
![simple_dropdown_position](https://user-images.githubusercontent.com/18379884/50568689-e6f97480-0d55-11e9-9bd9-af18ed69eca4.gif)

### Fixed
![simple_dropdown_position_fixed](https://user-images.githubusercontent.com/18379884/50568690-e9f46500-0d55-11e9-89c1-79c856bdfde3.gif)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5454
https://github.com/Semantic-Org/Semantic-UI/issues/5657