### PR TITLE
[Colors] Missing "globals" in optional theme path

### DIFF
--- a/src/theme.less
+++ b/src/theme.less
@@ -47,7 +47,7 @@
 @import "@{themesFolder}/default/globals/colors.less";
 
 /* Site Theme */
-@import (optional) "@{themesFolder}/@{site}/colors.less";
+@import (optional) "@{themesFolder}/@{site}/globals/colors.less";
 
 
 /*******************************


### PR DESCRIPTION
## Description
While testing https://fomantic-ui.com it turns out, the theme-changing on the frontpage does not work.
Beside my guess, that something else is also causing this, i found out in the console, it tries to receive `colors.less` at the wrong location (`/default/colors.less` instead of `/default/globals/colors.less`).

## Testcase
- open https://fomantic-ui,com
- scroll down to "Unbelievable Theming"
- Select any theme from the dropdown list
- watch the console

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/50573172-d5a07e80-0dce-11e9-80a9-8b3d2594e63a.png)
