### PR TITLE
[Search] Results with empty categories caused onSelect to return incorrect item

### DIFF
--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -855,26 +855,22 @@ $.fn.search = function(parameters) {
             if(settings.type === 'category') {
               // iterate through each category result
               $.each(results, function(index, category) {
-                resultIndex = 0;
-                $.each(category.results, function(index, value) {
-                  var
-                    result = category.results[index]
-                  ;
-                  if(result.id === undefined) {
-                    result.id = module.create.id(resultIndex, categoryIndex);
-                  }
-                  module.inject.result(result, resultIndex, categoryIndex);
-                  resultIndex++;
-                });
-                categoryIndex++;
+                if(category.results.length > 0){
+                  resultIndex = 0;
+                  $.each(category.results, function(index, result) {
+                    if(result.id === undefined) {
+                      result.id = module.create.id(resultIndex, categoryIndex);
+                    }
+                    module.inject.result(result, resultIndex, categoryIndex);
+                    resultIndex++;
+                  });
+                  categoryIndex++;
+                }
               });
             }
             else {
               // top level
-              $.each(results, function(index, value) {
-                var
-                  result = results[index]
-                ;
+              $.each(results, function(index, result) {
                 if(result.id === undefined) {
                   result.id = module.create.id(resultIndex);
                 }


### PR DESCRIPTION
## Description
When a type: "category" search box contains a category without results, incorrect items are passed to onSelect.
This was caused by wrongly increasing the categoryIndex on `module.inject.id` when no result was given for a category.

## Testcase
- enter 2 characters in the searchbox to trigger the search
- select the last entry  "fourth"
- The unfixed version shows "second", while the fixed one correctly shows "fourth" in the input field below the searchbox

### Unfixed
http://jsfiddle.net/3n85jcpp/1/

### Fixed
http://jsfiddle.net/3n85jcpp/9/

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5508
