### PR TITLE
[Icon] Make "link" and "disabled" work together correctly

### DIFF
--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -85,20 +85,16 @@ i.icon.loading {
              States
 *******************************/
 
-i.icon.hover {
-  opacity: 1 !important;
+i.icon:hover, i.icons:hover,
+i.icon:active, i.icons:active,
+i.emphasized.icon:not(.disabled), i.emphasized.icons:not(.disabled) {
+  opacity: 1;
 }
 
-i.icon.active {
-  opacity: 1 !important;
-}
-
-i.emphasized.icon {
-  opacity: 1 !important;
-}
-
-i.disabled.icon {
-  opacity: @disabledOpacity !important;
+i.disabled.icon, i.disabled.icons {
+  opacity: @disabledOpacity;
+  cursor: default;
+  pointer-events: none;
 }
 
 
@@ -120,13 +116,13 @@ i.fitted.icon {
          Link
 --------------------*/
 
-i.link.icon, i.link.icons {
+i.link.icon:not(.disabled), i.link.icons:not(.disabled) {
   cursor: pointer;
   opacity: @linkOpacity;
   transition: opacity @defaultDuration @defaultEasing;
 }
 i.link.icon:hover, i.link.icons:hover {
-  opacity: 1 !important;
+  opacity: 1;
 }
 
 /*-------------------


### PR DESCRIPTION
## Description
- `disabled` and `link` icon(s) at the same time ignored the `disabled` setting
- icon**s** (grouped) did also not work everywhere with those settings
- some CSS pseudoclass settings were wrong (for example `.hover` instead iof `:hover`)
- unnecessary `!important` values removed (which also partially caused the issue)

## Testcase
### Before
https://jsfiddle.net/vnmgt6y9/3/
from original SUI Issue

### After
https://jsfiddle.net/akym370t/
Because of the `!important` removements in the PR i prepared a similiar testcase having the same CSS settings given

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5694
