### PR TITLE
[Menu] Keep auto width for icon menu sizes

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -1770,7 +1770,7 @@ each(@colors, {
 .ui.mini.menu {
   font-size: @mini;
 }
-.ui.mini.vertical.menu {
+.ui.mini.vertical.menu:not(.icon) {
   width: @miniWidth;
 }
 .ui.mini.menu .dropdown {
@@ -1784,7 +1784,7 @@ each(@colors, {
 .ui.tiny.menu {
   font-size: @tiny;
 }
-.ui.tiny.vertical.menu {
+.ui.tiny.vertical.menu:not(.icon) {
   width: @tinyWidth;
 }
 .ui.tiny.menu .dropdown {
@@ -1798,7 +1798,7 @@ each(@colors, {
 .ui.small.menu {
   font-size: @small;
 }
-.ui.small.vertical.menu {
+.ui.small.vertical.menu:not(.icon) {
   width: @smallWidth;
 }
 .ui.small.menu .dropdown {
@@ -1820,7 +1820,7 @@ each(@colors, {
 .ui.large.menu {
   font-size: @large;
 }
-.ui.large.vertical.menu {
+.ui.large.vertical.menu:not(.icon) {
   width: @largeWidth;
 }
 .ui.large.menu .dropdown {
@@ -1834,7 +1834,7 @@ each(@colors, {
 .ui.huge.menu {
   font-size: @huge;
 }
-.ui.huge.vertical.menu {
+.ui.huge.vertical.menu:not(.icon) {
   width: @hugeWidth;
 }
 .ui.huge.menu .dropdown {
@@ -1848,7 +1848,7 @@ each(@colors, {
 .ui.big.menu {
   font-size: @big;
 }
-.ui.big.vertical.menu {
+.ui.big.vertical.menu:not(.icon) {
   width: @bigWidth;
 }
 .ui.big.menu .dropdown {
@@ -1862,7 +1862,7 @@ each(@colors, {
 .ui.massive.menu {
   font-size: @massive;
 }
-.ui.massive.vertical.menu {
+.ui.massive.vertical.menu:not(.icon) {
   width: @massiveWidth;
 }
 .ui.massive.menu .dropdown {


### PR DESCRIPTION
## Description
`icon menu` should always have its width getting auto calculated by the size of their icons and/or labels. This is basically already the case unless somebody adds any size like `mini` to the icon menu. The menu would get a fixed width then which does not really look right.

## Testcase
http://jsfiddle.net/joe2ks5w/2/
Remove the CSS Part to see current behavior

## Screenshot
![image](https://user-images.githubusercontent.com/5067638/28740875-ead38748-73bf-11e7-864c-71451921fe79.png)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5607
