### PR TITLE
[Form,Segment] Inverted variants should get inverted loader properly

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -724,7 +724,12 @@
 .ui.inverted.form .inline.field > p {
   color: @invertedLabelColor;
 }
-
+.ui.inverted.loading.form {
+  color: @invertedLoaderLineColor;
+}
+.ui.inverted.loading.form:before {
+  background: @loaderInvertedDimmerColor;
+}
 /* Inverted Field */
 .ui.inverted.form input:not([type]),
 .ui.inverted.form input[type="date"],

--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -467,7 +467,6 @@
   cursor: default;
   pointer-events: none;
   text-shadow: none !important;
-  color: transparent !important;
   transition: all 0s linear;
 }
 .ui.loading.segment:before {
@@ -602,6 +601,14 @@ each(@colors,{
 /* Attached */
 .ui.inverted.attached.segment {
   border-color: @solidWhiteBorderColor;
+}
+
+/* Loading */
+.ui.inverted.loading.segment {
+  color: @invertedLoaderLineColor;
+}
+.ui.inverted.loading.segment:before {
+  background: @loaderInvertedDimmerColor;
 }
 
 /*-------------------

--- a/src/themes/default/collections/form.variables
+++ b/src/themes/default/collections/form.variables
@@ -139,6 +139,7 @@
 
 /* Loading Dimmer */
 @loaderDimmerColor: rgba(255, 255, 255, 0.8);
+@loaderInvertedDimmerColor: rgba(0, 0, 0 , 0.85);
 @loaderDimmerZIndex: 100;
 
 /* Loading Spinner */

--- a/src/themes/default/elements/segment.variables
+++ b/src/themes/default/elements/segment.variables
@@ -80,6 +80,7 @@
 
 /* Loading Dimmer */
 @loaderDimmerColor: rgba(255, 255, 255, 0.8);
+@loaderInvertedDimmerColor: rgba(0, 0, 0 , 0.85);
 @loaderDimmerZIndex: 100;
 
 /* Loading Spinner */


### PR DESCRIPTION
## Description
When a form or segment is inverted, the `loading` class is still styled as for normal variants (white dimmer).
This PR now shows a black dimmer for inverted forms/segments with white loader color.
It also removes a bug where any textual segment content was completely invisble.

## Testcase
http://jsfiddle.net/zvs0fmh3/
Remove CSS to see previous behavior

## Screenshot
### Before
![image](https://user-images.githubusercontent.com/18379884/50576730-5afc5100-0e18-11e9-84ec-7c1dfad55c0e.png)

### After
![image](https://user-images.githubusercontent.com/18379884/50576722-3d2eec00-0e18-11e9-9ba4-639c71b46ab6.png)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5656
