### PR TITLE
[Menu] Corrected support for disabled items in inverted menus

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -449,11 +449,11 @@
      Disabled
 ---------------*/
 
-.ui.menu .item.disabled,
-.ui.menu .item.disabled:hover {
-  cursor: default !important;
-  background-color: transparent !important;
-  color: @disabledTextColor !important;
+.ui.menu .item.disabled {
+  cursor: default;
+  background-color: transparent;
+  color: @disabledTextColor;
+  pointer-events: none;
 }
 
 
@@ -846,19 +846,19 @@ Floated Menu / Item
 
 
 /* Inverted */
-.ui.secondary.inverted.menu .link.item,
-.ui.secondary.inverted.menu a.item {
-  color: @secondaryInvertedColor !important;
+.ui.secondary.inverted.menu .link.item:not(.disabled),
+.ui.secondary.inverted.menu a.item:not(.disabled) {
+  color: @secondaryInvertedColor;
 }
 .ui.secondary.inverted.menu .dropdown.item:hover,
 .ui.secondary.inverted.menu .link.item:hover,
 .ui.secondary.inverted.menu a.item:hover {
   background: @secondaryInvertedHoverBackground;
-  color: @secondaryInvertedHoverColor !important;
+  color: @secondaryInvertedHoverColor;
 }
 .ui.secondary.inverted.menu .active.item {
   background: @secondaryInvertedActiveBackground;
-  color: @secondaryInvertedActiveColor !important;
+  color: @secondaryInvertedActiveColor;
 }
 
 /* Fix item margins */
@@ -1008,7 +1008,7 @@ Floated Menu / Item
   border-width: @secondaryPointingBorderWidth;
   border-color: @secondaryPointingBorderColor;
 }
-.ui.secondary.inverted.pointing.menu .item {
+.ui.secondary.inverted.pointing.menu .item:not(.disabled) {
   color: @secondaryPointingInvertedItemTextColor;
 }
 .ui.secondary.inverted.pointing.menu .header.item {
@@ -1331,8 +1331,7 @@ each(@colors, {
 }
 
 /* Disabled */
-.ui.inverted.menu .item.disabled,
-.ui.inverted.menu .item.disabled:hover {
+.ui.inverted.menu .item.disabled {
   color: @invertedDisabledTextColor;
 }
 


### PR DESCRIPTION
## Description
Wrong specificity and missing `pointer-events:none` for disabled items in inverted menus. 

## Testcase
https://jsfiddle.net/216r43ep/1/

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/50577298-a49f6880-0e25-11e9-8fd0-3e389a7302cf.png)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6581
