### PR TITLE
[Steps] feat(steps): Icon size variation

### DIFF
--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -269,18 +269,18 @@ each(@colors, {
         Sizes
 --------------------*/
 
-i.mini.icon,
-i.mini.icons {
+i.mini.mini.mini.icon,
+i.mini.mini.mini.icons {
   line-height: 1;
   font-size: @mini;
 }
-i.tiny.icon,
-i.tiny.icons {
+i.tiny.tiny.tiny.icon,
+i.tiny.tiny.tiny.icons {
   line-height: 1;
   font-size: @tiny;
 }
-i.small.icon,
-i.small.icons {
+i.small.small.small.icon,
+i.small.small.small.icons {
   line-height: 1;
   font-size: @small;
 }
@@ -288,26 +288,26 @@ i.icon,
 i.icons {
   font-size: @medium;
 }
-i.large.icon,
-i.large.icons {
+i.large.large.large.icon,
+i.large.large.large.icons {
   line-height: 1;
   vertical-align: middle;
   font-size: @large;
 }
-i.big.icon,
-i.big.icons {
+i.big.big.big.icon,
+i.big.big.big.icons {
   line-height: 1;
   vertical-align: middle;
   font-size: @big;
 }
-i.huge.icon,
-i.huge.icons {
+i.huge.huge.huge.icon,
+i.huge.huge.huge.icons {
   line-height: 1;
   vertical-align: middle;
   font-size: @huge;
 }
-i.massive.icon,
-i.massive.icons {
+i.massive.massive.massive.icon,
+i.massive.massive.massive.icons {
   line-height: 1;
   vertical-align: middle;
   font-size: @massive;

--- a/src/definitions/elements/step.less
+++ b/src/definitions/elements/step.less
@@ -147,27 +147,6 @@
   font-size: @iconSize;
   margin: 0 @iconDistance 0 0;
 }
-.ui.steps .step > .icon.mini {
-  font-size: @mini;
-}
-.ui.steps .step > .icon.tiny {
-  font-size: @tiny;
-}
-.ui.steps .step > .icon.small {
-  font-size: @small;
-}
-.ui.steps .step > .icon.large {
-  font-size: @large;
-}
-.ui.steps .step > .icon.big {
-  font-size: @big;
-}
-.ui.steps .step > .icon.huge {
-  font-size: @huge;
-}
-.ui.steps .step > .icon.massive {
-  font-size: @massive;
-}
 .ui.steps .step > .icon,
 .ui.steps .step > .icon ~ .content {
   display: block;

--- a/src/definitions/elements/step.less
+++ b/src/definitions/elements/step.less
@@ -147,6 +147,27 @@
   font-size: @iconSize;
   margin: 0 @iconDistance 0 0;
 }
+.ui.steps .step > .icon.mini {
+  font-size: @mini;
+}
+.ui.steps .step > .icon.tiny {
+  font-size: @tiny;
+}
+.ui.steps .step > .icon.small {
+  font-size: @small;
+}
+.ui.steps .step > .icon.large {
+  font-size: @large;
+}
+.ui.steps .step > .icon.big {
+  font-size: @big;
+}
+.ui.steps .step > .icon.huge {
+  font-size: @huge;
+}
+.ui.steps .step > .icon.massive {
+  font-size: @massive;
+}
 .ui.steps .step > .icon,
 .ui.steps .step > .icon ~ .content {
   display: block;


### PR DESCRIPTION
## Description

Add size variation of icon in steps Module.
Default (medium for icon) is not changed.

I initially tried adding `.ui.steps .step > .icon.medium { icon-size: @medium; }` but it displays the icon for Medium. Therefore, icon cannot be medium (1em).
![image](https://user-images.githubusercontent.com/127635/50579695-be26cb80-0e8a-11e9-9b15-3eca425fb5da.png)


## Testcase
### Before
https://jsfiddle.net/nc0up8oz/
![image](https://user-images.githubusercontent.com/127635/50579657-6d16d780-0e8a-11e9-8409-cf4ae5444c26.png)

### After

https://jsfiddle.net/djm15ybh/1/
![image](https://user-images.githubusercontent.com/127635/50586078-5177f500-0ebb-11e9-9128-b01425d2e507.png)


## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6441