### PR TITLE
[Form] checkbox and radio (with errors) were only reset if the first option was selected

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -552,10 +552,13 @@ $.fn.form = function(parameters) {
             }
             $.each(validation, function(fieldName, field) {
               identifier = field.identifier || fieldName;
-              if( module.get.field(identifier)[0] == $field[0] ) {
-                field.identifier = identifier;
-                fieldValidation = field;
-              }
+              $.each(module.get.field(identifier), function(index, groupField) {
+                if(groupField == $field[0]) {
+                  field.identifier = identifier;
+                  fieldValidation = field;
+                  return false;
+                }
+              });
             });
             return fieldValidation || false;
           },


### PR DESCRIPTION
## Description
After validation fails, checkboxes and radios with multiple options were only reset if the first option was selected.

## Testcase
### Unfixed
https://jsfiddle.net/kmd1970/6d3dp1xq/

### Fixed
https://jsfiddle.net/u2abzw3r/

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5072
