### PR TITLE
[Menu] Last Item in secondary compact menu lost top left/right border radius

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -1469,7 +1469,7 @@ each(@colors, {
   display: -ms-inline-flexbox !important;
   display: inline-block;
 }
-.ui.compact.menu .item:last-child {
+.ui.compact.menu:not(.secondary) .item:last-child {
   border-radius: 0 @borderRadius @borderRadius 0;
 }
 .ui.compact.menu .item:last-child:before {


### PR DESCRIPTION
## Description
A `compact menu` always changed last item's border radius. But in a secondary menu this is unwanted behavior

## Testcase
http://jsfiddle.net/ay7gkmw4/1/

## Screenshot
### Before
![image](https://user-images.githubusercontent.com/18379884/50598478-2c7b8600-0eab-11e9-8c0e-76c4b8c4ed78.png)

### After
![image](https://user-images.githubusercontent.com/18379884/50598388-e4f4fa00-0eaa-11e9-8004-cb4aae107398.png)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5025
