### PR TITLE
[Dropdown] Deleting search from a multiple dropdown, also deletes last selected item

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1327,7 +1327,8 @@ $.fn.dropdown = function(parameters) {
                   isSearch          = module.is.searchSelection(),
                   isFocusedOnSearch = module.is.focusedOnSearch(),
                   isFocused         = module.is.focused(),
-                  caretAtStart      = (isFocusedOnSearch && module.get.caretPosition() === 0),
+                  caretAtStart      = (isFocusedOnSearch && module.get.caretPosition(false) === 0),
+                  isSelectedSearch  = (caretAtStart && module.get.caretPosition(true) !== 0),
                   $nextLabel
                 ;
                 if(isSearch && !hasActiveLabel && !isFocusedOnSearch) {
@@ -1408,7 +1409,7 @@ $.fn.dropdown = function(parameters) {
                     module.remove.activeLabels($activeLabel);
                     event.preventDefault();
                   }
-                  else if(caretAtStart && !hasActiveLabel && pressedKey == keys.backspace) {
+                  else if(caretAtStart && !isSelectedSearch && !hasActiveLabel && pressedKey == keys.backspace) {
                     module.verbose('Removing last label on input backspace');
                     $activeLabel = $label.last().addClass(className.active);
                     module.remove.activeLabels($activeLabel);
@@ -1805,19 +1806,25 @@ $.fn.dropdown = function(parameters) {
                 return $.inArray(value, array) === index;
             });
           },
-          caretPosition: function() {
+          caretPosition: function(returnEndPos) {
             var
               input = $search.get(0),
               range,
               rangeLength
             ;
-            if('selectionStart' in input) {
+            if(returnEndPos && 'selectionEnd' in input){
+              return input.selectionEnd;
+            }
+            else if(!returnEndPos && 'selectionStart' in input) {
               return input.selectionStart;
             }
-            else if (document.selection) {
+            if (document.selection) {
               input.focus();
               range       = document.selection.createRange();
               rangeLength = range.text.length;
+              if(returnEndPos) {
+                return rangeLength;
+              }
               range.moveStart('character', -input.value.length);
               return range.text.length - rangeLength;
             }


### PR DESCRIPTION
## Description
If you have a dropdown (multiple) with one or more items selected, using backspace to delete the search, it also deletes the last selected item, if you have the whole text selected (Either by tabbing in or selecting all of the text with your mouse).

## Testcase
- Select 1 or more items in the select.
- Type something into the search
- Blur out of the select (mouse or tab)
- Tab back into the select / select all the search text with your mouse
- Press backspace

### Unfixed
https://jsfiddle.net/dbr26njq/40/

### Fixed
https://jsfiddle.net/dbr26njq/1294/

## Screenshot
### Before
![dropdown_selected_delete](https://user-images.githubusercontent.com/18379884/50602606-fee90980-0eb7-11e9-93a5-9a6e712e9eb6.gif)

### After
![dropdown_selected_delete_fixed](https://user-images.githubusercontent.com/18379884/50602615-027c9080-0eb8-11e9-8774-b069caa93606.gif)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/4887