### PR TITLE
[List] Make horizontal (divided) lists wrap nicely on small screens

### DIFF
--- a/src/definitions/elements/list.less
+++ b/src/definitions/elements/list.less
@@ -291,12 +291,12 @@ ol.ui.list ol li,
 }
 .ui.horizontal.list > .item {
   display: inline-block;
-  margin-left: @horizontalSpacing;
+  margin-right: @horizontalSpacing;
   font-size: 1rem;
 }
-.ui.horizontal.list:not(.celled) > .item:first-child {
-  margin-left: 0 !important;
-  padding-left: 0 !important;
+.ui.horizontal.list:not(.celled) > .item:last-child {
+  margin-right: 0;
+  padding-right: 0;
 }
 .ui.horizontal.list .list:not(.icon) {
   padding-left: 0;
@@ -749,7 +749,7 @@ ol.ui.horizontal.list li:before,
 .ui.divided.horizontal.list {
   margin-left: 0;
 }
-.ui.divided.horizontal.list > .item:not(:first-child) {
+.ui.divided.horizontal.list > .item {
   padding-left: @horizontalDividedSpacing;
 }
 .ui.divided.horizontal.list > .item:not(:last-child) {
@@ -757,12 +757,12 @@ ol.ui.horizontal.list li:before,
 }
 .ui.divided.horizontal.list > .item {
   border-top: none;
-  border-left: @dividedBorder;
+  border-right: @dividedBorder;
   margin: 0;
   line-height: @horizontalDividedLineHeight;
 }
-.ui.horizontal.divided.list > .item:first-child {
-  border-left: none;
+.ui.horizontal.divided.list > .item:last-child {
+  border-right: none;
 }
 /* Inverted */
 .ui.divided.inverted.list > .item,


### PR DESCRIPTION
## Description
When displaying the horizontal list in a small screen, the wrapped items have this strange space in the left side instead of perfectly aligning like a grid.

## Testcase
https://fomantic-ui.com/elements/list.html#horizontal
- Shrink the screen, so the examples start to wrap
- To not forget the `divided horizontal` variant (which the SUI PR's always forgot), add the `divided` class manually to one of the horizontal examples todouble check the below screenshots

## Screenshots
#### Before
![horizontal_list_wrapped_](https://user-images.githubusercontent.com/18379884/50615221-dbd44f00-0ee3-11e9-91be-e6cfb74b58a7.PNG)

#### After
![horizontal_list_wrapped_fixed](https://user-images.githubusercontent.com/18379884/50615235-e7277a80-0ee3-11e9-9072-7f8862b2b5a0.PNG)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/4501
