### PR TITLE
[List] Missing pseudo-class leads to invisible list item

### DIFF
--- a/src/definitions/elements/list.less
+++ b/src/definitions/elements/list.less
@@ -63,7 +63,7 @@ ol.ui.list li,
 
 ul.ui.list > li:first-child:after,
 ol.ui.list > li:first-child:after,
-.ui.list > .list > .item,
+.ui.list > .list > .item:after,
 .ui.list > .item:after {
   content: '';
   display: block;


### PR DESCRIPTION
## Description
This is obviously an old typ or copy/paste mistake and seems to affect only a few users at all.
In a CSS group of conditions which are obviously made for the :after pseudo-element, one line has the pseudo-class missing.
But this isn't just a typo, it actually leads into an invisible list item in case your code had exactly the matching DOM structure `.ui.list > .list > .item`, which i prepared in the jsfiddle below

## Testcase
http://jsfiddle.net/mgk0rbd6/

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/4526
