### PR TITLE
[List] Add suffixed ordered list variation

### DIFF
--- a/src/definitions/elements/list.less
+++ b/src/definitions/elements/list.less
@@ -651,12 +651,6 @@ ol.ui.list li:before,
   opacity: @orderedCountOpacity;
 }
 
-ol.ui.basic.list li:before,
-.ui.basic.ordered.list .list > .item:before,
-.ui.basic.ordered.list > .item:before {
-  content: @orderedCountContentBasic;
-}
-
 ol.ui.inverted.list li:before,
 .ui.ordered.inverted.list .list > .item:before,
 .ui.ordered.inverted.list > .item:before {
@@ -693,6 +687,14 @@ ol.ui.horizontal.list li:before,
   position: static;
   margin: 0 @horizontalOrderedCountDistance 0 0;
 }
+
+/* Suffixed Ordered */
+ol.ui.suffixed.list li:before,
+.ui.suffixed.ordered.list .list > .item:before,
+.ui.suffixed.ordered.list > .item:before {
+  content: @orderedCountContentSuffixed;
+}
+
 
 /*-------------------
        Divided

--- a/src/definitions/elements/list.less
+++ b/src/definitions/elements/list.less
@@ -651,6 +651,12 @@ ol.ui.list li:before,
   opacity: @orderedCountOpacity;
 }
 
+ol.ui.basic.list li:before,
+.ui.basic.ordered.list .list > .item:before,
+.ui.basic.ordered.list > .item:before {
+  content: @orderedCountContentBasic;
+}
+
 ol.ui.inverted.list li:before,
 .ui.ordered.inverted.list .list > .item:before,
 .ui.ordered.inverted.list > .item:before {

--- a/src/themes/default/elements/list.variables
+++ b/src/themes/default/elements/list.variables
@@ -176,8 +176,8 @@
 @orderedCountName: ordered;
 @orderedCountSeparator: ".";
 @orderedCountSuffix: ".";
-@orderedCountContent: counters(@orderedCountName, @orderedCountSeparator) @orderedCountSuffix;
-@orderedCountContentBasic: counters(@orderedCountName, @orderedCountSeparator) " ";
+@orderedCountContent: counters(@orderedCountName, @orderedCountSeparator) " ";
+@orderedCountContentSuffixed: counters(@orderedCountName, @orderedCountSeparator) @orderedCountSuffix;
 @orderedCountColor: @textColor;
 @orderedCountDistance: 1.25rem;
 @orderedCountOpacity: 0.8;

--- a/src/themes/default/elements/list.variables
+++ b/src/themes/default/elements/list.variables
@@ -174,8 +174,10 @@
 
 /* Ordered List */
 @orderedCountName: ordered;
-@orderedCountContent: counters(ordered, ".") ".";
-@orderedCountContentBasic: counters(ordered, ".") " ";
+@orderedCountSeparator: ".";
+@orderedCountSuffix: ".";
+@orderedCountContent: counters(@orderedCountName, @orderedCountSeparator) @orderedCountSuffix;
+@orderedCountContentBasic: counters(@orderedCountName, @orderedCountSeparator) " ";
 @orderedCountColor: @textColor;
 @orderedCountDistance: 1.25rem;
 @orderedCountOpacity: 0.8;

--- a/src/themes/default/elements/list.variables
+++ b/src/themes/default/elements/list.variables
@@ -174,7 +174,8 @@
 
 /* Ordered List */
 @orderedCountName: ordered;
-@orderedCountContent: counters(ordered, ".") " ";
+@orderedCountContent: counters(ordered, ".") ".";
+@orderedCountContentBasic: counters(ordered, ".") " ";
 @orderedCountColor: @textColor;
 @orderedCountDistance: 1.25rem;
 @orderedCountOpacity: 0.8;


### PR DESCRIPTION
## Description

Ordered list has conventionally dot or something after the end of counter like

> 1. 2019
> 2. 2018
> 3. 500px

But SUI/FUI's ordered list does not follow the convention and omit dot.
This may lower readability specially when list item starts with number (below example).

> 1&ensp;2019
> 2&ensp;2018
> 3&ensp;500px

So This PR 

* Add `.suffixed.ordered.list` variation that add the dots.
* Add LESS variables that allows developers to change separator and suffix like '1-2.' or '1.3)'.

## Testcase
### Before
https://jsfiddle.net/Lsawqmj6/

### After
https://jsfiddle.net/fso94dmx/1/
![image](https://user-images.githubusercontent.com/127635/50635416-67f27f00-0f95-11e9-9b59-53c588f8d653.png)


## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/4738