### PR TITLE
[Transition] Remember inline style display and dont show hidden objects like <script>

### DIFF
--- a/src/definitions/modules/accordion.js
+++ b/src/definitions/modules/accordion.js
@@ -189,12 +189,13 @@ $.fn.accordion = function(parameters) {
               $activeContent
                 .children()
                   .transition({
-                    animation   : 'fade in',
-                    queue       : false,
-                    useFailSafe : true,
-                    debug       : settings.debug,
-                    verbose     : settings.verbose,
-                    duration    : settings.duration
+                    animation        : 'fade in',
+                    queue            : false,
+                    useFailSafe      : true,
+                    debug            : settings.debug,
+                    verbose          : settings.verbose,
+                    duration         : settings.duration,
+                    skipInlineHidden : true
                   })
               ;
             }
@@ -250,12 +251,13 @@ $.fn.accordion = function(parameters) {
                 $activeContent
                   .children()
                     .transition({
-                      animation   : 'fade out',
-                      queue       : false,
-                      useFailSafe : true,
-                      debug       : settings.debug,
-                      verbose     : settings.verbose,
-                      duration    : settings.duration
+                      animation        : 'fade out',
+                      queue            : false,
+                      useFailSafe      : true,
+                      debug            : settings.debug,
+                      verbose          : settings.verbose,
+                      duration         : settings.duration,
+                      skipInlineHidden : true
                     })
                 ;
               }
@@ -320,11 +322,12 @@ $.fn.accordion = function(parameters) {
                 $openContents
                   .children()
                     .transition({
-                      animation   : 'fade out',
-                      useFailSafe : true,
-                      debug       : settings.debug,
-                      verbose     : settings.verbose,
-                      duration    : settings.duration
+                      animation        : 'fade out',
+                      useFailSafe      : true,
+                      debug            : settings.debug,
+                      verbose          : settings.verbose,
+                      duration         : settings.duration,
+                      skipInlineHidden : true
                     })
                 ;
               }

--- a/src/definitions/modules/transition.js
+++ b/src/definitions/modules/transition.js
@@ -253,7 +253,7 @@ $.fn.transition = function() {
               displayType    = module.get.displayType(),
               overrideStyle  = userStyle + 'display: ' + displayType + ' !important;',
               inlineDisplay  = $module[0].style.display,
-              mustStayHidden = !displayType || inlineDisplay === 'none'
+              mustStayHidden = !displayType || inlineDisplay === 'none' || $module[0].tagName.match(/(script|link|style)/i)
             ;
             if (mustStayHidden){
               module.remove.transition();

--- a/src/definitions/modules/transition.js
+++ b/src/definitions/modules/transition.js
@@ -249,21 +249,25 @@ $.fn.transition = function() {
           visible: function() {
             var
               style          = $module.attr('style'),
-              userStyle      = module.get.userStyle(),
+              userStyle      = module.get.userStyle(style),
               displayType    = module.get.displayType(),
               overrideStyle  = userStyle + 'display: ' + displayType + ' !important;',
               currentDisplay = $module.css('display'),
-              emptyStyle     = (style === undefined || style === '')
+              inlineDisplay  = $module[0].style.display,
+              mustStayHidden = !displayType || inlineDisplay === 'none'
             ;
-            if(currentDisplay !== displayType) {
-              module.verbose('Overriding default display to show element', displayType);
-              $module
-                .attr('style', overrideStyle)
-              ;
+            if (mustStayHidden){
+              module.remove.transition();
+              return false;
             }
-            else if(emptyStyle) {
+            module.verbose('Overriding default display to show element', displayType);
+            $module
+              .attr('style', overrideStyle)
+            ;
+            if(style === '') {
               $module.removeAttr('style');
             }
+            return true;
           },
           hidden: function() {
             var
@@ -311,28 +315,27 @@ $.fn.transition = function() {
 
         set: {
           animating: function(animation) {
-            var
-              animationClass,
-              direction
-            ;
-            // remove previous callbacks
-            module.remove.completeCallback();
-
-            // determine exact animation
-            animation      = animation || settings.animation;
-            animationClass = module.get.animationClass(animation);
-
-            // save animation class in cache to restore class names
-            module.save.animation(animationClass);
-
             // override display if necessary so animation appears visibly
-            module.force.visible();
+            if(module.force.visible()) {
+              var
+                  animationClass,
+                  direction
+              ;
+              // remove previous callbacks
+              module.remove.completeCallback();
 
-            module.remove.hidden();
-            module.remove.direction();
+              // determine exact animation
+              animation = animation || settings.animation;
+              animationClass = module.get.animationClass(animation);
 
-            module.start.animation(animationClass);
+              // save animation class in cache to restore class names
+              module.save.animation(animationClass);
 
+              module.remove.hidden();
+              module.remove.direction();
+
+              module.start.animation(animationClass);
+            }
           },
           duration: function(animationName, duration) {
             duration = duration || settings.duration;
@@ -504,6 +507,7 @@ $.fn.transition = function() {
           },
           transition: function() {
             $module
+              .removeClass(className.transition)
               .removeClass(className.visible)
               .removeClass(className.hidden)
             ;
@@ -625,8 +629,13 @@ $.fn.transition = function() {
               return settings.displayType;
             }
             if(shouldDetermine && $module.data(metadata.displayType) === undefined) {
+              var currentDisplay = $module.css('display');
+              if(currentDisplay === '' || currentDisplay === 'none'){
               // create fake element to determine display state
-              module.can.transition(true);
+                module.can.transition(true);
+              } else {
+                module.save.displayType(currentDisplay);
+              }
             }
             return $module.data(metadata.displayType);
           },
@@ -803,12 +812,13 @@ $.fn.transition = function() {
 
         show: function(display) {
           module.verbose('Showing element', display);
-          module.remove.hidden();
-          module.set.visible();
-          module.force.visible();
-          settings.onShow.call(element);
-          settings.onComplete.call(element);
-          // module.repaint();
+          if(module.force.visible()) {
+            module.remove.hidden();
+            module.set.visible();
+            settings.onShow.call(element);
+            settings.onComplete.call(element);
+            // module.repaint();
+          }
         },
 
         toggle: function() {

--- a/src/definitions/modules/transition.js
+++ b/src/definitions/modules/transition.js
@@ -253,7 +253,7 @@ $.fn.transition = function() {
               displayType    = module.get.displayType(),
               overrideStyle  = userStyle + 'display: ' + displayType + ' !important;',
               inlineDisplay  = $module[0].style.display,
-              mustStayHidden = !displayType || inlineDisplay === 'none' || $module[0].tagName.match(/(script|link|style)/i)
+              mustStayHidden = !displayType || (inlineDisplay === 'none' && settings.skipInlineHidden) || $module[0].tagName.match(/(script|link|style)/i)
             ;
             if (mustStayHidden){
               module.remove.transition();
@@ -1088,6 +1088,9 @@ $.fn.transition.settings = {
 
   // new animations will occur after previous ones
   queue         : true,
+
+// whether initially inline hidden objects should be skipped for transition
+  skipInlineHidden: false,
 
   metadata : {
     displayType: 'display'

--- a/src/definitions/modules/transition.js
+++ b/src/definitions/modules/transition.js
@@ -252,7 +252,6 @@ $.fn.transition = function() {
               userStyle      = module.get.userStyle(style),
               displayType    = module.get.displayType(),
               overrideStyle  = userStyle + 'display: ' + displayType + ' !important;',
-              currentDisplay = $module.css('display'),
               inlineDisplay  = $module[0].style.display,
               mustStayHidden = !displayType || inlineDisplay === 'none'
             ;


### PR DESCRIPTION
## Description
Transition did always detect "block" as display value and did not respect or remembered an initial given inline block style which was probably wanted by the user. For example `inline` or even `none`, if an element within a transition should definately not be shown. 
Not only because of this, but it was also displaying `script` or other unwanted tags :roll_eyes: 
`script`, `link` or `style` tags are now skipped all the time.

Especially for accordion it turns out to be usefull that transition should be skipped if the item has initially been set to be hidden. This is true in most cases for the to be animated element itself, but in an accordion there could be some elements within the container where those elements should be kept hidden.

Therefore i added a new setting

 ```javascript
skipInlineHidden: false ; // (default false to stay backward compatible) 
```
to the transition module.
The accordion module uses this now to still hide any child element of a accordion container (not the container itself!) in case a child element was already initially hidden.
See the source of the fiddle below for better explanation :wink:

For additional testing i injected the new transition.js into all of my local `gh-pages`-branch to make sure no other components had negative side effects (way too many examples otherwise to put into a fiddle)

If you also want to test it, you can simply:

- Checkout gh-pages of the https://github.com/fomantic/Fomantic-UI-Docs/tree/gh-pages
- copy transition.js from this PR to /dist folder
- Change 
```html
<script src="/dist/semantic.min.js"></script>
<script src="/dist/transition.js"></script>
```
In the following docs html files: accordion, popup,dimmer,transition,form, search, modal, toast, visibility,modal,dropdown (those modules make use of transition.js , thats why. The docs itself use transition.js on every page)

## Testcase
### Broken
http://jsfiddle.net/qLp3md9n/

### Fixed
http://jsfiddle.net/qLp3md9n/2/

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/2988
https://github.com/Semantic-Org/Semantic-UI/issues/3171
https://github.com/Semantic-Org/Semantic-UI/issues/6735
