### PR TITLE
[Dropdown]: Template for select-dropdown did not use classname-property from settings

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -373,7 +373,7 @@ $.fn.dropdown = function(parameters) {
                 .attr('class', $input.attr('class') )
                 .addClass(className.selection)
                 .addClass(className.dropdown)
-                .html( templates.dropdown(selectValues,settings.preserveHTML) )
+                .html( templates.dropdown(selectValues,settings.preserveHTML, settings.className) )
                 .insertBefore($input)
               ;
               if($input.hasClass(className.multiple) && $input.prop('multiple') === false) {
@@ -396,7 +396,7 @@ $.fn.dropdown = function(parameters) {
             module.refresh();
           },
           menu: function(values) {
-            $menu.html( templates.menu(values, fields,settings.preserveHTML));
+            $menu.html( templates.menu(values, fields,settings.preserveHTML,settings.className));
             $item    = $menu.find(selector.item);
             $divider = settings.hideDividers ? $item.parent().children(selector.divider) : $();
           },
@@ -4037,7 +4037,7 @@ $.fn.dropdown.settings.templates = {
     return string;
   },
   // generates dropdown from select values
-  dropdown: function(select, preserveHTML) {
+  dropdown: function(select, preserveHTML, className) {
     var
       placeholder = select.placeholder || false,
       values      = select.values || [],
@@ -4051,19 +4051,16 @@ $.fn.dropdown.settings.templates = {
     else {
       html += '<div class="text"></div>';
     }
-    html += '<div class="menu">';
+    html += '<div class="'+className.menu+'">';
     $.each(values, function(index, option) {
-      html += (option.disabled)
-        ? '<div class="disabled item" data-value="' + option.value.replace(/"/g,"") + '">' + escape(option.name,preserveHTML) + '</div>'
-        : '<div class="item" data-value="' + option.value.replace(/"/g,"") + '">' + escape(option.name,preserveHTML) + '</div>'
-      ;
+      html += '<div class="'+(option.disabled ? className.disabled+' ':'')+className.item+'" data-value="' + option.value.replace(/"/g,"") + '">' + escape(option.name,preserveHTML) + '</div>';
     });
     html += '</div>';
     return html;
   },
 
   // generates just menu from select
-  menu: function(response, fields, preserveHTML) {
+  menu: function(response, fields, preserveHTML, className) {
     var
       values = response[fields.values] || [],
       html   = '',
@@ -4082,10 +4079,10 @@ $.fn.dropdown.settings.templates = {
             ? 'data-text="' + option[fields.text] + '"'
             : '',
           maybeDisabled = (option[fields.disabled])
-            ? 'disabled '
+            ? className.disabled+' '
             : ''
         ;
-        html += '<div class="'+ maybeDisabled +'item" data-value="' + option[fields.value].replace(/"/g,"") + '"' + maybeText + '>';
+        html += '<div class="'+ maybeDisabled + className.item+'" data-value="' + option[fields.value].replace(/"/g,"") + '"' + maybeText + '>';
         html +=   escape(option[fields.name],preserveHTML);
         html += '</div>';
       } else if (itemType === 'header') {


### PR DESCRIPTION
## Description

## Testcase
In case a dropdown should be initiated out of a `select` -tag, the html was created via a template. This template however did not use classname settings from the `settings.className` property list, but had them hardcoded instead.

## Screenshot
Given a very (very! :rofl:  ) simple example
Two dropdowns, one from  select, one from div:
```html
<select class="ui dropdown"></select>
<div class="ui dropdown"></div>
```
Both initiated by
```javascript
$('.ui.dropdown').dropdown({
        className : {
            menu: 'custom-hint-box menu',
            selection: 'custom-select'
        }
    });
```
In the DOM Inspector you will recognize the difference: The className setting is not applied to the dropdown made out of the select-tag

### Unfixed
![image](https://user-images.githubusercontent.com/18379884/50682306-b4c66c00-100e-11e9-9071-5a69e205a150.png)

### Fixed
![image](https://user-images.githubusercontent.com/18379884/50682245-89438180-100e-11e9-8262-dbe78d282825.png)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/3603
