### PR TITLE
[Loader,Modal] Default Loader color settings in Dimmers had impact on loaders in modals

### DIFF
--- a/src/definitions/elements/loader.less
+++ b/src/definitions/elements/loader.less
@@ -140,23 +140,23 @@
 --------------------*/
 
 /* Show inside active dimmer */
-.ui.dimmer .loader {
+.ui.dimmer > .loader {
   display: block;
 }
 
 /* Black Dimmer */
-.ui.dimmer .ui.loader {
+.ui.dimmer > .ui.loader {
   color: @invertedLoaderTextColor;
 }
-.ui.dimmer .ui.loader:not(.elastic):before {
+.ui.dimmer > .ui.loader:not(.elastic):before {
   border-color: @invertedLoaderFillColor;
 }
 
 /* White Dimmer (Inverted) */
-.ui.inverted.dimmer .ui.loader {
+.ui.inverted.dimmer > .ui.loader {
   color: @loaderTextColor;
 }
-.ui.inverted.dimmer .ui.loader:not(.elastic):before {
+.ui.inverted.dimmer > .ui.loader:not(.elastic):before {
   border-color: @loaderFillColor;
 }
 
@@ -168,9 +168,9 @@
         Text
 --------------------*/
 
-.ui.text.loader {
-  width: auto !important;
-  height: auto !important;
+.ui.ui.ui.ui.text.loader {
+  width: auto;
+  height: auto;
   text-align: center;
   font-style: normal;
 }
@@ -205,49 +205,41 @@
 
 
 /* Loader */
-.ui.inverted.dimmer .ui.mini.loader,
 .ui.mini.loader {
   width: @mini;
   height: @mini;
   font-size: @miniFontSize;
 }
-.ui.inverted.dimmer .ui.tiny.loader,
 .ui.tiny.loader {
   width: @tiny;
   height: @tiny;
   font-size: @tinyFontSize;
 }
-.ui.inverted.dimmer .ui.small.loader,
 .ui.small.loader {
   width: @small;
   height: @small;
   font-size: @smallFontSize;
 }
-.ui.inverted.dimmer .ui.loader,
 .ui.loader {
   width: @medium;
   height: @medium;
   font-size: @mediumFontSize;
 }
-.ui.inverted.dimmer .ui.large.loader,
 .ui.large.loader {
   width: @large;
   height: @large;
   font-size: @largeFontSize;
 }
-.ui.inverted.dimmer .ui.big.loader,
 .ui.big.loader {
   width: @big;
   height: @big;
   font-size: @bigFontSize;
 }
-.ui.inverted.dimmer .ui.huge.loader,
 .ui.huge.loader {
   width: @huge;
   height: @huge;
   font-size: @hugeFontSize;
 }
-.ui.inverted.dimmer .ui.massive.loader,
 .ui.massive.loader {
   width: @massive;
   height: @massive;
@@ -395,10 +387,10 @@ each(@colors, {
        Elastic
 --------------------*/
 
-.ui.dimmer .ui.elastic.loader {
+.ui.dimmer > .ui.elastic.loader {
   color: @invertedLoaderLineColor;
 }
-.ui.inverted.dimmer .ui.elastic.loader {
+.ui.inverted.dimmer > .ui.elastic.loader {
   color: @loaderLineColor;
 }
 .ui.elastic.loading.loading:not(.form):not(.segment):after,

--- a/src/definitions/modules/modal.less
+++ b/src/definitions/modules/modal.less
@@ -606,6 +606,7 @@
 .ui.inverted.modal > .actions {
   background: @invertedActionBackground;
   border-top: @invertedActionBorder;
+  color: @invertedActionColor;
 }
 
 .ui.inverted.dimmer > .modal > .close {

--- a/src/themes/default/modules/modal.variables
+++ b/src/themes/default/modules/modal.variables
@@ -200,4 +200,5 @@
 @invertedHeaderBackgroundColor: @darkTextColor;
 @invertedActionBackground: #191A1B;
 @invertedActionBorder: 1px solid rgba(34, 36, 38, 0.85);
+@invertedActionColor: @white;
 @invertedDimmerCloseColor: rgba(0,0,0,.85);


### PR DESCRIPTION
## Description
When a modal also had loaders used, these got the wrong default color (white if dimmer of modal was black, so white color on white modal background was...uhm..white :rofl: )
I fixed this now for every combination of dimmer and modal

Also fixed unnessary css settings and missing color in inverted modal action (came across this while testing the original SUI issue)

## Testcase
http://jsfiddle.net/o92qen2j/10/
In every Modal there is a inline loader in the actions section which is not visible if the fix is not applied
Remove CSS to see the original issue again

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/4014
