### PR TITLE
[Button, Icon] Loading icon Position in Button was not rotating around center

### DIFF
--- a/src/definitions/elements/button.less
+++ b/src/definitions/elements/button.less
@@ -983,6 +983,8 @@
   border-top-left-radius: inherit;
   border-bottom-left-radius: inherit;
   text-align: center;
+  animation:none;
+  padding: @verticalPadding 0 @verticalPadding 0;
 
   margin: @labeledIconMargin;
   width: @labeledIconWidth;
@@ -1011,11 +1013,10 @@
 .ui.labeled.icon.buttons > .button > .icon:after,
 .ui.labeled.icon.button > .icon:after {
   display: block;
-  position: absolute;
+  position: relative;
   width: 100%;
-  top: 50%;
+  top: 0;
   text-align: center;
-  transform: translateY(-50%);
 }
 
 .ui.labeled.icon.buttons .button > .icon {
@@ -1045,7 +1046,10 @@
   padding-right: @horizontalPadding !important;
 }
 
-
+/* Loading Icon in Labeled Button */
+.ui.labeled.icon.button > .loading.icon:before {
+  animation: loader 2s linear infinite;
+}
 
 
 /*--------------

--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -70,15 +70,7 @@ i.icon:before {
 i.icon.loading {
   height: 1em;
   line-height: 1;
-  animation: icon-loading @loadingDuration linear infinite;
-}
-@keyframes icon-loading {
- from {
-    transform: rotate(0deg);
- }
- to {
-    transform: rotate(360deg);
- }
+  animation: loader @loadingDuration linear infinite;
 }
 
 /*******************************

--- a/src/themes/default/elements/button.variables
+++ b/src/themes/default/elements/button.variables
@@ -44,7 +44,7 @@
 ;
 
 /* Icon */
-@iconHeight: @relativeTiny;
+@iconHeight: auto;
 @iconOpacity: 0.8;
 @iconDistance: @relative6px;
 @iconColor: '';


### PR DESCRIPTION
## Description
A `loading icon` within a button was rotated around a wrong anchor position (similiar to the Fix in #336 )
- The positioning is corrected
- It is now also supported in `labeled icon button` (a loading spinner was rotating the background sqare before if you tried it)

Due to the fixes you are now finally able to correctly use loading icons in buttons together with text by either using `labeled icon button`or just `icon button`.

After fixing it, the used `notched circle icon` used in the fiddle still looked slightly misaligned. It turned out this is due to the icon in FontAwesome itself not being centered accurately.
To proove this, i added an example in the fiddle below where you can obviously see it. The 100% circle background stays fixed while the spinning icon does not precisely although it`s a 100% square (same pixel height/width/font-size)

## Testcase
http://jsfiddle.net/bztsj9wm/3/

Remove the CSS to see the previous wrong behavior

## Screenshot
### Broken (spinners move around wrong anchor and `labeled icon button` rotated background color
![loading_icon_button_wrong](https://user-images.githubusercontent.com/18379884/50711925-03582280-1070-11e9-8c5b-79a73bbfccf9.gif)

### Fixed, all looks fine :smile: 
![loading_icon_button_fixed](https://user-images.githubusercontent.com/18379884/50711939-094e0380-1070-11e9-8167-c340d95a7fcd.gif)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/3971
https://github.com/Semantic-Org/Semantic-UI/issues/2271
