### PR TITLE
[Loader] Elastic Loader was not working in Firefox

### DIFF
--- a/src/definitions/elements/loader.less
+++ b/src/definitions/elements/loader.less
@@ -405,6 +405,7 @@ each(@colors, {
 .ui.elastic.loading.loading.loading > i.icon:before,
 .ui.elastic.loader.loader:before {
   animation: elastic-loader 1s infinite cubic-bezier(.27, 1.05, .92, .61);
+  -moz-animation: currentcolor-elastic-loader 1s infinite cubic-bezier(.27, 1.05, .92, .61);
   border-right-color: transparent;
 }
 .ui.elastic.inline.loader:empty {
@@ -449,6 +450,30 @@ each(@colors, {
   }
   10.1%, 35%{
     border-bottom-color: inherit;
+  }
+  50.1%{
+    border-left-color: transparent;
+  }
+  100% {
+    border-left-color: transparent;
+    border-bottom-color: transparent;
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes currentcolor-elastic-loader {
+  0%, 1% {
+    border-left-color: transparent;
+    border-bottom-color: transparent
+  }
+  1.1%, 50% {
+    border-left-color: currentColor;
+  }
+  10%, 35.1%{
+    border-bottom-color: transparent;
+  }
+  10.1%, 35%{
+    border-bottom-color: currentColor;
   }
   50.1%{
     border-left-color: transparent;


### PR DESCRIPTION
## Description
Firefox does not support `inherit` in animation keyframes for `border-color` (it should inherit from color, which is indeed working in firefox but **not inside keyframes** 😭 )
All other browsers do support this also in keyframes (but those do not support `currentColor` in keyframes for `border-color` instead 🙄 ).
As there is no vendor specific `-???-border-left-color`, i had to double the animation sequence for `-moz-animation` only. Most clean solution (and prepared in case any other browser might change their behavior also (which i doubt 😉 )

## Testcase
http://jsfiddle.net/a5gt6nc9/2/
Fiddle works everywhere, also in Firefox now. Remove the CSS to see the issue in Firefox

## Screenshot
### Firefox
![firefox_loader_issue](https://user-images.githubusercontent.com/18379884/50741183-041cc000-11fa-11e9-97b9-cbd0b101a4bd.gif)

### Every other Browser
![firefox_loader_issue_normal](https://user-images.githubusercontent.com/18379884/50741190-0b43ce00-11fa-11e9-8787-69194bebb62d.gif)

## Version
2.7.1

