### PR TITLE
[Segment, Menu] "secondary segment" or "secondary menu" have a different meaning

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -1288,10 +1288,12 @@ each(@colors, {
   @color: replace(@key, '@', '');
   @c: @colors[@@color][color];
 
-  .ui.menu .@{color}.active.item,
-  .ui.@{color}.menu .active.item {
-    border-color: @c;
-    color: @c;
+  & when not (@color=secondary) {
+    .ui.menu .@{color}.active.item,
+    .ui.@{color}.menu .active.item {
+      border-color: @c;
+      color: @c;
+    }
   }
 })
 

--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -538,7 +538,7 @@
 each(@colors,{
   @color: replace(@key,'@','');
   @c: @colors[@@color][color];
-  & when not (@color=secondary) {
+  & when not (@color=primary) and not (@color=secondary) {
     .ui.@{color}.segment.segment.segment.segment.segment:not(.inverted) {
       border-top: @coloredBorderSize solid @c;
     }

--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -538,12 +538,14 @@
 each(@colors,{
   @color: replace(@key,'@','');
   @c: @colors[@@color][color];
-  .ui.@{color}.segment.segment.segment.segment.segment:not(.inverted) {
-    border-top: @coloredBorderSize solid @c;
-  }
-  .ui.inverted.@{color}.segment.segment.segment.segment.segment {
-    background-color: @c;
-    color: @white;
+  & when not (@color=secondary) {
+    .ui.@{color}.segment.segment.segment.segment.segment:not(.inverted) {
+      border-top: @coloredBorderSize solid @c;
+    }
+    .ui.inverted.@{color}.segment.segment.segment.segment.segment {
+      background-color: @c;
+      color: @white;
+    }
   }
 })
 


### PR DESCRIPTION
## Description
`secondary` is part of the new  central dynamic color map from #316.
Unfortunately there already was `secondary segment` and `secondary menu` available, but not meant as color variant resulting in different visual behavior as before.

To stay backward compatible, i simply removed `secondary` from the color creation loop in `segment` aswell as `menu`. For all other colorizable elements `secondary` is still available (as it is a new feature since 2.7.0)
I also removed `primary` for color creation in `segment` because it was also separately supported previously (even if not documented)
I kept `primary` for color creation in `menu` because it had no separate support before.
Tell me, if i should remove this for menu aswell


## Closes
#364 

## Version
2.7.1