### PR TITLE
[Label] Link icon cursors in corner labels did not work

### DIFF
--- a/src/definitions/elements/label.less
+++ b/src/definitions/elements/label.less
@@ -288,7 +288,7 @@ a.ui.label {
 }
 
 .ui.corner.label .icon {
-  cursor: default;
+  cursor: inherit;
   position: relative;
   top: @cornerIconTopOffset;
   left: @cornerIconLeftOffset;


### PR DESCRIPTION
## Description
 `link` icons which are contained within a `corner label` do not have the desired effect of setting `cursor:pointer`. 
This is a regression since 2015 by https://github.com/Semantic-Org/Semantic-UI/commit/958848847cd39e1efc8e69bcd06db067d3e277d5

The original intention to set `cursor:default`  was to prevent mouse selection (according to the commit message). However i was not able to reproduce this behavior :thinking: , maybe it was a  special browser fix.

To be save with this intention and still support the `pointer` if the label was created using an `a` tag, i changed the value to `inherit` instead. 

## Testcase
https://fomantic-ui.com/elements/label.html#corner

## Screenshot
### Unfixed
![label_corner_icon_cursor](https://user-images.githubusercontent.com/18379884/50799867-343d8f00-12de-11e9-9265-996c3398b2c4.gif)

### Fixed
![label_corner_icon_cursor_fixed](https://user-images.githubusercontent.com/18379884/50799871-3869ac80-12de-11e9-8cde-7821e45c4c98.gif)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/4238
https://github.com/Semantic-Org/Semantic-UI/issues/5299
https://github.com/Semantic-Org/Semantic-UI/issues/3809
