### PR TITLE
[Dropdown] Allow a real zero to be a selectable value in 'set selected'

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -2026,7 +2026,7 @@ $.fn.dropdown = function(parameters) {
               : (value !== undefined && value !== null)
             ;
             isMultiple = (module.is.multiple() && Array.isArray(value));
-            strict     = (value === '' || value === 0)
+            strict     = (value === '' || value === false  || value === true)
               ? true
               : strict || false
             ;


### PR DESCRIPTION
## Description
When dropdown list has an entry with given value "0", is is not selectable via `set selected` method

In the code, there already was a triple equal check, but this made a real 0 invalid resulting in always comparing String to Number (which of course is false)

## Testcase
### Unfixed (from original  SUI issue)
http://jsfiddle.net/budiadiono/fcsbashq/1/

### Fixed
http://jsfiddle.net/g0f7y9pq/

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5354
https://github.com/Semantic-Org/Semantic-UI/issues/5638
