### PR TITLE
[Dimmer] blurring dimmable leaves z-index stacking side effects

### DIFF
--- a/src/themes/default/modules/dimmer.variables
+++ b/src/themes/default/modules/dimmer.variables
@@ -20,7 +20,7 @@
 @textColor: @white;
 @overflow: hidden;
 
-@blurredStartFilter: e("blur(0px) grayscale(0)");
+@blurredStartFilter: initial;
 @blurredEndFilter: e("blur(5px) grayscale(0.7)");
 @blurredTransition: 800ms filter @defaultEasing;
 


### PR DESCRIPTION
## Description
Thanks to @mayfield for the Fix (me being a lazy dude kindly copied parts of his issue text :smile: here)

>For reference: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context

>The use of a filter CSS property will impose z-index stacking rules for an element. As such, when using a blurring modal dimmer there are side effects left over from having a filter property on the non-dimmed content. 

>This leads to unexpected stacking behavior for elements that would otherwise not have z-index stacking rules applied to them. One example being the use of menus with dropdowns following the open/close of a blurred modal.

## Testcase
http://jsfiddle.net/ncoa89yf/2/
- Remove the CSS and open the top dropdown to see the issue
- use the button to proove the transform filter is still animating (because the startfilter is changed in the PR)

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/18379884/50825667-e0609380-1339-11e9-98d4-dfa6649a740d.png)

### After
![image](https://user-images.githubusercontent.com/18379884/50825643-d048b400-1339-11e9-8762-43e4add889ab.png)

More screenshots in the original SUI issue below

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5416

