### PR TITLE
[Formvalidation] Radio buttons do not validate if the first is disabled

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -271,7 +271,7 @@ $.fn.form = function(parameters) {
             if(!$field || $field.length === 0) {
               return true;
             }
-            else if($field.is('input[type="checkbox"]')) {
+            else if($field.is(selector.checkbox)) {
               return !$field.is(':checked');
             }
             else {
@@ -980,17 +980,21 @@ $.fn.form = function(parameters) {
               module.debug('Using field name as identifier', identifier);
               field.identifier = identifier;
             }
-            if($field.prop('disabled')) {
+            var isDisabled = true;
+            $.each($field, function(){
+                if(!$(this).prop('disabled')) {
+                  isDisabled = false;
+                  return false;
+                }
+            });
+            if(isDisabled) {
               module.debug('Field is disabled. Skipping', identifier);
-              fieldValid = true;
             }
             else if(field.optional && module.is.blank($field)){
               module.debug('Field is optional and blank. Skipping', identifier);
-              fieldValid = true;
             }
             else if(field.depends && module.is.empty($dependsField)) {
               module.debug('Field depends on another value that is not present or empty. Skipping', $dependsField);
-              fieldValid = true;
             }
             else if(field.rules !== undefined) {
               $.each(field.rules, function(index, rule) {


### PR DESCRIPTION
## Description

- If the first option of a radio group was disabled the whole validation of that group was skipped
- Additional fix: `is empty` always returned `false` for empty radio button groups
- I also removed unnecessary sets of `fieldValid=true`..because it is initially `true` in all cases anyway

## Testcase
Follow the short info in the fiddles (TL;DR: press both buttons :smile: )
### Broken
https://jsfiddle.net/u2abzw3r/1/

### Fixed
https://jsfiddle.net/u2abzw3r/2/

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6511
