### PR TITLE
[Menu] Labels in secondary pointing menu items were misaligned

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -937,6 +937,11 @@ Floated Menu / Item
   border-bottom-width: 0;
 }
 
+.ui.secondary.pointing.menu .item > .label {
+  margin-top: -@labelVerticalPadding;
+  margin-bottom: -@labelVerticalPadding;
+}
+
 /* Item Types */
 .ui.secondary.pointing.menu .header.item {
   color: @secondaryPointingHeaderColor !important;

--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -941,6 +941,10 @@ Floated Menu / Item
   margin-top: -@labelVerticalPadding;
   margin-bottom: -@labelVerticalPadding;
 }
+.ui.secondary.pointing.menu .item > .circular.label {
+  margin-top: -@circularLabelVerticalPadding;
+  margin-bottom: -@circularLabelVerticalPadding;
+}
 
 /* Item Types */
 .ui.secondary.pointing.menu .header.item {

--- a/src/themes/default/collections/menu.variables
+++ b/src/themes/default/collections/menu.variables
@@ -119,6 +119,7 @@
 
 @labelTextMargin: 1em;
 @labelVerticalPadding: 0.3em;
+@circularLabelVerticalPadding: 0.5em; /* has to be equal to @circularPadding from label.less */
 @labelHorizontalPadding: @relativeMini;
 
 @labelAndIconFloat: none;


### PR DESCRIPTION
## Description
Putting an inline label for some, but not all menu items in a `secondary pointing menu` breaks the vertical alignment.
I labeled this as a bug rather than an enhancement as it was in the original SUI issue.

## Testcase
http://jsfiddle.net/mgy37rw5/
Remove the CSS to see the issue

## Screenshot
### Broken
![image](https://user-images.githubusercontent.com/18379884/50979194-4560e880-14f6-11e9-9c24-32942dbbc312.png)

### Fixed
![image](https://user-images.githubusercontent.com/18379884/50979164-3843f980-14f6-11e9-8590-b51a4310ee7c.png)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5959