### PR TITLE
[Menu] Wrong Border for inverted pointing menu removed and fix for secondary as color

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -1010,10 +1010,6 @@ Floated Menu / Item
   border-color: @secondaryPointingInvertedBorderColor;
 }
 
-.ui.secondary.inverted.pointing.menu {
-  border-width: @secondaryPointingBorderWidth;
-  border-color: @secondaryPointingBorderColor;
-}
 .ui.secondary.inverted.pointing.menu .item:not(.disabled) {
   color: @secondaryPointingInvertedItemTextColor;
 }
@@ -1416,15 +1412,17 @@ each(@colors, {
   @color: replace(@key, '@', '');
   @c: @colors[@@color][color];
 
-  .ui.inverted.menu .@{color}.active.item,
-  .ui.inverted.@{color}.menu {
-    background-color: @c;
-  }
-  .ui.inverted.@{color}.menu .item:before {
-    background-color: @invertedColoredDividerBackground;
-  }
-  .ui.inverted.@{color}.menu .active.item {
-    background-color: @invertedColoredActiveBackground;
+  & when not (@color=secondary) {
+    .ui.inverted.menu .@{color}.active.item,
+    .ui.inverted.@{color}.menu {
+      background-color: @c;
+    }
+    .ui.inverted.@{color}.menu .item:before {
+      background-color: @invertedColoredDividerBackground;
+    }
+    .ui.inverted.@{color}.menu .active.item {
+      background-color: @invertedColoredActiveBackground;
+    }
   }
 })
 


### PR DESCRIPTION
## Description
An `inverted secondary pointing menu` had a border set around the whole menu instead of only at the bottom as in the non-inverted variant. This was definately wrong (copy/paste) behavior, because the border-color class was doubled and had the non-inverted variable `@secondaryPointingBorderColor` instead of `@secondaryPointingInvertedBorderColor` set (which is again done one class definition later)
I guess in those (probably rarely used) cases where this combination was used, it was used with a black background, where the border was very hard to recognize. In a whole: It simply looked wrong and inconsistent to the non-inverted variant.

Additionally I also fixed the missing `inverted` color loop to omit the `secondary` value just like in #366 because `secondary` is used with a different meaning in `menu`

## Testcase
http://jsfiddle.net/efp8z6Ln/952/
Remove the CSS to see the previous behavior.

## Screenshot
### Before
![image](https://user-images.githubusercontent.com/18379884/50998193-013a0c00-1527-11e9-82c1-5f22b88e0b27.png)

### After
![image](https://user-images.githubusercontent.com/18379884/50998157-e9fb1e80-1526-11e9-80d4-c30c09274c20.png)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/4953
