### PR TITLE
[Formvalidation] Input array validations should respect each single field on its own

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -704,7 +704,7 @@ $.fn.form = function(parameters) {
             }
             validation = $.extend({}, validation, newValidation);
           },
-          prompt: function(identifier, errors) {
+          prompt: function(identifier, errors, internal) {
             var
               $field       = module.get.field(identifier),
               $fieldGroup  = $field.closest($group),
@@ -716,9 +716,11 @@ $.fn.form = function(parameters) {
               : errors
             ;
             module.verbose('Adding field error state', identifier);
-            $fieldGroup
-              .addClass(className.error)
-            ;
+            if(!internal) {
+              $fieldGroup
+                  .addClass(className.error)
+              ;
+            }
             if(settings.inline) {
               if(!promptExists) {
                 $prompt = settings.templates.prompt(errors);
@@ -997,11 +999,18 @@ $.fn.form = function(parameters) {
               module.debug('Field depends on another value that is not present or empty. Skipping', $dependsField);
             }
             else if(field.rules !== undefined) {
+              $field.closest($group).removeClass(className.error);
               $.each(field.rules, function(index, rule) {
-                if( module.has.field(identifier) && !( module.validate.rule(field, rule) ) ) {
-                  module.debug('Field is invalid', identifier, rule.type);
-                  fieldErrors.push(module.get.prompt(rule, field));
-                  fieldValid = false;
+                if( module.has.field(identifier)) {
+                  var invalidFields = module.validate.rule(field, rule,true) || [];
+                  if (invalidFields.length>0){
+                    module.debug('Field is invalid', identifier, rule.type);
+                    fieldErrors.push(module.get.prompt(rule, field));
+                    fieldValid = false;
+                    if(showErrors){
+                      $(invalidFields).closest($group).addClass(className.error);
+                    }
+                  }
                 }
               });
             }
@@ -1014,7 +1023,7 @@ $.fn.form = function(parameters) {
             else {
               if(showErrors) {
                 formErrors = formErrors.concat(fieldErrors);
-                module.add.prompt(identifier, fieldErrors);
+                module.add.prompt(identifier, fieldErrors, true);
                 settings.onInvalid.call($field, fieldErrors);
               }
               return false;
@@ -1023,14 +1032,15 @@ $.fn.form = function(parameters) {
           },
 
           // takes validation rule and returns whether field passes rule
-          rule: function(field, rule) {
+          rule: function(field, rule, internal) {
             var
               $field       = module.get.field(field.identifier),
               type         = rule.type,
               isValid      = true,
               ancillary    = module.get.ancillaryValue(rule),
               ruleName     = module.get.ruleName(rule),
-              ruleFunction = settings.rules[ruleName]
+              ruleFunction = settings.rules[ruleName],
+              invalidFields = []
             ;
             if( !$.isFunction(ruleFunction) ) {
               module.error(error.noRule, ruleName);
@@ -1044,9 +1054,11 @@ $.fn.form = function(parameters) {
                   : (settings.shouldTrim) ? $.trim(value + '') : String(value + '')
               ;
               isValid = ruleFunction.call(field, value, ancillary);
-              return isValid;
+              if (!isValid) {
+                invalidFields.push(field);
+              }
             });
-            return isValid;
+            return internal ? invalidFields : !(invalidFields.length>0);
           }
         },
 

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1027,7 +1027,6 @@ $.fn.form = function(parameters) {
             var
               $field       = module.get.field(field.identifier),
               type         = rule.type,
-              value        = $field.val(),
               isValid      = true,
               ancillary    = module.get.ancillaryValue(rule),
               ruleName     = module.get.ruleName(rule),
@@ -1037,12 +1036,17 @@ $.fn.form = function(parameters) {
               module.error(error.noRule, ruleName);
               return;
             }
-            // cast to string avoiding encoding special values
-            value = (value === undefined || value === '' || value === null)
-              ? ''
-              : (settings.shouldTrim) ? $.trim(value + '') : String(value + '')
-            ;
-            return ruleFunction.call($field, value, ancillary);
+            $.each($field, function(index,field){
+              var  value  = $(field).val();
+              // cast to string avoiding encoding special values
+              value = (value === undefined || value === '' || value === null)
+                  ? ''
+                  : (settings.shouldTrim) ? $.trim(value + '') : String(value + '')
+              ;
+              isValid = ruleFunction.call(field, value, ancillary);
+              return isValid;
+            });
+            return isValid;
           }
         },
 


### PR DESCRIPTION
## Description
If a form uses array inputs by appending brackets to their names ( `name="myfield[]"`) the validation on those fields was always done for the whole field group. Means, if the first field was valid, it validated for the whole group which is wrong.
This behavior is now fixed, so even if multiple input fields have the same name to act as array inputs, the validation is done on each field separately and also the error class is set/removed to each field individually.
@prudho was already providing a [PR for that in SUI](https://github.com/Semantic-Org/Semantic-UI/pull/6370) some time ago, but the individual error display handling was missing there.

> Hint: If you ask yourself while reviewing, why i added an `internal` parameter to the `add.prompt()`and `validate.rule()` functions: This is to make sure those functions are still callable  as behavior from separate JS (for example: `$('.foo').form('validate rule', argumentOne, argumentTwo)` so they do not break existing code

## Testcase
### Before
http://jsfiddle.net/a1cnph4f/
Try to click on submit to invalidate each the form. If any of the multiple fields is  invalid it won't get the error class.

### After
http://jsfiddle.net/a1cnph4f/1/
Correct behavior now: error class for each invalid field
 I also put a normal (single) field into the fiddle to make sure the usual behavior is still working.

Special testcase: Radiobuttons are also working (which **need** the behavior)
http://jsfiddle.net/47Lysubr/

## Screenshots
### Before
![inputarrays_wrong](https://user-images.githubusercontent.com/18379884/51074108-48391600-167b-11e9-99b2-5b60fe59b477.gif)

### After
![inputarrays_right](https://user-images.githubusercontent.com/18379884/51074110-4f602400-167b-11e9-96b5-ed44aa6ffa2b.gif)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6368
https://github.com/Semantic-Org/Semantic-UI/issues/2683
https://github.com/Semantic-Org/Semantic-UI/issues/2688
https://github.com/Semantic-Org/Semantic-UI/issues/5469
https://github.com/Semantic-Org/Semantic-UI/issues/829