### PR TITLE
[Label] Right icon should have correct margin when placed after text

### DIFF
--- a/src/definitions/elements/label.less
+++ b/src/definitions/elements/label.less
@@ -101,6 +101,7 @@ a.ui.label {
 }
 
 /* Backward compatible positioning */
+.ui.label:not(.icon) > .close.icon,
 .ui.label:not(.icon) > .delete.icon {
   margin: 0 0 0 @deleteMargin;
 }

--- a/src/definitions/elements/label.less
+++ b/src/definitions/elements/label.less
@@ -105,6 +105,20 @@ a.ui.label {
   opacity: 1;
 }
 
+/* Label for only an icon */
+.ui.icon.label > .icon {
+  margin: 0 auto;
+}
+
+/* Right Side Icon */
+.ui.right.icon.label > .icon {
+  margin: 0 0 0 @iconDistance;
+}
+.ui.right.icon.label > .close.icon,
+.ui.right.icon.label > .delete.icon {
+  margin: 0 0 0 @deleteMargin;
+}
+
 /*-------------------
        Group
 --------------------*/

--- a/src/definitions/elements/label.less
+++ b/src/definitions/elements/label.less
@@ -91,18 +91,16 @@ a.ui.label {
   margin: 0 @detailIconDistance 0 0;
 }
 
-/* Removable and Hoverable label */
+/* Removable label */
 .ui.label > .close.icon,
-.ui.label > .delete.icon,
-.ui.label > .hoverable.icon {
+.ui.label > .delete.icon {
   cursor: pointer;
   font-size: @deleteSize;
   opacity: @deleteOpacity;
   transition: @deleteTransition;
 }
 .ui.label > .close.icon:hover,
-.ui.label > .delete.icon:hover,
-.ui.label > .hoverable.icon:hover {
+.ui.label > .delete.icon:hover {
   opacity: 1;
 }
 

--- a/src/definitions/elements/label.less
+++ b/src/definitions/elements/label.less
@@ -73,6 +73,7 @@ a.ui.label {
 }
 
 /* Icon */
+.ui.left.icon.label > .icon,
 .ui.label > .icon {
   width: auto;
   margin: 0 @iconDistance 0 0;
@@ -101,6 +102,10 @@ a.ui.label {
 }
 
 /* Backward compatible positioning */
+.ui.label.left.icon > .close.icon,
+.ui.label.left.icon > .delete.icon {
+  margin: 0 @deleteMargin 0 0;
+}
 .ui.label:not(.icon) > .close.icon,
 .ui.label:not(.icon) > .delete.icon {
   margin: 0 0 0 @deleteMargin;

--- a/src/definitions/elements/label.less
+++ b/src/definitions/elements/label.less
@@ -90,13 +90,23 @@ a.ui.label {
   margin: 0 @detailIconDistance 0 0;
 }
 
-/* Hoverable label */
+/* Removable and Hoverable label */
+.ui.label > .close.icon,
+.ui.label > .delete.icon,
 .ui.label > .hoverable.icon {
   cursor: pointer;
   font-size: @deleteSize;
   opacity: @deleteOpacity;
   transition: @deleteTransition;
 }
+
+/* Backward compatible positioning */
+.ui.label:not(.icon) > .delete.icon {
+  margin: 0 0 0 @deleteMargin;
+}
+
+.ui.label > .close.icon:hover,
+.ui.label > .delete.icon:hover,
 .ui.label > .hoverable.icon:hover {
   opacity: 1;
 }

--- a/src/definitions/elements/label.less
+++ b/src/definitions/elements/label.less
@@ -100,6 +100,11 @@ a.ui.label {
   opacity: @deleteOpacity;
   transition: @deleteTransition;
 }
+.ui.label > .close.icon:hover,
+.ui.label > .delete.icon:hover,
+.ui.label > .hoverable.icon:hover {
+  opacity: 1;
+}
 
 /* Backward compatible positioning */
 .ui.label.left.icon > .close.icon,
@@ -109,12 +114,6 @@ a.ui.label {
 .ui.label:not(.icon) > .close.icon,
 .ui.label:not(.icon) > .delete.icon {
   margin: 0 0 0 @deleteMargin;
-}
-
-.ui.label > .close.icon:hover,
-.ui.label > .delete.icon:hover,
-.ui.label > .hoverable.icon:hover {
-  opacity: 1;
 }
 
 /* Label for only an icon */

--- a/src/definitions/elements/label.less
+++ b/src/definitions/elements/label.less
@@ -90,18 +90,14 @@ a.ui.label {
   margin: 0 @detailIconDistance 0 0;
 }
 
-
-/* Removable label */
-.ui.label > .close.icon,
-.ui.label > .delete.icon {
+/* Hoverable label */
+.ui.label > .hoverable.icon {
   cursor: pointer;
-  margin-right: 0;
-  margin-left: @deleteMargin;
   font-size: @deleteSize;
   opacity: @deleteOpacity;
   transition: @deleteTransition;
 }
-.ui.label > .delete.icon:hover {
+.ui.label > .hoverable.icon:hover {
   opacity: 1;
 }
 
@@ -113,10 +109,6 @@ a.ui.label {
 /* Right Side Icon */
 .ui.right.icon.label > .icon {
   margin: 0 0 0 @iconDistance;
-}
-.ui.right.icon.label > .close.icon,
-.ui.right.icon.label > .delete.icon {
-  margin: 0 0 0 @deleteMargin;
 }
 
 /*-------------------


### PR DESCRIPTION
## Description

This PR is based on https://github.com/Semantic-Org/Semantic-UI/pull/6210 by @w96k.

* Add `icon label` variation that allows to put an icon without text.
* Add `right icon label` variation that allows to put an icon in the right side of label with correct margin. 
* Add `left icon label` variation to let `delete icon` and `close icon` be placed in left with correct margin for backward-compatibility
* ~Add `hoverable` class that makes icon to be used for action, as same style as current `close`/`delete` icon have.~

## Testcase
### Before
https://jsfiddle.net/oLc3pqeu/

### After
https://jsfiddle.net/y4L7cadb/

## Screenshot (when possible)
### Normal Label
![image](https://user-images.githubusercontent.com/127635/51092248-741dde00-17d8-11e9-85bb-482d3e72ad89.png)


### Ribbon Label
![image](https://user-images.githubusercontent.com/127635/51081918-581a2e00-173f-11e9-9915-e64f24d59824.png)

## Closes
#222 
https://github.com/Semantic-Org/Semantic-UI/pull/6210
https://github.com/Semantic-Org/Semantic-UI/issues/5328
https://github.com/Semantic-Org/Semantic-UI/issues/5446
https://github.com/Semantic-Org/Semantic-UI/issues/5619
https://github.com/Semantic-Org/Semantic-UI/pull/6210
