### PR TITLE
[Dropdown] Use delete icon classname from settings instead of having it hardcoded

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -2705,7 +2705,7 @@ $.fn.dropdown = function(parameters) {
             $label =  $('<a />')
               .addClass(className.label)
               .attr('data-' + metadata.value, escapedValue)
-              .html(templates.label(escapedValue, text, settings.preserveHTML))
+              .html(templates.label(escapedValue, text, settings.preserveHTML, settings.className))
             ;
             $label = settings.onLabelCreate.call($label, escapedValue, text);
 
@@ -4005,7 +4005,8 @@ $.fn.dropdown.settings = {
     leftward    : 'left',
     visible     : 'visible',
     clearable   : 'clearable',
-    noselection : 'noselection'
+    noselection : 'noselection',
+    delete      : 'delete'
   }
 
 };
@@ -4095,10 +4096,10 @@ $.fn.dropdown.settings.templates = {
   },
 
   // generates label for multiselect
-  label: function(value, text, preserveHTML) {
+  label: function(value, text, preserveHTML, className) {
     var
         escape = $.fn.dropdown.settings.templates.escape;
-    return escape(text,preserveHTML) + '<i class="delete icon"></i>';
+    return escape(text,preserveHTML) + '<i class="'+className.delete+' icon"></i>';
   },
 
 


### PR DESCRIPTION
## Description
While discovering #383 it turns out, the `delete` icon is hardcoded in the template for labels.
Although you are able to change the selector for this via settings, you cannot for the icon class itself, but would have to provide the whole template for labels instead, just to be able to use another iconname

This PR changes the label-template to fetch the classname for the delete icon from the settings instead

## Relates
#383 
