### PR TITLE
[Popup] correct tooltip z-index value

### DIFF
--- a/src/themes/default/modules/popup.variables
+++ b/src/themes/default/modules/popup.variables
@@ -45,7 +45,7 @@
 
 /* Arrow */
 @arrowBackground: @background;
-@arrowZIndex: 3;
+@arrowZIndex: 1901;
 @arrowJitter: 0.05em;
 @arrowOffset: -(@arrowSize / 2) + @arrowJitter;
 
@@ -79,7 +79,7 @@
 @tooltipFontSize: @medium;
 @tooltipLineHeight: @lineHeight;
 @tooltipDistanceAway: @relative7px;
-@tooltipZIndex: 2;
+@tooltipZIndex: 1900;
 @tooltipDuration: @defaultDuration;
 @tooltipEasing: @defaultEasing;
 


### PR DESCRIPTION
## Description
Changed the tooltip `z-index` to be the same as standard popup which forces it to appear on top of other components such as sticky elements.

## Testcase
https://jsfiddle.net/95f1wmL8/

## Screenshot (when possible)
![]()
![image](https://user-images.githubusercontent.com/11588822/51115736-0803a000-1801-11e9-8bbd-5e8c7eea63d9.png)

## Closes
#394
