### PR TITLE
[Step] make steps wrap by default as intended for single step

### DIFF
--- a/src/definitions/elements/step.less
+++ b/src/definitions/elements/step.less
@@ -29,6 +29,7 @@
 .ui.steps {
   display: inline-flex;
   flex-direction: row;
+  flex-wrap: wrap;
   align-items: stretch;
   margin: @stepMargin;
   background: @stepsBackground;

--- a/src/definitions/elements/step.less
+++ b/src/definitions/elements/step.less
@@ -29,7 +29,6 @@
 .ui.steps {
   display: inline-flex;
   flex-direction: row;
-  flex-wrap: wrap;
   align-items: stretch;
   margin: @stepMargin;
   background: @stepsBackground;
@@ -37,6 +36,9 @@
   line-height: @lineHeight;
   border-radius: @stepsBorderRadius;
   border: @stepsBorder;
+}
+.ui.steps:not(.unstackable) {
+  flex-wrap: wrap;
 }
 
 /* First Steps */


### PR DESCRIPTION
## Description
A huge amount of steps were overflowing the viewport if the amount of steps was not explicit given as classname. It was already intended to wrap (a single step already got `flex-wrap:wrap`), but it was missing for grouping by using `steps`.

This is ignored when `unstackable steps` is used because a possible overflow is wanted behavior.

If a step amount is given to the group (`six steps`), the behavior stays as before: Each step will reduce itself to stay inline. (Also part of the testcase below)

## Testcase
http://jsfiddle.net/v8yrgs6t/
Remove the CSS to see the issue

## Screenshot
### Before
![image](https://user-images.githubusercontent.com/18379884/51196029-9144d080-18ee-11e9-9d9d-5d40e702a5ca.png)

### After
![image](https://user-images.githubusercontent.com/18379884/51196006-7eca9700-18ee-11e9-91e0-3a1290be1e15.png)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/4880
https://github.com/Semantic-Org/Semantic-UI-React/issues/1114
