### PR TITLE
[Segment] Introducing stackable horizontal segments

### DIFF
--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -412,6 +412,9 @@
   border-radius: @borderRadius;
   border: @border;
 }
+.ui.stackable.horizontal.segments {
+  flex-wrap: wrap;
+}
 
 /* Nested Horizontal Group */
 .ui.segments > .horizontal.segments {

--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -443,7 +443,7 @@
 .ui.segments > .horizontal.segments:first-child {
   border-top: none;
 }
-.ui.horizontal.segments > .segment:first-child {
+.ui.horizontal.segments:not(.stackable) > .segment:first-child {
   border-left: none;
 }
 


### PR DESCRIPTION
## Description
Added `stackable` variant to `horizontal segments` to make those segments wrap if needed

## Testcase
http://jsfiddle.net/tmxLgno1/2/
Remove CSS to see usual behavior without stackable support

## Screenshot
### _Normal behavior_: `.ui.horizontal.segments`
![image](https://user-images.githubusercontent.com/18379884/51214713-029c7780-191f-11e9-8591-7ca6e0c9178c.png)


### _New behavior_: `.ui.stackable.horizontal.segments`
![image](https://user-images.githubusercontent.com/18379884/51214696-f31d2e80-191e-11e9-8178-91b66dc3ed92.png)




