### PR TITLE
[Checkbox] Call onChange only once and dont at all on "set checked" (and others)

### DIFF
--- a/src/definitions/modules/checkbox.js
+++ b/src/definitions/modules/checkbox.js
@@ -261,7 +261,7 @@ $.fn.checkbox = function(parameters) {
           module.set.checked();
           if( !module.should.ignoreCallbacks() ) {
             settings.onChecked.call(input);
-            settings.onChange.call(input);
+            module.trigger.change();
           }
         },
 
@@ -273,7 +273,7 @@ $.fn.checkbox = function(parameters) {
           module.set.unchecked();
           if( !module.should.ignoreCallbacks() ) {
             settings.onUnchecked.call(input);
-            settings.onChange.call(input);
+            module.trigger.change();
           }
         },
 
@@ -286,7 +286,7 @@ $.fn.checkbox = function(parameters) {
           module.set.indeterminate();
           if( !module.should.ignoreCallbacks() ) {
             settings.onIndeterminate.call(input);
-            settings.onChange.call(input);
+            module.trigger.change();
           }
         },
 
@@ -299,7 +299,7 @@ $.fn.checkbox = function(parameters) {
           module.set.determinate();
           if( !module.should.ignoreCallbacks() ) {
             settings.onDeterminate.call(input);
-            settings.onChange.call(input);
+            module.trigger.change();
           }
         },
 
@@ -310,9 +310,12 @@ $.fn.checkbox = function(parameters) {
           }
           module.debug('Enabling checkbox');
           module.set.enabled();
-          settings.onEnable.call(input);
-          // preserve legacy callbacks
-          settings.onEnabled.call(input);
+          if( !module.should.ignoreCallbacks() ) {
+            settings.onEnable.call(input);
+            // preserve legacy callbacks
+            settings.onEnabled.call(input);
+            module.trigger.change();
+          }
         },
 
         disable: function() {
@@ -322,9 +325,12 @@ $.fn.checkbox = function(parameters) {
           }
           module.debug('Disabling checkbox');
           module.set.disabled();
-          settings.onDisable.call(input);
-          // preserve legacy callbacks
-          settings.onDisabled.call(input);
+          if( !module.should.ignoreCallbacks() ) {
+            settings.onDisable.call(input);
+            // preserve legacy callbacks
+            settings.onDisabled.call(input);
+            module.trigger.change();
+          }
         },
 
         get: {
@@ -453,7 +459,6 @@ $.fn.checkbox = function(parameters) {
               .prop('indeterminate', false)
               .prop('checked', true)
             ;
-            module.trigger.change();
           },
           unchecked: function() {
             module.verbose('Removing checked class');
@@ -470,7 +475,6 @@ $.fn.checkbox = function(parameters) {
               .prop('indeterminate', false)
               .prop('checked', false)
             ;
-            module.trigger.change();
           },
           indeterminate: function() {
             module.verbose('Setting class to indeterminate');
@@ -485,7 +489,6 @@ $.fn.checkbox = function(parameters) {
             $input
               .prop('indeterminate', true)
             ;
-            module.trigger.change();
           },
           determinate: function() {
             module.verbose('Removing indeterminate class');
@@ -514,7 +517,6 @@ $.fn.checkbox = function(parameters) {
             $input
               .prop('disabled', 'disabled')
             ;
-            module.trigger.change();
           },
           enabled: function() {
             module.verbose('Removing disabled class');
@@ -527,7 +529,6 @@ $.fn.checkbox = function(parameters) {
             $input
               .prop('disabled', false)
             ;
-            module.trigger.change();
           },
           tabbable: function() {
             module.verbose('Adding tabindex to checkbox');

--- a/src/definitions/modules/checkbox.js
+++ b/src/definitions/modules/checkbox.js
@@ -222,11 +222,11 @@ $.fn.checkbox = function(parameters) {
             }
 
             if (!module.should.ignoreCallbacks() && checkIndex !== false) {
-              if(!settings.beforeUnchecked.apply(input)) {
+              if(settings.beforeUnchecked.apply(input)===false) {
                 module.verbose('Option not allowed to be unchecked, cancelling key navigation');
                 return false;
               }
-              if (!settings.beforeChecked.apply($(r[checkIndex]).children(selector.input)[0])) {
+              if (settings.beforeChecked.apply($(r[checkIndex]).children(selector.input)[0])===false) {
                 module.verbose('Next option should not allow check, cancelling key navigation');
                 return false;
               }


### PR DESCRIPTION
## Description
The keypoint here is, that this PR basically fixes a very old behavior in SUI:
According to the docs the behaviors `set checked|unchecked|enabled|disabled|determinate|indeterminate` are not supposed to run callbacks. But they actually always did (!) They ever since triggered the `change event`, but it never had any impact, just because the module itself did not have any `onChange` event until #295
That said, in conclusion the onchange event was now called twice: In the `set` methods aswell as in the `module` methods. :disappointed:  The onChange event has to be kept, otherwise the keynav will not notify any change to the event system, so i removed the (wrong) event triggering in the above mentioned behavior functions and put them outside instead.

In addition i also hotfixed #295, because the beforeChecked/Unchecked methods were not called correctly 

## Testcase
#399
https://jsfiddle.net/7vjLsr1f/

#400
https://jsfiddle.net/3sbreo71/


## Closes
#399 
#400
