### PR TITLE
[Label] Content in floating labels should not wrap whitespace

### DIFF
--- a/src/definitions/elements/label.less
+++ b/src/definitions/elements/label.less
@@ -894,8 +894,10 @@ each(@colors,{
   position: absolute;
   z-index: @floatingZIndex;
   top: @floatingTopOffset;
-  left: 100%;
+  right: 0;
   margin: 0 0 0 @floatingLeftOffset !important;
+  white-space: nowrap;
+  transform: translateX(50%);
 }
 
 /*-------------------


### PR DESCRIPTION
## Description
If a `floating label` had whitespace inside, especially when including icons, it did not stay inline. This happens for every whitespace.

To make it still look consistent even if the label content is a bit larger, i also made the label centered to the top right corner of the parent element, 

## Testcase
http://jsfiddle.net/k1qp7dgv/3/
Remove CSS to see the issue

## Screenshot
#### Before
![image](https://user-images.githubusercontent.com/18379884/51302769-9bbcb280-1a33-11e9-827d-2ea01092a51f.png)

#### After
![image](https://user-images.githubusercontent.com/18379884/51302745-8d6e9680-1a33-11e9-8e0d-b389956f1bbb.png)


## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/4217
https://github.com/Semantic-Org/Semantic-UI/issues/4155
