### PR TITLE
[Menu] Increased color specificity to override secondary menu default colors

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -1294,8 +1294,8 @@ each(@colors, {
   @c: @colors[@@color][color];
 
   & when not (@color=secondary) {
-    .ui.menu .@{color}.active.item,
-    .ui.@{color}.menu .active.item {
+    .ui.ui.menu .@{color}.active.item,
+    .ui.ui.@{color}.menu .active.item {
       border-color: @c;
       color: @c;
     }
@@ -1422,14 +1422,14 @@ each(@colors, {
   @c: @colors[@@color][color];
 
   & when not (@color=secondary) {
-    .ui.inverted.menu .@{color}.active.item,
-    .ui.inverted.@{color}.menu {
+    .ui.ui.inverted.menu .@{color}.active.item,
+    .ui.ui.inverted.@{color}.menu {
       background-color: @c;
     }
     .ui.inverted.@{color}.menu .item:before {
       background-color: @invertedColoredDividerBackground;
     }
-    .ui.inverted.@{color}.menu .active.item {
+    .ui.ui.inverted.@{color}.menu .active.item {
       background-color: @invertedColoredActiveBackground;
     }
   }


### PR DESCRIPTION
## Description
using a `secondary pointing menu` together with a color was still showing the default colors of a `secondary menu` because of too low specificity

## Testcase
https://jsfiddle.net/uvg6e4af/
Remove CSS to see issue

The fiddle cointains the inverted variant aswell which also includes the fixes from #380

## Screenshot
### Before
![image](https://user-images.githubusercontent.com/18379884/51325977-70a38480-1a6e-11e9-8632-6bcd951ea5da.png)

### After
![image](https://user-images.githubusercontent.com/18379884/51325666-b875dc00-1a6d-11e9-8105-d21b9175bdf6.png)

## Closes
#406 
