### PR TITLE
[Progress] Fix 0% display and  "inverted indicating" label color 

### DIFF
--- a/src/definitions/modules/progress.js
+++ b/src/definitions/modules/progress.js
@@ -122,14 +122,14 @@ $.fn.progress = function(parameters) {
               module.debug('Total value set from metadata', data.total);
               module.set.total(data.total);
             }
-            if(data.percent) {
-              module.debug('Current percent value set from metadata', data.percent);
-              module.set.percent(data.percent);
-            }
-            if(data.value) {
+            if(!isNaN(data.value)) {
               module.debug('Current value set from metadata', data.value);
               module.set.value(data.value);
               module.set.progress(data.value);
+            }
+            if(!isNaN(data.percent)) {
+              module.debug('Current percent value set from metadata', data.percent);
+              module.set.percent(data.percent);
             }
           },
           settings: function() {

--- a/src/definitions/modules/progress.js
+++ b/src/definitions/modules/progress.js
@@ -118,13 +118,13 @@ $.fn.progress = function(parameters) {
                 value   : $module.data(metadata.value)
               }
             ;
-            if(data.percent) {
-              module.debug('Current percent value set from metadata', data.percent);
-              module.set.percent(data.percent);
-            }
             if(data.total) {
               module.debug('Total value set from metadata', data.total);
               module.set.total(data.total);
+            }
+            if(data.percent) {
+              module.debug('Current percent value set from metadata', data.percent);
+              module.set.percent(data.percent);
             }
             if(data.value) {
               module.debug('Current value set from metadata', data.value);

--- a/src/definitions/modules/progress.less
+++ b/src/definitions/modules/progress.less
@@ -62,7 +62,7 @@
 .ui.progress[data-percent="0"] .bar .progress {
   color: @textColor;
 }
-.ui.progress[data-percent="0"] .bar .progress {
+.ui.inverted.progress[data-percent="0"] .bar .progress {
   color: @invertedTextColor;
 }
 

--- a/src/definitions/modules/progress.less
+++ b/src/definitions/modules/progress.less
@@ -56,6 +56,15 @@
   border-radius: @barBorderRadius;
   transition: @barTransition;
 }
+.ui.progress[data-percent="0"] .bar {
+  background:transparent;
+}
+.ui.progress[data-percent="0"] .bar .progress {
+  color: @textColor;
+}
+.ui.progress[data-percent="0"] .bar .progress {
+  color: @invertedTextColor;
+}
 
 /* Percent Complete */
 .ui.progress .bar > .progress {
@@ -145,6 +154,30 @@
   color: @indicatingSixthLabelColor;
 }
 
+/* Inverted Indicating Label */
+.ui.inverted.indicating.progress[data-percent^="1"] .label,
+.ui.inverted.indicating.progress[data-percent^="2"] .label {
+  color: @invertedIndicatingFirstLabelColor;
+}
+.ui.inverted.indicating.progress[data-percent^="3"] .label {
+  color: @invertedIndicatingSecondLabelColor;
+}
+.ui.inverted.indicating.progress[data-percent^="4"] .label,
+.ui.inverted.indicating.progress[data-percent^="5"] .label {
+  color: @invertedIndicatingThirdLabelColor;
+}
+.ui.inverted.indicating.progress[data-percent^="6"] .label {
+  color: @invertedIndicatingFourthLabelColor;
+}
+.ui.inverted.indicating.progress[data-percent^="7"] .label,
+.ui.inverted.indicating.progress[data-percent^="8"] .label {
+  color: @invertedIndicatingFifthLabelColor;
+}
+.ui.inverted.indicating.progress[data-percent^="9"] .label,
+.ui.inverted.indicating.progress[data-percent^="100"] .label {
+  color: @invertedIndicatingSixthLabelColor;
+}
+
 /* Single Digits */
 .ui.indicating.progress[data-percent="1"] .bar,
 .ui.indicating.progress[data-percent="2"] .bar,
@@ -157,6 +190,7 @@
 .ui.indicating.progress[data-percent="9"] .bar {
   background-color: @indicatingFirstColor;
 }
+.ui.indicating.progress[data-percent="0"] .label,
 .ui.indicating.progress[data-percent="1"] .label,
 .ui.indicating.progress[data-percent="2"] .label,
 .ui.indicating.progress[data-percent="3"] .label,
@@ -168,9 +202,21 @@
 .ui.indicating.progress[data-percent="9"] .label {
   color: @indicatingFirstLabelColor;
 }
+.ui.inverted.indicating.progress[data-percent="0"] .label,
+.ui.inverted.indicating.progress[data-percent="1"] .label,
+.ui.inverted.indicating.progress[data-percent="2"] .label,
+.ui.inverted.indicating.progress[data-percent="3"] .label,
+.ui.inverted.indicating.progress[data-percent="4"] .label,
+.ui.inverted.indicating.progress[data-percent="5"] .label,
+.ui.inverted.indicating.progress[data-percent="6"] .label,
+.ui.inverted.indicating.progress[data-percent="7"] .label,
+.ui.inverted.indicating.progress[data-percent="8"] .label,
+.ui.inverted.indicating.progress[data-percent="9"] .label {
+  color: @invertedIndicatingFirstLabelColor;
+}
 
 /* Indicating Success */
-.ui.indicating.progress.success .label {
+.ui.ui.indicating.progress.success .label {
   color: @successHeaderColor;
 }
 
@@ -184,11 +230,11 @@
 ---------------*/
 
 .ui.progress.success .bar {
-  background-color: @successColor !important;
+  background-color: @successColor;
 }
-.ui.progress.success .bar,
-.ui.progress.success .bar::after {
-  animation: none !important;
+.ui.ui.progress.success .bar,
+.ui.ui.progress.success .bar::after {
+  animation: none;
 }
 .ui.progress.success > .label {
   color: @successHeaderColor;
@@ -199,11 +245,11 @@
 ---------------*/
 
 .ui.progress.warning .bar {
-  background-color: @warningColor !important;
+  background-color: @warningColor;
 }
-.ui.progress.warning .bar,
-.ui.progress.warning .bar::after {
-  animation: none !important;
+.ui.ui.progress.warning .bar,
+.ui.ui.progress.warning .bar::after {
+  animation: none;
 }
 .ui.progress.warning > .label {
   color: @warningHeaderColor;
@@ -214,11 +260,11 @@
 ---------------*/
 
 .ui.progress.error .bar {
-  background-color: @errorColor !important;
+  background-color: @errorColor;
 }
-.ui.progress.error .bar,
-.ui.progress.error .bar::after {
-  animation: none !important;
+.ui.ui.progress.error .bar,
+.ui.ui.progress.error .bar::after {
+  animation: none;
 }
 .ui.progress.error > .label {
   color: @errorHeaderColor;
@@ -266,9 +312,9 @@
 .ui.disabled.progress {
   opacity: 0.35;
 }
-.ui.disabled.progress .bar,
-.ui.disabled.progress .bar::after {
-  animation: none !important;
+.ui.ui.disabled.progress .bar,
+.ui.ui.disabled.progress .bar::after {
+  animation: none;
 }
 
 

--- a/src/themes/default/modules/progress.variables
+++ b/src/themes/default/modules/progress.variables
@@ -79,6 +79,13 @@
 @indicatingFifthLabelColor: @textColor;
 @indicatingSixthLabelColor: @textColor;
 
+@invertedIndicatingFirstLabelColor: @invertedTextColor;
+@invertedIndicatingSecondLabelColor: @invertedTextColor;
+@invertedIndicatingThirdLabelColor: @invertedTextColor;
+@invertedIndicatingFourthLabelColor: @invertedTextColor;
+@invertedIndicatingFifthLabelColor: @invertedTextColor;
+@invertedIndicatingSixthLabelColor: @invertedTextColor;
+
 /*-------------------
         States
 --------------------*/


### PR DESCRIPTION
## Description
When using `progress` 
### Fix 1
 Trying to display "0%" was not recognized when given as a `data-percent` or `data-value` attribute. 0 was recognized as "false", thus it was not displayed at all.

### Fix 2
Even when 0% was displayed (using JS), the progressbar already has increased to 2em, because this is set as min-width. Reason because of this is obviously to force the percentage display any time, as the text is inside the bar and would vanish if the bar itself would had a width of 0%. 
To still show "0%" but also have the bar disappear to definately show zero progress, the background color is now simply transparent when the value is 0%. Percentages >0% will show the progressbar as before.

### Fix 3
If the progress was `inverted indicating` the label below the bar was set to black. Simply because there wasn't a separate setting for the inverted variant.

In addition i replaced some `!import` settings by proper specificity classes

## Testcase
### Broken
http://jsfiddle.net/2a8gqb3d/

### Fixed
http://jsfiddle.net/e2mj4fg8/

## Screenshot
### Broken
![image](https://user-images.githubusercontent.com/18379884/51411976-40411080-1b6a-11e9-9553-65fc26f0bd4e.png)

### Fixed
![image](https://user-images.githubusercontent.com/18379884/51412019-7088af00-1b6a-11e9-8922-170dd6a56b95.png)


## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6341
https://github.com/Semantic-Org/Semantic-UI/issues/6445
https://github.com/Semantic-Org/Semantic-UI/pull/6297
https://github.com/Semantic-Org/Semantic-UI-React/issues/2672
