### PR TITLE
[Text] Added sizes identically to icon

### DIFF
--- a/src/definitions/elements/text.less
+++ b/src/definitions/elements/text.less
@@ -40,4 +40,30 @@ span.ui.disabled.text {
   opacity: @disabledOpacity;
 }
 
+/* Sizes */
+span.ui.mini.text {
+  font-size: @mini;
+}
+span.ui.tiny.text {
+  font-size: @tiny;
+}
+span.ui.small.text {
+  font-size: @small;
+}
+span.ui.medium.text {
+  font-size: @medium;
+}
+span.ui.large.text {
+  font-size: @large;
+}
+span.ui.big.text {
+  font-size: @big;
+}
+span.ui.huge.text {
+  font-size: @huge;
+}
+span.ui.massive.text {
+  font-size: @massive;
+}
+
 .loadUIOverrides();

--- a/src/themes/default/elements/text.variables
+++ b/src/themes/default/elements/text.variables
@@ -5,3 +5,12 @@
 /*-------------------
        Element
 --------------------*/
+@mini: 0.4em;
+@tiny: 0.5em;
+@small: 0.75em;
+@medium: 1em;
+@large: 1.5em;
+@big: 2em;
+@huge: 4em;
+@massive: 8em;
+


### PR DESCRIPTION
## Description
Added support for `text` sizes. The same as for `icon` to have the same flow

## Testcase
https://jsfiddle.net/dehuotga/

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/51459748-dbe4a380-1d59-11e9-9e1f-7210d8a8f43a.png)

## Closes
#413 
