### PR TITLE
[Validation] Supply checked radio value to custom rule

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1040,8 +1040,9 @@ $.fn.form = function(parameters) {
               ruleName     = module.get.ruleName(rule),
               ruleFunction = settings.rules[ruleName],
               invalidFields = [],
+              isRadio = $field.is(selector.radio),
               isValid = function(field){
-                var value = $(field).val();
+                var value = (isRadio ? $(field).filter(':checked').val() : $(field).val());
                 // cast to string avoiding encoding special values
                 value = (value === undefined || value === '' || value === null)
                     ? ''
@@ -1054,7 +1055,7 @@ $.fn.form = function(parameters) {
               module.error(error.noRule, ruleName);
               return;
             }
-            if($field.is(selector.radio)) {
+            if(isRadio) {
               if (!isValid($field)) {
                 invalidFields = $field;
               }

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -704,7 +704,7 @@ $.fn.form = function(parameters) {
             }
             validation = $.extend({}, validation, newValidation);
           },
-          prompt: function(identifier, errors) {
+          prompt: function(identifier, errors, internal) {
             var
               $field       = module.get.field(identifier),
               $fieldGroup  = $field.closest($group),
@@ -716,9 +716,11 @@ $.fn.form = function(parameters) {
               : errors
             ;
             module.verbose('Adding field error state', identifier);
-            $fieldGroup
-              .addClass(className.error)
-            ;
+            if(!internal) {
+              $fieldGroup
+                  .addClass(className.error)
+              ;
+            }
             if(settings.inline) {
               if(!promptExists) {
                 $prompt = settings.templates.prompt(errors);
@@ -997,11 +999,18 @@ $.fn.form = function(parameters) {
               module.debug('Field depends on another value that is not present or empty. Skipping', $dependsField);
             }
             else if(field.rules !== undefined) {
+              $field.closest($group).removeClass(className.error);
               $.each(field.rules, function(index, rule) {
-                if( module.has.field(identifier) && !( module.validate.rule(field, rule) ) ) {
-                  module.debug('Field is invalid', identifier, rule.type);
-                  fieldErrors.push(module.get.prompt(rule, field));
-                  fieldValid = false;
+                if( module.has.field(identifier)) {
+                  var invalidFields = module.validate.rule(field, rule,true) || [];
+                  if (invalidFields.length>0){
+                    module.debug('Field is invalid', identifier, rule.type);
+                    fieldErrors.push(module.get.prompt(rule, field));
+                    fieldValid = false;
+                    if(showErrors){
+                      $(invalidFields).closest($group).addClass(className.error);
+                    }
+                  }
                 }
               });
             }
@@ -1014,7 +1023,7 @@ $.fn.form = function(parameters) {
             else {
               if(showErrors) {
                 formErrors = formErrors.concat(fieldErrors);
-                module.add.prompt(identifier, fieldErrors);
+                module.add.prompt(identifier, fieldErrors, true);
                 settings.onInvalid.call($field, fieldErrors);
               }
               return false;
@@ -1023,14 +1032,15 @@ $.fn.form = function(parameters) {
           },
 
           // takes validation rule and returns whether field passes rule
-          rule: function(field, rule) {
+          rule: function(field, rule, internal) {
             var
               $field       = module.get.field(field.identifier),
               type         = rule.type,
               isValid      = true,
               ancillary    = module.get.ancillaryValue(rule),
               ruleName     = module.get.ruleName(rule),
-              ruleFunction = settings.rules[ruleName]
+              ruleFunction = settings.rules[ruleName],
+              invalidFields = []
             ;
             if( !$.isFunction(ruleFunction) ) {
               module.error(error.noRule, ruleName);
@@ -1044,9 +1054,11 @@ $.fn.form = function(parameters) {
                   : (settings.shouldTrim) ? $.trim(value + '') : String(value + '')
               ;
               isValid = ruleFunction.call(field, value, ancillary);
-              return isValid;
+              if (!isValid) {
+                invalidFields.push(field);
+              }
             });
-            return isValid;
+            return internal ? invalidFields : !(invalidFields.length>0);
           }
         },
 

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1027,7 +1027,6 @@ $.fn.form = function(parameters) {
             var
               $field       = module.get.field(field.identifier),
               type         = rule.type,
-              value        = $field.val(),
               isValid      = true,
               ancillary    = module.get.ancillaryValue(rule),
               ruleName     = module.get.ruleName(rule),
@@ -1037,12 +1036,17 @@ $.fn.form = function(parameters) {
               module.error(error.noRule, ruleName);
               return;
             }
-            // cast to string avoiding encoding special values
-            value = (value === undefined || value === '' || value === null)
-              ? ''
-              : (settings.shouldTrim) ? $.trim(value + '') : String(value + '')
-            ;
-            return ruleFunction.call($field, value, ancillary);
+            $.each($field, function(index,field){
+              var  value  = $(field).val();
+              // cast to string avoiding encoding special values
+              value = (value === undefined || value === '' || value === null)
+                  ? ''
+                  : (settings.shouldTrim) ? $.trim(value + '') : String(value + '')
+              ;
+              isValid = ruleFunction.call(field, value, ancillary);
+              return isValid;
+            });
+            return isValid;
           }
         },
 


### PR DESCRIPTION
# Description
Using a custom rule for a radio button to validate against a given value of each radio was not working because the value was always taken from the first radio button of the group.
This is now fixed to supply the individual value from the actually checked radio button.

## Testcase
### Broken
https://jsfiddle.net/3568sfau/

### Fixed
https://jsfiddle.net/3568sfau/1/

## Screenshot
 Taken from the fiddles above: After Validating the received value is displayed underneath the button.

### Broken
Always receives "yes", regardless which radio button was checked:

![radio_value_broken](https://user-images.githubusercontent.com/18379884/51537358-9c4bb380-1e4e-11e9-8ba6-20310c6385a6.gif)

### Fixed
Correctly receives "yes" if the first radio button is checked and receives "no" when the second radio button is checked:

![radio_value_fixed](https://user-images.githubusercontent.com/18379884/51537363-a077d100-1e4e-11e9-8027-2bc0036af0fb.gif)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6194
