### PR TITLE
[Dropdown] Sanitize possible given text values

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -4077,7 +4077,7 @@ $.fn.dropdown.settings.templates = {
       if( itemType === 'item' ) {
         var
           maybeText = (option[fields.text])
-            ? 'data-text="' + option[fields.text] + '"'
+            ? ' data-text="' + String(option[fields.text]).replace(/"/g,"") + '"'
             : '',
           maybeDisabled = (option[fields.disabled])
             ? className.disabled+' '


### PR DESCRIPTION
## Description
Slightly fixed a theoretical vulnerability if text-values for inline dropdowns are given. As we did it everywhere else, this is simply done by removing any double existing double quotes for a `data-text` value.
However, pure HTML Code injection was already sanitized when `preserveHTML` was used.
