### PR TITLE
[Progress] Don't show min-width progress bar when module was not initialized

### DIFF
--- a/src/definitions/modules/progress.less
+++ b/src/definitions/modules/progress.less
@@ -56,6 +56,7 @@
   border-radius: @barBorderRadius;
   transition: @barTransition;
 }
+.ui.progress:not([data-percent]) .bar,
 .ui.progress[data-percent="0"] .bar {
   background:transparent;
 }


### PR DESCRIPTION
## Description
Progressbars which have not been initialized by javascript or don't have the `data-percent` attribute set (which will be set on initialization) still showed the min-width progressbar background.

## Testcase
https://jsfiddle.net/ba51wkjm/

## Closes
#424 
