### PR TITLE
[Label] Introducing bottom floating label

### DIFF
--- a/src/definitions/elements/label.less
+++ b/src/definitions/elements/label.less
@@ -909,6 +909,10 @@ each(@colors,{
 .ui.left.aligned.floating.label {
   transform: translateX(-@floatingAlignOffset);
 }
+.ui.bottom.floating.label {
+  top: auto;
+  bottom: @floatingBottomOffset;
+}
 
 /*-------------------
         Sizes

--- a/src/themes/default/elements/label.variables
+++ b/src/themes/default/elements/label.variables
@@ -236,6 +236,7 @@
 
 /* Floating */
 @floatingTopOffset: -1em;
+@floatingBottomOffset: @floatingTopOffset;
 @floatingAlignOffset: 1.2em;
 @floatingZIndex: 100;
 


### PR DESCRIPTION
## Description
In addition to #418 and suggested in #429 by @etshy this PR adds support to all `.floating.label` variants to be shown at the bottom instead of the top

 ```css
.ui.bottom.floating.label{}
.ui.bottom.left.floating.label{}
.ui.bottom.left.aligned.floating.label{}
.ui.bottom.right.floating.label{}
.ui.bottom.right.aligned.floating.label{}
 ```

## Testcase
http://jsfiddle.net/tjuwcr8h/

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/51800685-04c1d880-2233-11e9-83d5-371b923e2704.png)

