### PR TITLE
[Modal] Option to make restoring focus, after a modal hides ,optional

### DIFF
--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -592,7 +592,7 @@ $.fn.modal = function(parameters) {
 
         restore: {
           focus: function() {
-            if($focusedElement && $focusedElement.length > 0) {
+            if($focusedElement && $focusedElement.length > 0 && settings.restoreFocus) {
               $focusedElement.focus();
             }
           }
@@ -1036,6 +1036,7 @@ $.fn.modal.settings = {
   detachable     : true,
   closable       : true,
   autofocus      : true,
+  restoreFocus   : true,
 
   inverted       : false,
   blurring       : false,


### PR DESCRIPTION
## Description
Before a modal is shown, it saves the current focussed element and restores it, after the modal was hidden again.
In some cases this might be unwanted behavior, like in https://github.com/Semantic-Org/Semantic-UI/issues/6198 , where i also adopted the Testcase, so i made refocus now optional by implementing a new option `restoreFocus` (default true to keep current behavior)

## Testcase
https://jsfiddle.net/3nmLycdr/
This was taken and adjusted from the original PR
- Make sure the viewport is small enough, so you must scroll down and the calendar won't be shown completely in the viewport
- Scroll down to the calendar
- Click either month or week buttons (so they get focus)
- Scroll down to the last calendar row. The focussed buttons should not be visible in the viewport anymore
- when the modal opens, just click `cancel`, so it closes again

When `restoreFocus: true` (behavior as before), the viewport now autoscrolls up to where the buttons are
When `restoreFocus: false` (set in the fiddle), the viewport stays where it is

The original PR was also forcing the code to have the element being visible to make it scroll. I don't think this should be forced, so i decided just to go with the additional setting... which exactly fixes, what the issue was originally made for.

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6198
