### PR TITLE
[Modal] Reactivate approve/deny event handling if onHide returned false

### DIFF
--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -447,6 +447,7 @@ $.fn.modal = function(parameters) {
           module.debug('Hiding modal');
           if(settings.onHide.call(element, $(this)) === false) {
             module.verbose('Hide callback returned false cancelling hide');
+            ignoreRepeatedEvents = false;
             return false;
           }
 


### PR DESCRIPTION
## Description
The `onDeny` and `onApprove` events were only called once and never again, in case `onHide` returned false preventing the modal to be closed.

I decided against calling the given callback function (which would have fixed it in that case also), but the callback is basically unknown in general and `hide` could also be called as a behavior from outside where probably given callbacks are not supposed to be called also in case the modal was denied to be closed.

## Testcase
- Click on the 'No' Button of  the modal, An alert message appears

### Broken
- Click again. It does not work anymore
https://jsfiddle.net/0sqk6yhx/

### Fixed
- Click again. It does work all the time
https://jsfiddle.net/7gs90uqc/

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5558

