### PR TITLE
[Modal] Prevent closing the modal when webkit scrollbar has been dragged

### DIFF
--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -79,6 +79,7 @@ $.fn.modal = function(parameters) {
         ignoreRepeatedEvents = false,
 
         initialMouseDownInModal,
+        initialMouseDownInScrollbar,
 
         elementEventNamespace,
         id,
@@ -281,6 +282,10 @@ $.fn.modal = function(parameters) {
             if(initialMouseDownInModal) {
               module.verbose('Mouse down event registered inside the modal');
             }
+            initialMouseDownInScrollbar = module.is.scrolling() && $(window).outerWidth() - settings.scrollbarWidth <= event.clientX;
+            if(initialMouseDownInScrollbar) {
+              module.verbose('Mouse down event registered inside the scrollbar');
+            }
           },
           mouseup: function(event) {
             if(!settings.closable) {
@@ -291,8 +296,8 @@ $.fn.modal = function(parameters) {
               module.debug('Dimmer clicked but mouse down was initially registered inside the modal');
               return;
             }
-            if(module.is.scrolling() && $(window).outerWidth() - settings.scrollbarWidth <= event.clientX ){
-              module.debug('Dimmer clicked but within scrollbar');
+            if(initialMouseDownInScrollbar){
+              module.debug('Dimmer clicked but mouse down was initially registered inside the scrollbar');
               return;
             }
             var

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -291,6 +291,10 @@ $.fn.modal = function(parameters) {
               module.debug('Dimmer clicked but mouse down was initially registered inside the modal');
               return;
             }
+            if(module.is.scrolling() && $(window).outerWidth() - settings.scrollbarWidth <= event.clientX ){
+              module.debug('Dimmer clicked but within scrollbar');
+              return;
+            }
             var
               $target   = $(event.target),
               isInModal = ($target.closest(selector.modal).length > 0),
@@ -1060,6 +1064,7 @@ $.fn.modal.settings = {
 
   // padding with edge of page
   padding    : 50,
+  scrollbarWidth: 10,
 
   // called before show animation
   onShow     : function(){},


### PR DESCRIPTION
## Description
As mentioned in https://github.com/fomantic/Fomantic-UI/pull/431#issuecomment-458141837 by @ko2in, a modal gets closed when a webkit-custom scrollbar of the dimmer has been dragged
It seems to be only happening on webkit because of the custom scrollbar. The event system still recognizes the dimmer as target.

The new option `scrollbarWidth` by default has the same value as the `@customScrollbarWidth` value from `site.less`. I initially wanted to calculate the scrollbar-Width at runtime via javascript, but it turns out this is not possible, because webkit does not return a width difference if a custom scrollbar is used. (that probably also the reason why the event still receognized the dimmer when clicking on the scrollbar)
I think, using the same value as the webkit scrollbar width is the more reliable solution.

## Testcase
Drag the dimmers scrollbar and watch how ...
### Broken
... the modal closes
http://jsfiddle.net/7qa1upwf/2/

### Fixed
.. the modal stays
http://jsfiddle.net/hvf4w2ap/




