### PR TITLE
[Icon] Increase color specificity

### DIFF
--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -243,14 +243,14 @@ each(@colors, {
   @c: @colors[@@color][color];
   @l: @colors[@@color][light];
 
-  i.@{color}.icon {
+  i.@{color}.icon.icon.icon.icon {
     color: @c;
   }
-  i.inverted.@{color}.icon {
+  i.inverted.@{color}.icon.icon.icon.icon {
     color: @l;
   }
-  i.inverted.bordered.@{color}.icon,
-  i.inverted.circular.@{color}.icon {
+  i.inverted.bordered.@{color}.icon.icon.icon.icon,
+  i.inverted.circular.@{color}.icon.icon.icon.icon {
     background-color: @c;
     color: @white;
   }


### PR DESCRIPTION
## Description
This PR increases color specificity, so icons in links of a `list item` won't be overridden by the default grey

## Testcase
http://jsfiddle.net/qy3ptbka/1/
Remove CSS to see the issue

## Closes
#436 
