### PR TITLE
[Card] Support inverted colors

### DIFF
--- a/src/definitions/views/card.less
+++ b/src/definitions/views/card.less
@@ -546,15 +546,15 @@ each(@colors,{
   .ui.inverted.cards > .@{color}.card,
   .ui.inverted.@{color}.card {
     box-shadow:
-            @borderShadow,
+            0 @shadowDistance 3px 0 @solidWhiteBorderColor,
             0 @coloredShadowDistance 0 0 @l,
-            @shadowBoxShadow
+            0 0 0 @borderWidth @solidWhiteBorderColor
   ;
     &:hover {
     box-shadow:
-            @borderShadow,
+            0 @shadowDistance 3px 0 @solidWhiteBorderColor,
             0 @coloredShadowDistance 0 0 @lh,
-            @shadowHoverBoxShadow
+            0 0 0 @borderWidth @solidWhiteBorderColor
     ;
     }
   }

--- a/src/definitions/views/card.less
+++ b/src/definitions/views/card.less
@@ -523,6 +523,8 @@ each(@colors,{
   @color: replace(@key,'@','');
   @c: @colors[@@color][color];
   @h: @colors[@@color][hover];
+  @l: @colors[@@color][light];
+  @lh: @colors[@@color][lightHover];
 
   .ui.@{color}.cards > .card,
   .ui.cards > .@{color}.card,
@@ -532,13 +534,25 @@ each(@colors,{
             0 @coloredShadowDistance 0 0 @c,
             @shadowBoxShadow
   ;
-  }
-  .ui.@{color}.cards > .card:hover,
-  .ui.cards > .@{color}.card:hover,
-  .ui.@{color}.card:hover {
+    &:hover {
     box-shadow:
             @borderShadow,
             0 @coloredShadowDistance 0 0 @h,
+            @shadowHoverBoxShadow
+  ;
+  }
+  .ui.inverted.@{color}.cards > .card,
+  .ui.inverted.cards > .@{color}.card,
+  .ui.inverted.@{color}.card {
+    box-shadow:
+            @borderShadow,
+            0 @coloredShadowDistance 0 0 @l,
+            @shadowBoxShadow
+  ;
+    &:hover {
+    box-shadow:
+            @borderShadow,
+            0 @coloredShadowDistance 0 0 @lh,
             @shadowHoverBoxShadow
   ;
   }

--- a/src/definitions/views/card.less
+++ b/src/definitions/views/card.less
@@ -539,7 +539,8 @@ each(@colors,{
             @borderShadow,
             0 @coloredShadowDistance 0 0 @h,
             @shadowHoverBoxShadow
-  ;
+    ;
+    }
   }
   .ui.inverted.@{color}.cards > .card,
   .ui.inverted.cards > .@{color}.card,
@@ -554,7 +555,8 @@ each(@colors,{
             @borderShadow,
             0 @coloredShadowDistance 0 0 @lh,
             @shadowHoverBoxShadow
-  ;
+    ;
+    }
   }
 })
 


### PR DESCRIPTION
## Description
An inverted card did not support any color. It was always overridden by the default inverted gray.

## Testcase
https://jsfiddle.net/3sjmfoew/

## Closes
#454 
