### PR TITLE
[Card] Bottom attached colored buttons left blurry grey bottom line

### DIFF
--- a/src/definitions/views/card.less
+++ b/src/definitions/views/card.less
@@ -331,6 +331,9 @@
 .ui.card > .button {
   margin: @buttonMargin;
   width: @buttonWidth;
+  &:last-child {
+    margin-bottom: -@borderWidth;
+  }
 }
 
 /*--------------


### PR DESCRIPTION
## Description
Whenever a bottom attached button was used in cards and the card itself had a color, there was always a small 1px blurry grey box-shadow background left, which made it look a bit disturbing. See screenshots

## Testcase
https://jsfiddle.net/gome0xvc/1/

## Screenshot
#### Inverted green card before
![image](https://user-images.githubusercontent.com/18379884/52178244-1e7f9480-27cc-11e9-8b2d-76ebcb2ec44b.png)

#### Inverted green card after
![image](https://user-images.githubusercontent.com/18379884/52178254-54247d80-27cc-11e9-8032-ba00a2bf45a1.png)

#### Normal green card before
![image](https://user-images.githubusercontent.com/18379884/52178268-846c1c00-27cc-11e9-8953-bdb84a2da1a8.png)

#### Normal green card after
![image](https://user-images.githubusercontent.com/18379884/52178264-774f2d00-27cc-11e9-8665-b9f8c8248606.png)

## Closes
#454 
