### PR TITLE
[Progress] Fix 0 percent bars on colored progress

### DIFF
--- a/src/definitions/modules/progress.less
+++ b/src/definitions/modules/progress.less
@@ -56,8 +56,8 @@
   border-radius: @barBorderRadius;
   transition: @barTransition;
 }
-.ui.progress:not([data-percent]) .bar,
-.ui.progress[data-percent="0"] .bar {
+.ui.ui.progress:not([data-percent]) .bar,
+.ui.ui.progress[data-percent="0"] .bar {
   background:transparent;
 }
 .ui.progress[data-percent="0"] .bar .progress {

--- a/src/definitions/modules/progress.less
+++ b/src/definitions/modules/progress.less
@@ -56,8 +56,8 @@
   border-radius: @barBorderRadius;
   transition: @barTransition;
 }
-.ui.ui.progress:not([data-percent]) .bar,
-.ui.ui.progress[data-percent="0"] .bar {
+.ui.ui.ui.progress:not([data-percent]) .bar,
+.ui.ui.ui.progress[data-percent="0"] .bar {
   background:transparent;
 }
 .ui.progress[data-percent="0"] .bar .progress {


### PR DESCRIPTION
## Description
The background fix from #412 only works when the progressbar does not have a fixed color class assigned :cry: 

## Testcase
https://jsfiddle.net/x6fyp5he/

```html
<div class="ui red progress" data-percent="0">
  <div class="bar"></div>
</div>
```

## Screenshot

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/52270014-fd3fb500-293f-11e9-8548-ee71d288fc52.png)|![image](https://user-images.githubusercontent.com/18379884/52269984-e600c780-293f-11e9-8878-2daf3db6a05a.png)|


