### PR TITLE
[Shape] Transition did not work when child element also had a transition set

### DIFF
--- a/src/definitions/modules/shape.less
+++ b/src/definitions/modules/shape.less
@@ -133,6 +133,10 @@
 .ui.shape.animating .side {
   transition: @sideTransition;
 }
+.ui.shape .animating.side *,
+.ui.shape.animating .side * {
+  transition: none;
+}
 
 /*--------------
      Active


### PR DESCRIPTION
## Description
Shape Transition was not working when another element within the current shape side also had some other transition set (like  a `loading button` or simply a `icon button` (because icon buttons have opacity transition set!))

## Testcase
Remove CSS to see issues
http://jsfiddle.net/0yf8hvm1/ (loading button)
https://jsfiddle.net/b8gpmjtx/ (icon button)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/2860
https://github.com/Semantic-Org/Semantic-UI/issues/4782
