### PR TITLE
[Modal] Don't move content and modal on dimmer when scrollbar hides

### DIFF
--- a/src/definitions/modules/dimmer.js
+++ b/src/definitions/modules/dimmer.js
@@ -306,10 +306,8 @@ $.fn.dimmer = function(parameters) {
                   queue       : false,
                   duration    : module.get.duration(),
                   useFailSafe : true,
-                  onStart     : function() {
-                    module.remove.dimmed();
-                  },
                   onComplete  : function() {
+                    module.remove.dimmed();
                     module.remove.variation();
                     module.remove.active();
                     callback();
@@ -319,10 +317,10 @@ $.fn.dimmer = function(parameters) {
             }
             else {
               module.verbose('Hiding dimmer with javascript');
-              module.remove.dimmed();
               $dimmer
                 .stop()
                 .fadeOut(module.get.duration(), function() {
+                  module.remove.dimmed();
                   module.remove.active();
                   $dimmer.removeAttr('style');
                   callback();

--- a/src/definitions/modules/dimmer.less
+++ b/src/definitions/modules/dimmer.less
@@ -150,6 +150,7 @@
 body.animating.in.dimmable,
 body.dimmed.dimmable {
   overflow: hidden;
+  background:inherit;
 }
 
 body.dimmable > .dimmer {

--- a/src/definitions/modules/dimmer.less
+++ b/src/definitions/modules/dimmer.less
@@ -150,7 +150,6 @@
 body.animating.in.dimmable,
 body.dimmed.dimmable {
   overflow: hidden;
-  background:inherit;
 }
 
 body.dimmable > .dimmer {

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -80,6 +80,7 @@ $.fn.modal = function(parameters) {
 
         initialMouseDownInModal,
         initialMouseDownInScrollbar,
+        initialBodyMargin = '',
 
         elementEventNamespace,
         id,
@@ -507,6 +508,7 @@ $.fn.modal = function(parameters) {
 
         showDimmer: function() {
           if($dimmable.dimmer('is animating') || !$dimmable.dimmer('is active') ) {
+            module.save.bodyMargin();
             module.debug('Showing dimmer');
             $dimmable.dimmer('show');
           }
@@ -519,6 +521,7 @@ $.fn.modal = function(parameters) {
           if( $dimmable.dimmer('is animating') || ($dimmable.dimmer('is active')) ) {
             module.unbind.scrollLock();
             $dimmable.dimmer('hide', function() {
+              module.restore.bodyMargin();
               module.remove.clickaway();
               module.remove.screenHeight();
             });
@@ -597,6 +600,12 @@ $.fn.modal = function(parameters) {
             if(!inCurrentModal) {
               $focusedElement = $(document.activeElement).blur();
             }
+          },
+          bodyMargin: function() {
+            initialBodyMargin = $body.css('margin-right');
+            var bodyMarginRightPixel = parseInt(initialBodyMargin.replace(/[^\d.]/g, '')),
+                bodyScrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
+            $body.css('margin-right', (bodyMarginRightPixel + bodyScrollbarWidth) + 'px');
           }
         },
 
@@ -605,6 +614,9 @@ $.fn.modal = function(parameters) {
             if($focusedElement && $focusedElement.length > 0 && settings.restoreFocus) {
               $focusedElement.focus();
             }
+          },
+          bodyMargin: function() {
+            $body.css('margin-right', initialBodyMargin);
           }
         },
 

--- a/src/definitions/modules/sidebar.less
+++ b/src/definitions/modules/sidebar.less
@@ -94,7 +94,7 @@
 
 /* Whole Page */
 body.pushable {
-  background: @canvasBackground !important;
+  background: @canvasBackground;
 }
 
 /* Page Context */

--- a/src/definitions/modules/sidebar.less
+++ b/src/definitions/modules/sidebar.less
@@ -95,6 +95,9 @@
 /* Whole Page */
 body.pushable {
   background: @canvasBackground;
+  &.dimmed {
+    background: inherit;
+  }
 }
 
 /* Page Context */


### PR DESCRIPTION
## Description
When a modal is shown, a possible scrollbar gets hidden because of `overflow:hidden` to the body. This is correct to prevent scrolling of the background.
However, the overflow actually removes the scrollbar providing additional space (width of the scrollbar) to the body content. This again results in a recognizable width change of all background content and will be visible again when the modal closes.
Also, because of this behavior, the modal gets immediatly moved to the left by the width of the scrollbar when it gets hidden, because the dimmer resets the overflow setting **before** the dimmer is actually completely hidden.

This PR solves everything now:

- Still remove the scrollbar by overflow hidden (no change)
- **but** give a temporary right margin to the body having the same width as the scrollbar of the background
- This way all the content stays where it was before, while and after a modal is shown/hidden resulting in a smooth modal transition and non-disturbing background

## Testcase
### Broken / current behavior
https://jsfiddle.net/smudoy1k/4/

### Fixed / smooth behavior
https://jsfiddle.net/smudoy1k/5/

## Screenshot
### Broken / current behavior
![modal_scrollbar_move_bad](https://user-images.githubusercontent.com/18379884/52490627-6dab3800-2bc5-11e9-824c-59a2fe093388.gif)

### Fixed / smooth behavior
![modal_scrollbar_move_good](https://user-images.githubusercontent.com/18379884/52490642-769c0980-2bc5-11e9-9aad-45ae791b6043.gif)

## Closes
#427 
https://github.com/Semantic-Org/Semantic-UI/issues/4025
https://github.com/Semantic-Org/Semantic-UI/issues/2061
https://github.com/Semantic-Org/Semantic-UI/issues/4207
https://github.com/Semantic-Org/Semantic-UI/issues/3760
