### PR TITLE
[Sidebar] Make closable only work in clickaway event as stated in the docs

### DIFF
--- a/src/definitions/modules/sidebar.js
+++ b/src/definitions/modules/sidebar.js
@@ -141,17 +141,19 @@ $.fn.sidebar = function(parameters) {
 
         event: {
           clickaway: function(event) {
-            var
-              clickedInPusher = ($pusher.find(event.target).length > 0 || $pusher.is(event.target)),
-              clickedContext  = ($context.is(event.target))
-            ;
-            if(clickedInPusher) {
-              module.verbose('User clicked on dimmed page');
-              module.hide();
-            }
-            if(clickedContext) {
-              module.verbose('User clicked on dimmable context (scaled out page)');
-              module.hide();
+            if(settings.closable){
+              var
+                clickedInPusher = ($pusher.find(event.target).length > 0 || $pusher.is(event.target)),
+                clickedContext  = ($context.is(event.target))
+              ;
+              if(clickedInPusher) {
+                module.verbose('User clicked on dimmed page');
+                module.hide();
+              }
+              if(clickedContext) {
+                module.verbose('User clicked on dimmable context (scaled out page)');
+                module.hide();
+              }
             }
           },
           touch: function(event) {
@@ -409,7 +411,7 @@ $.fn.sidebar = function(parameters) {
             ? callback
             : function(){}
           ;
-          if(settings.closable && (module.is.visible() || module.is.animating())) {
+          if(module.is.visible() || module.is.animating()) {
             module.debug('Hiding sidebar', callback);
             module.refreshSidebars();
             module.pullPage(function() {


### PR DESCRIPTION
## Description
This PR fixes a misunderstood meaning of `closable` implemented in #335 
The `closable` setting should only have effect on clickAway events, but a sidebar should be closable all the time when triggered via any behavior call as stated in the docs.

## Testcase
- Click "Open" to open the sidebar
- Click "Close" (top left in the sidebar..hard to see, because its black...sorry)
- ...

### Broken
... it does not close
http://jsfiddle.net/xqtb1pw0

### Fixed
.. it does (but does not when clicking in the pusher area as expected)
http://jsfiddle.net/pw2xfs3v/

## Closes
#467 
