### PR TITLE
[Segment] Fix  support for inverted, secondary or tertiary in horizontal segments

### DIFF
--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -432,7 +432,6 @@
   -ms-flex: 1 1 0; /* Solves #2550 MS Flex */
   margin: 0;
   min-width: 0;
-  background-color: transparent;
   border-radius: 0;
   border: none;
   box-shadow: none;


### PR DESCRIPTION
## Description
`inverted`, `secondary` or `tertiary` segment was not working inside of `horizontal segments` group

## Testcase
Because the reason for this is an unnecessary background-color property (obviously copy/pasted when it was introduced in 2015 by https://github.com/Semantic-Org/Semantic-UI/commit/6258196a97a485db5800c4000a8015c535d942b1 ) , it cannot be simply removed in a fiddle by another css class, so you have to manually remove the property in chrome developer tools to see the fix (See screenshot below for better explanation proof) I could not find any reason why the segment itself inside a horizontal segment group should have an explicit transparent background set. It only makes sense for the segment group.
http://jsfiddle.net/hoqmxbka/

## Screenshot
![horizontal_segments_background](https://user-images.githubusercontent.com/18379884/52510730-76b7fb80-2bfd-11e9-9fbd-9d1fd873dbec.gif)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/3587
https://github.com/Semantic-Org/Semantic-UI-React/issues/3310
