### PR TITLE
fix(build): write metadata.json for docs

### DIFF
--- a/tasks/docs/build.js
+++ b/tasks/docs/build.js
@@ -56,7 +56,8 @@ module.exports = function (callback) {
     return gulp.src(config.paths.template.eco + globs.eco)
       .pipe(map(metadata.parser))
       .on('end', function () {
-        fs.writeFile(output.metadata + '/metadata.json', JSON.stringify(metadata.result, null, 2), new Function());
+        fs.mkdirSync(output.metadata, {recursive: true});
+        fs.writeFileSync(output.metadata + '/metadata.json', JSON.stringify(metadata.result, null, 2));
       });
   }
 


### PR DESCRIPTION
## Description
When building docs the metadata.json was not written to disk anymore.

## Closes
fomantic/Fomantic-UI-Docs#94
