### PR TITLE
[Transition] Transitions made of hidden inline style elements were not animated correctly anymore

### DIFF
--- a/src/definitions/modules/transition.js
+++ b/src/definitions/modules/transition.js
@@ -263,9 +263,6 @@ $.fn.transition = function() {
             $module
               .attr('style', overrideStyle)
             ;
-            if(style === '') {
-              $module.removeAttr('style');
-            }
             return true;
           },
           hidden: function() {
@@ -314,22 +311,17 @@ $.fn.transition = function() {
 
         set: {
           animating: function(animation) {
-            // override display if necessary so animation appears visibly
-            if(module.force.visible()) {
-              var
-                  animationClass,
-                  direction
-              ;
-              // remove previous callbacks
-              module.remove.completeCallback();
+            // remove previous callbacks
+            module.remove.completeCallback();
 
-              // determine exact animation
-              animation = animation || settings.animation;
-              animationClass = module.get.animationClass(animation);
+            // determine exact animation
+            animation = animation || settings.animation;
+            var animationClass = module.get.animationClass(animation);
 
               // save animation class in cache to restore class names
-              module.save.animation(animationClass);
+            module.save.animation(animationClass);
 
+            if(module.force.visible()) {
               module.remove.hidden();
               module.remove.direction();
 


### PR DESCRIPTION
## Description
This PR fixes a regression since #357. All transitions made out of elements being invisible by an inline style `display:none` were not working correctly anymore. 

## Testcase
The subheader of the title should animate by the `drop` transition
### Broken
http://jsfiddle.net/q2u0hjy1

### Fixed
http://jsfiddle.net/bc5hgv9j/1/

