### PR TITLE
[Dropdown] Allow a label to be clickable inside a dropdown button

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1669,7 +1669,7 @@ $.fn.dropdown = function(parameters) {
               $target      = $(event.target),
               $label       = $target.closest(selector.siblingLabel),
               inVisibleDOM = document.body.contains(event.target),
-              notOnLabel   = ($module.find($label).length === 0),
+              notOnLabel   = ($module.find($label).length === 0 || !(module.is.multiple() && settings.useLabels)),
               notInMenu    = ($target.closest($menu).length === 0)
             ;
             callback = $.isFunction(callback)


### PR DESCRIPTION
## Description
If a dropdown button has a label inside, the click/touch event to show/toggle the dropdown menu was ignoring any click on the label itself.
 
## Testcase
- Click on the big grey button to trigger the dropdown. It works.
- Click on the white label inside the grey dropdown button....

### Broken
... it does not work.
https://jsfiddle.net/fej70wv2/

### Fixed
... it works.
https://jsfiddle.net/fej70wv2/1/

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6165
