### PR TITLE
[Segment] compact segment in horizontal segment group should stay compact

### DIFF
--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -427,9 +427,11 @@
 }
 
 /* Horizontal Segment */
-.ui.horizontal.segments > .segment {
+.ui.horizontal.segments:not(.compact) > .segment:not(.compact) {
   flex: 1 1 auto;
   -ms-flex: 1 1 0; /* Solves #2550 MS Flex */
+}
+.ui.horizontal.segments > .segment {
   margin: 0;
   min-width: 0;
   border-radius: 0;


### PR DESCRIPTION
## Description
If a compact segment is used within a `horizontal segment` group, the segment was expanded, thus ignoring the `compact` flex-setting. The PR now only sets the specific flex setting for horizontal segments if it is not for compact segment children.

## Testcase
Remove CSS to see the issue 
https://jsfiddle.net/eL4usw6n/

## Closes
#477 
