### PR TITLE
[Menu] Last right item in a menu inside a container misses right border

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -392,6 +392,10 @@
   .ui.menu:not(.secondary):not(.text):not(.tabular):not(.borderless) > .container > .item:not(.right):not(.borderless):first-child {
     border-left: @dividerSize solid @dividerBackground;
   }
+  .ui.menu:not(.secondary):not(.text):not(.tabular):not(.borderless) > .container > .right.item:not(.borderless):last-child,
+  .ui.menu:not(.secondary):not(.text):not(.tabular):not(.borderless) > .container > .right.menu > .item:not(.borderless):last-child {
+    border-right: @dividerSize solid @dividerBackground;
+  }
 }
 
 


### PR DESCRIPTION
## Description
Having right items in a menu inside a container misses a final right border just like there is a left border for the very left item.

## Testcase
Result-view has to be at least a width of 768px to see the outer borders
Remove CSS to see the difference
http://jsfiddle.net/s693qbct/

## Screenshot
### Before
![image](https://user-images.githubusercontent.com/18379884/52597513-6d27d100-2e53-11e9-80c5-55489a6ccc47.png)
### After
![image](https://user-images.githubusercontent.com/18379884/52597638-c6900000-2e53-11e9-911a-68de8481c1fa.png)



## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/3332
