### PR TITLE
[Popup] onHide was called twice

### DIFF
--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -450,10 +450,6 @@ $.fn.popup = function(parameters) {
           hide: function(callback) {
             callback = $.isFunction(callback) ? callback : function(){};
             module.debug('Hiding pop-up');
-            if(settings.onHide.call($popup, element) === false) {
-              module.debug('onHide callback returned false, cancelling popup animation');
-              return;
-            }
             if(settings.transition && $.fn.transition !== undefined && $module.transition('is supported')) {
               $popup
                 .transition({


### PR DESCRIPTION
## Description
The `onHide` event in the popup module was called twice.
- First at the hide behavior (where it is correct)
- Second right after the first call again in the module.animate.hide call and this is only called from the hide method mentioned before

Obviously an old copy/paste bug. In comparison to `onShow` this has now the same flow logic after applying the fix.

## Testcase
- Click on the little button to show the Popup
- Click again to hide it and watch the console:

### Wrong
onHide is shown twice
http://jsfiddle.net/bm1gzosv

### Correct
onHide is shown once
http://jsfiddle.net/bm1gzosv/1/


## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/4722
https://github.com/Semantic-Org/Semantic-UI/issues/4752
