### PR TITLE
[Label] Table ribbon labels had wrong calculated position

### DIFF
--- a/src/themes/default/elements/label.variables
+++ b/src/themes/default/elements/label.variables
@@ -140,7 +140,7 @@
 @ribbonImageOffset: e(%("calc(%d - %d)", -@ribbonImageMargin, @ribbonTriangleSize));
 @rightRibbonImageOffset: e(%("calc(100%% + %d + %d)", @ribbonImageMargin, @ribbonTriangleSize));
 
-@ribbonTableMargin: @relativeMini; /* Rounding Offset on Triangle */
+@ribbonTableMargin: @relativeMedium; /* Rounding Offset on Triangle */
 @ribbonTableOffset: e(%("calc(%d - %d)", -@ribbonTableMargin, @ribbonTriangleSize));
 @rightRibbonTableOffset: e(%("calc(100%% + %d + %d)", @ribbonTableMargin, @ribbonTriangleSize));
 


### PR DESCRIPTION
## Description
When a `ribbon label` was used for `table` cells there were slightly mispositioned making it overlap the border

## Testcase
Remove CSS to see issue
https://jsfiddle.net/g3t0zea4/

## Screenshot
|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/52622865-282f8900-2eab-11e9-938b-e836da16f9f5.png)|![image](https://user-images.githubusercontent.com/18379884/52622813-00402580-2eab-11e9-92ff-d334b43e1e4c.png)|

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5203
