### PR TITLE
[Progress] Inverted success/warning/error progress bars had no color

### DIFF
--- a/src/definitions/modules/progress.less
+++ b/src/definitions/modules/progress.less
@@ -230,7 +230,7 @@
      Success
 ---------------*/
 
-.ui.progress.success .bar {
+.ui.ui.progress.success .bar {
   background-color: @successColor;
 }
 .ui.ui.progress.success .bar,
@@ -245,7 +245,7 @@
      Warning
 ---------------*/
 
-.ui.progress.warning .bar {
+.ui.ui.progress.warning .bar {
   background-color: @warningColor;
 }
 .ui.ui.progress.warning .bar,
@@ -260,7 +260,7 @@
      Error
 ---------------*/
 
-.ui.progress.error .bar {
+.ui.ui.progress.error .bar {
   background-color: @errorColor;
 }
 .ui.ui.progress.error .bar,


### PR DESCRIPTION
## Description
Because of too low specificity the states `success`,`warning` and `error` for `inverted progress` had only the default gray color set overriding their respective colors

## Testcase
Remove CSS to see issue
https://jsfiddle.net/rhvqno2z/

