### PR TITLE
[Segment] Make Clearing segment work with stacked or piled segments

### DIFF
--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -526,11 +526,9 @@
 --------------------*/
 
 .ui.clearing.segment:after {
-  content: ".";
+  content: "";
   display: block;
-  height: 0;
   clear: both;
-  visibility: hidden;
 }
 
 /*-------------------


### PR DESCRIPTION
## Description
The `clearing` segment used the usual clearfix-method with a :after pseudo element.
However `piled` and `stacked` segment used the :after element aswell to display their effects.

The clearing class has now been adjusted so it works together now

## Testcase
http://jsfiddle.net/c8nk90jv/3/

## Screenshot

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/52676640-18f02000-2f2b-11e9-9119-083320f766d7.png)|![image](https://user-images.githubusercontent.com/18379884/52676650-24434b80-2f2b-11e9-8bfc-445d602bcec4.png)|

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/4865
https://github.com/Semantic-Org/Semantic-UI/issues/4611
