### PR TITLE
[Button] Basic colored buttons were overridden by basic button group box shadow

### DIFF
--- a/src/definitions/elements/button.less
+++ b/src/definitions/elements/button.less
@@ -1818,8 +1818,7 @@ each(@colors, {
   border-radius: 0;
   margin: @groupButtonOffset;
 }
-.ui.buttons > .ui.button:not(.basic):not(.inverted),
-.ui.buttons:not(.basic):not(.inverted) > .button {
+.ui.buttons:not(.basic):not(.inverted) > .button:not(.basic):not(.inverted) {
   box-shadow: @groupButtonBoxShadow;
 }
 


### PR DESCRIPTION
## Description
`buttons` in `basic buttons` group should never show a box shadow if either the group or the buttons inside are basic or inverted. Otherwise the box-shadow of colored basic buttons were overridden

## Testcase
https://fomantic-ui.com/views/card.html#cards

## Screenshots
![basic_button_group](https://user-images.githubusercontent.com/18379884/52718151-17623e80-2fa3-11e9-8900-0eabc2d482b5.gif)

## Closes
#495 


