### PR TITLE
[Segment,Header] Color sub header in inverted segment just like normal header

### DIFF
--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -61,6 +61,7 @@
 --------------------*/
 
 /* Header */
+.ui.inverted.segment .sub.header,
 .ui.inverted.segment > .ui.header {
   color: @white;
 }

--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -61,7 +61,7 @@
 --------------------*/
 
 /* Header */
-.ui.inverted.segment .sub.header,
+.ui.inverted.segment > .ui.header > .sub.header,
 .ui.inverted.segment > .ui.header {
   color: @white;
 }


### PR DESCRIPTION
## Description
`header` is directly supported to change its color to white in `inverted segment` without the need to be specified as `inverted header`.
Unfortunately this is not the case for `sub header`, which this PR now fixes

## Testcase
https://jsfiddle.net/njvdhk2e/

## Closes
#486 
