### PR TITLE
[Menu] Disabled items in tabular menus had same color as normal items

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -455,7 +455,7 @@
      Disabled
 ---------------*/
 
-.ui.menu .item.disabled {
+.ui.ui.menu .item.disabled {
   cursor: default;
   background-color: transparent;
   color: @disabledTextColor;
@@ -1344,7 +1344,7 @@ each(@colors, {
 }
 
 /* Disabled */
-.ui.inverted.menu .item.disabled {
+.ui.ui.inverted.menu .item.disabled {
   color: @invertedDisabledTextColor;
 }
 


### PR DESCRIPTION
## Description
A `disabled item` in a `tabular menu` got the same color as a normal item. For normal or secondary menus is appears as expected.

## Testcase
https://jsfiddle.net/o6mpnjL1/2/

## Screenshot (when possible)
|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/52801257-c6734880-307d-11e9-863f-d8df1360a468.png)|![image](https://user-images.githubusercontent.com/18379884/52801226-b491a580-307d-11e9-8f7a-f0e18196852b.png)|

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/3178
https://github.com/Semantic-Org/Semantic-UI/issues/3578
