### PR TITLE
[Checkbox] Visual support for indeterminate toggle

### DIFF
--- a/src/definitions/modules/checkbox.less
+++ b/src/definitions/modules/checkbox.less
@@ -205,6 +205,14 @@
   opacity: @checkboxIndeterminateCheckOpacity;
   color: @checkboxIndeterminateCheckColor;
 }
+.ui.indeterminate.toggle.checkbox {
+  & input:not([type=radio]):indeterminate ~ label:before {
+    background: @toggleCenterLaneBackground;
+  }
+  & input:not([type=radio]) ~ label:after {
+    left: @toggleCenterOffset;
+  }
+}
 
 /*--------------
   Active Focus

--- a/src/themes/default/modules/checkbox.variables
+++ b/src/themes/default/modules/checkbox.variables
@@ -166,6 +166,8 @@
 @toggleLaneVerticalOffset: 0;
 @toggleOffOffset: -0.05rem;
 @toggleOnOffset: (@toggleLaneWidth - @toggleHandleSize) + 0.15rem;
+@toggleCenterOffset: @toggleOnOffset / 2;
+@toggleCenterLaneBackground: @veryStrongTransparentBlack;
 
 @toggleLabelDistance: @toggleLaneWidth + 1rem;
 @toggleLabelLineHeight: 1.5rem;


### PR DESCRIPTION
## Description
It's already possible to set the `indeterminate` state to a checkbox via javascript behavior
```javascript
$('.ui.toggle').checkbox('set indeterminate');
```
But that's actually **regardless** if it's a toggle checkbox or a normal checkbox!
So the only missing is a visual indication for a toggle checkbox to completely support `indeterminate` there aswell.

Thanks for the original proposal code to @lauri-elevant

## Testcase
https://jsfiddle.net/cbyp1ego/

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/52824613-9184e700-30b9-11e9-84ea-e3b5ef09f8fd.png)


## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/3216
https://github.com/Semantic-Org/Semantic-UI/issues/5133
