### PR TITLE
[Input] Tiny size variant was missing

### DIFF
--- a/src/definitions/elements/input.less
+++ b/src/definitions/elements/input.less
@@ -512,6 +512,9 @@
 .ui.mini.input {
   font-size: @relativeMini;
 }
+.ui.tiny.input {
+  font-size: @relativeTiny;
+}
 .ui.small.input {
   font-size: @relativeSmall;
 }


### PR DESCRIPTION
## Description
The `input` element was missing the `tiny` size variant, thus such inputs were diplayed in medium / default size.

## Testcase
Remove CSS to see issue
https://jsfiddle.net/xeungdv8/1/

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/52844822-c9198080-3105-11e9-84ea-47507e06c8dd.png)|![image](https://user-images.githubusercontent.com/18379884/52844794-b56e1a00-3105-11e9-8072-15dd02aa9244.png)|

## Closes
https://github.com/Semantic-Org/Semantic-UI-React/issues/3439
