### PR TITLE
[API] Do not raise console error on all 2xx status codes on failure

### DIFF
--- a/src/definitions/behaviors/api.js
+++ b/src/definitions/behaviors/api.js
@@ -577,7 +577,7 @@ $.api = $.fn.api = function(parameters) {
                 if(xhr !== undefined) {
                   module.debug('XHR produced a server error', status, httpMessage);
                   // make sure we have an error to display to console
-                  if( xhr.status != 200 && httpMessage !== undefined && httpMessage !== '') {
+                  if( (xhr.status < 200 || xhr.status >= 300) && httpMessage !== undefined && httpMessage !== '') {
                     module.error(error.statusMessage + httpMessage, ajaxSettings.url);
                   }
                   settings.onError.call(context, errorMessage, $module, xhr);


### PR DESCRIPTION
## Description
The current API behavior raises an console error on failure, even when the status code was 2xx.
It only omits it when the status code is exactly 200

## Testcase
### Current: Only Status 200 is ignored
https://jsfiddle.net/q5osrg7k/2/
### After: All Status 2xx are ignored
https://jsfiddle.net/q5osrg7k/3/

## Screenshot
### Current
![200](https://user-images.githubusercontent.com/18379884/52958105-aef4d200-3393-11e9-8f08-ebd9a2b4376c.gif)
### After
![2xx](https://user-images.githubusercontent.com/18379884/52958120-b74d0d00-3393-11e9-951e-452377eebb5f.gif)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/4908


