### PR TITLE
[API] Set context in beforesend to $module instead of possible stateContext to match docs

### DIFF
--- a/src/definitions/behaviors/api.js
+++ b/src/definitions/behaviors/api.js
@@ -721,7 +721,7 @@ $.api = $.fn.api = function(parameters) {
             var
               runSettings
             ;
-            runSettings = settings.beforeSend.call(context, settings);
+            runSettings = settings.beforeSend.call($module, settings);
             if(runSettings) {
               if(runSettings.success !== undefined) {
                 module.debug('Legacy success callback detected', runSettings);


### PR DESCRIPTION
## Description
According to [the docs](https://fomantic-ui.com/behaviors/api.html#/settings), `beforeSend` should have the "initialized element" as context, not the element matching `stateContext`!

## Testcase
### Current/Wrong
https://jsfiddle.net/7oz0bncp/
### Fixed
https://jsfiddle.net/7oz0bncp/1/

## Screenshot
### Current/Wrong
![beforesend_wrong](https://user-images.githubusercontent.com/18379884/52962687-32b3bc00-339e-11e9-956d-8d88ceec5d4d.gif)

### Fixed
![beforesend_right](https://user-images.githubusercontent.com/18379884/52962695-36dfd980-339e-11e9-9034-9dc27a1b3f5a.gif)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6207
