### PR TITLE
[Build] Fix incorrect format of file permission

### DIFF
--- a/tasks/build/assets.js
+++ b/tasks/build/assets.js
@@ -21,7 +21,7 @@ var
 
 function build(src, config) {
   return gulp.src(src, {base: config.paths.source.themes})
-    .pipe(gulpif(config.hasPermission, chmod(config.permission)))
+    .pipe(gulpif(config.hasPermissions, chmod(config.parsedPermissions)))
     .pipe(gulp.dest(config.paths.output.themes))
     .pipe(print(log.created))
     ;

--- a/tasks/build/css.js
+++ b/tasks/build/css.js
@@ -77,7 +77,7 @@ function build(src, type, compress, config, opts) {
       compress ? config.paths.assets.compressed : config.paths.assets.uncompressed))
     .pipe(gulpif(compress, minifyCSS(settings.minify)))
     .pipe(gulpif(fileExtension, rename(fileExtension)))
-    .pipe(gulpif(config.hasPermission, chmod(config.permission)))
+    .pipe(gulpif(config.hasPermissions, chmod(config.parsedPermissions)))
     .pipe(gulp.dest(compress ? config.paths.output.compressed : config.paths.output.uncompressed))
     .pipe(print(log.created))
     ;
@@ -104,7 +104,7 @@ function pack(type, compress) {
     .pipe(dedupe())
     .pipe(replace(assets.uncompressed, assets.packaged))
     .pipe(concatCSS(concatenatedCSS, settings.concatCSS))
-    .pipe(gulpif(config.hasPermission, chmod(config.permission)))
+    .pipe(gulpif(config.hasPermissions, chmod(config.parsedPermissions)))
     .pipe(gulpif(compress, minifyCSS(settings.concatMinify)))
     .pipe(header(banner, settings.header))
     .pipe(gulp.dest(output.packaged))

--- a/tasks/build/javascript.js
+++ b/tasks/build/javascript.js
@@ -51,14 +51,14 @@ function build(src, type, config) {
     .pipe(plumber())
     .pipe(flatten())
     .pipe(replace(comments.license.in, comments.license.out))
+    .pipe(gulpif(config.hasPermissions, chmod(config.parsedPermissions)))
     .pipe(gulp.dest(config.paths.output.uncompressed))
-    .pipe(gulpif(config.hasPermission, chmod(config.permission)))
     .pipe(print(log.created))
     .pipe(uglify(settings.uglify))
     .pipe(rename(settings.rename.minJS))
     .pipe(header(banner, settings.header))
+    .pipe(gulpif(config.hasPermissions, chmod(config.parsedPermissions)))
     .pipe(gulp.dest(config.paths.output.compressed))
-    .pipe(gulpif(config.hasPermission, chmod(config.permission)))
     .pipe(print(log.created))
     ;
 }
@@ -79,7 +79,7 @@ function pack(type, compress) {
     .pipe(concat(concatenatedJS))
     .pipe(gulpif(compress, uglify(settings.concatUglify)))
     .pipe(header(banner, settings.header))
-    .pipe(gulpif(config.hasPermission, chmod(config.permission)))
+    .pipe(gulpif(config.hasPermissions, chmod(config.parsedPermissions)))
     .pipe(gulp.dest(output.packaged))
     .pipe(print(log.created))
     ;

--- a/tasks/config/project/config.js
+++ b/tasks/config/project/config.js
@@ -109,7 +109,7 @@ module.exports = {
       // pass blank object to avoid causing errors
       config.permission     = {};
       config.hasPermissions = false;
-      config.parsedPermissions = false;
+      config.parsedPermissions = {};
     }
 
     /*--------------

--- a/tasks/config/project/config.js
+++ b/tasks/config/project/config.js
@@ -103,11 +103,13 @@ module.exports = {
 
     if(config.permission) {
       config.hasPermissions = true;
+      config.parsedPermissions = typeof config.permission === 'string' ? parseInt(config.permission, 8) : config.permission;
     }
     else {
       // pass blank object to avoid causing errors
       config.permission     = {};
       config.hasPermissions = false;
+      config.parsedPermissions = false;
     }
 
     /*--------------


### PR DESCRIPTION
## Description
gulp-chmod needs the octal representation of the file permissions (f.e. `0o755`), but in the config it was saved as a string. As a result, gulp-chmod crashed.
Additionally permissions on js files were not set correctly.

## Closes
#502 
