### PR TITLE
[Dropdown] Catch a possible null value for preselected values

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -751,7 +751,7 @@ $.fn.dropdown = function(parameters) {
                 }
                 var preSelected = $input.val();
                 if(!Array.isArray(preSelected)) {
-                    preSelected = preSelected!=="" ? preSelected.split(settings.delimiter) : [];
+                    preSelected = preSelected && preSelected!=="" ? preSelected.split(settings.delimiter) : [];
                 }
                 $.each(preSelected,function(index,value){
                   $item.filter('[data-value="'+value+'"]')


### PR DESCRIPTION
## Description
In case the initial value of a dropdown is `null` (for example an empty `select` tag returns this),
the fetch of preselected values after a remote api call is broken

## Testcase
### Broken
Just click into the search dropdown to trigger the remoteAPI call and watch the console returning JS errors immediatly
https://jsfiddle.net/y18p4thg/1/

### Fixed
https://jsfiddle.net/y18p4thg/2/

## Closes
#505 
