### PR TITLE
[Checkbox] Support check/uncheck by hitting space key in IE11 and Edge

### DIFF
--- a/src/definitions/modules/checkbox.js
+++ b/src/definitions/modules/checkbox.js
@@ -174,6 +174,13 @@ $.fn.checkbox = function(parameters) {
           }
         },
 
+        preventDefaultOnInputTarget: function() {
+          if(event && $(event.target).is(selector.input)) {
+            module.verbose('Preventing default check action after manual check action');
+            event.preventDefault();
+          }
+        },
+
         event: {
           change: function(event) {
             if( !module.should.ignoreCallbacks() ) {
@@ -263,6 +270,7 @@ $.fn.checkbox = function(parameters) {
             settings.onChecked.call(input);
             module.trigger.change();
           }
+          module.preventDefaultOnInputTarget();
         },
 
         uncheck: function() {
@@ -275,6 +283,7 @@ $.fn.checkbox = function(parameters) {
             settings.onUnchecked.call(input);
             module.trigger.change();
           }
+          module.preventDefaultOnInputTarget();
         },
 
         indeterminate: function() {


### PR DESCRIPTION
## Description
Unable to check/uncheck the checkbox. Tick mark flicks on hitting Space button.
This occurs only when JS is assigned over that checkbox DIV.
and only on Edge and Internet Explorer Browsers.

## Testcase
Click on the checkbox or its label once and right after check try to check/uncheck via spacebar again
### Broken
Does not work in IE11 or Edge
https://jsfiddle.net/jph1r2se/2/

### Fixed
Works now :)
https://jsfiddle.net/06kde5fg/

## Screenshot

|Edge||IE||
|-|-|-|-|
|Before|After|Before|After|
|![edgespace_bad](https://user-images.githubusercontent.com/18379884/53183537-d3eb7e00-35fb-11e9-839c-79ffdb1c98a9.gif)|![edgespace_good](https://user-images.githubusercontent.com/18379884/53183544-d8b03200-35fb-11e9-868f-19e366f05103.gif)|![ie11space_bad](https://user-images.githubusercontent.com/18379884/53183555-dc43b900-35fb-11e9-8d64-08c661fca018.gif)|![ie11space_good](https://user-images.githubusercontent.com/18379884/53183576-dfd74000-35fb-11e9-8be7-a07c1f6df770.gif)|







## Closes
#226 
https://github.com/Semantic-Org/Semantic-UI/issues/5854
