### PR TITLE
[Modal] A modal couldnt be closed a second time it was opened by another modal

### DIFF
--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -401,6 +401,7 @@ $.fn.modal = function(parameters) {
               module.hideOthers(module.showModal);
             }
             else {
+              ignoreRepeatedEvents = false;
               if( settings.allowMultiple ) {
                 if ( module.others.active() ) {
                   $otherModals.filter('.' + className.active).find(selector.dimmer).addClass('active');


### PR DESCRIPTION
## Description
If a modal opens another modal using `onDeny` callback, the `onDeny` method of that modal works only one time and it never works again which means the modal cannot be closed.

## Testcase
* Click the button to open Modal 1.
* Inside Modal 1, click the button to open Modal 2.
* Close Modal 2, which will re-open Modal 1 again.
* Click again the button in Modal 1 to open Modal 2 again.
* Try to close Modal 2 again now and ...

### Broken
...  it cannot be closed.
https://jsfiddle.net/1qo9nkre/

### Fixed
... it closes again as expected 
https://jsfiddle.net/0m1pukaw/

## Closes
#511 
https://github.com/Semantic-Org/Semantic-UI/issues/6069
