### PR TITLE
[Calendar] Day was calculated to last day of month if year had 2-digit notation between 60 and 99

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -1286,6 +1286,9 @@ $.fn.calendar.settings = {
             continue;
           }
           if (j > 59) {
+            if (j < 99) {
+              j += 1900;
+            }
             year = j;
             numbers.splice(i, 1);
             break;


### PR DESCRIPTION
## Description
If an entered date had a 2-digit year notation (like 88 which actually meant 1988) and the year was set between 60 and 99, the day was always internally wrong calculated and displayed to the last day of the month

## Testcase
### Broken
https://jsfiddle.net/to7c056b/1/

### Fixed
https://jsfiddle.net/mar7xzvu/

## Screenshot
|Before|After|
|-|-|
|![calendar88_bad](https://user-images.githubusercontent.com/18379884/53275725-7be87080-36fc-11e9-8d75-eb6114e4dba6.gif)|![calendar88_good](https://user-images.githubusercontent.com/18379884/53275736-8440ab80-36fc-11e9-883b-12d9c91eeb82.gif)|

## Closes
#507 
