### PR TITLE
[Label] Make corner icon position absolute to support other tags for label like <button>

### DIFF
--- a/src/definitions/elements/label.less
+++ b/src/definitions/elements/label.less
@@ -308,9 +308,10 @@ a.ui.label {
 
 .ui.corner.label .icon {
   cursor: inherit;
-  position: relative;
+  position: absolute;
   top: @cornerIconTopOffset;
-  left: @cornerIconLeftOffset;
+  left: auto;
+  right: @cornerIconRightOffset;
   font-size: @cornerIconSize;
   margin: 0;
 }
@@ -330,7 +331,8 @@ a.ui.label {
   border-top-color: inherit;
 }
 .ui.left.corner.label .icon {
-  left: -@cornerIconLeftOffset;
+  left: @cornerIconLeftOffset;
+  right: auto;
 }
 
 /* Segment */

--- a/src/themes/default/elements/label.variables
+++ b/src/themes/default/elements/label.variables
@@ -204,7 +204,8 @@
 
 @cornerIconSize: @relativeLarge;
 @cornerIconTopOffset: @relative9px;
-@cornerIconLeftOffset: @relative11px;
+@cornerIconLeftOffset: @relative8px;
+@cornerIconRightOffset: @relative8px;
 
 /* Corner Text */
 @cornerTextWidth: 3em;


### PR DESCRIPTION
## Description
By making the icon inside a `corner label` position absolute, its positioning is not modified anymore, if the `corner label` was used inside a `<button>` tag

## Testcase
The `ui corner label` is used in a `<button>` tag instead of an `a`
```html
<button class="ui left corner label">
    <i class="heart icon"></i>
</button>
``` 
### Current case
https://jsfiddle.net/moshfeu/h4582kbc/3/

### Adjusted
https://jsfiddle.net/Lfha3wnb/1/

## Screenshot (current case)
![](https://user-images.githubusercontent.com/3723951/53366489-623d6800-394c-11e9-81df-6d591e8f12fc.png)

## Closes
#518 
https://github.com/Semantic-Org/Semantic-UI-React/issues/3462
