### PR TITLE
[Modal] Introducing "overlay fullscreen modal"

### DIFF
--- a/src/definitions/modules/modal.less
+++ b/src/definitions/modules/modal.less
@@ -237,14 +237,8 @@
   .ui.entire.fullscreen.modal .content.content.content {
     min-height: @entireFullscreenScrollingContentMaxHeightMobile;
   }
-  .ui.legacy.entire.fullscreen.modal .content.content.content {
-    min-height: @legacyEntireFullscreenScrollingContentMaxHeightMobile;
-  }
   .ui.entire.fullscreen.modal .scrolling.content.content.content {
     max-height: @entireFullscreenScrollingContentMaxHeightMobile;
-  }
-  .ui.legacy.entire.fullscreen.modal .scrolling.content.content.content {
-    max-height: @legacyEntireFullscreenScrollingContentMaxHeightMobile;
   }
   .ui.modal > .content {
     display: block;
@@ -346,12 +340,6 @@
 
 .ui.legacy.entire.fullscreen.modal {
   margin-top: -@scrollingMargin !important;
-}
-.ui.legacy.entire.fullscreen.modal .content {
-  min-height: @legacyEntireFullscreenScrollingContentMaxHeight;
-}
-.ui.legacy.entire.fullscreen.modal .scrolling.content {
-  max-height: @legacyEntireFullscreenScrollingContentMaxHeight;
 }
 
 /*******************************

--- a/src/definitions/modules/modal.less
+++ b/src/definitions/modules/modal.less
@@ -234,11 +234,11 @@
     padding: @mobileHeaderPadding !important;
     padding-right: @closeHitbox !important;
   }
-  .ui.entire.fullscreen.modal .content.content.content {
-    min-height: @entireFullscreenScrollingContentMaxHeightMobile;
+  .ui.overlay.fullscreen.modal .content.content.content {
+    min-height: @overlayFullscreenScrollingContentMaxHeightMobile;
   }
-  .ui.entire.fullscreen.modal .scrolling.content.content.content {
-    max-height: @entireFullscreenScrollingContentMaxHeightMobile;
+  .ui.overlay.fullscreen.modal .scrolling.content.content.content {
+    max-height: @overlayFullscreenScrollingContentMaxHeightMobile;
   }
   .ui.modal > .content {
     display: block;
@@ -338,7 +338,7 @@
   top: auto !important;
 }
 
-.ui.legacy.entire.fullscreen.modal {
+.ui.legacy.overlay.fullscreen.modal {
   margin-top: -@scrollingMargin !important;
 }
 
@@ -422,11 +422,11 @@
   max-height: @scrollingContentMaxHeight;
   overflow: auto;
 }
-.ui.entire.fullscreen.modal .content {
-  min-height: @entireFullscreenScrollingContentMaxHeight;
+.ui.overlay.fullscreen.modal .content {
+  min-height: @overlayFullscreenScrollingContentMaxHeight;
 }
-.ui.entire.fullscreen.modal .scrolling.content {
-  max-height: @entireFullscreenScrollingContentMaxHeight;
+.ui.overlay.fullscreen.modal .scrolling.content {
+  max-height: @overlayFullscreenScrollingContentMaxHeight;
 }
 
 /*--------------
@@ -438,7 +438,7 @@
   left: @fullScreenOffset;
   margin: @fullScreenMargin;
 }
-.ui.entire.fullscreen.modal {
+.ui.overlay.fullscreen.modal {
   width: 100%;
   left: 0;
   margin: 0 auto;

--- a/src/definitions/modules/modal.less
+++ b/src/definitions/modules/modal.less
@@ -185,31 +185,31 @@
 
 /* Modal Width */
 @media only screen and (max-width : @largestMobileScreen) {
-  .ui.modal {
+  .ui.modal:not(.fullscreen) {
     width: @mobileWidth;
     margin: @mobileMargin;
   }
 }
 @media only screen and (min-width : @tabletBreakpoint) {
-  .ui.modal {
+  .ui.modal:not(.fullscreen) {
     width: @tabletWidth;
     margin: @tabletMargin;
   }
 }
 @media only screen and (min-width : @computerBreakpoint) {
-  .ui.modal {
+  .ui.modal:not(.fullscreen) {
     width: @computerWidth;
     margin: @computerMargin;
   }
 }
 @media only screen and (min-width : @largeMonitorBreakpoint) {
-  .ui.modal {
+  .ui.modal:not(.fullscreen) {
     width: @largeMonitorWidth;
     margin: @largeMonitorMargin;
   }
 }
 @media only screen and (min-width : @widescreenMonitorBreakpoint) {
-  .ui.modal {
+  .ui.modal:not(.fullscreen) {
     width: @widescreenMonitorWidth;
     margin: @widescreenMonitorMargin;
   }
@@ -233,6 +233,18 @@
   .ui.modal > .header {
     padding: @mobileHeaderPadding !important;
     padding-right: @closeHitbox !important;
+  }
+  .ui.entire.fullscreen.modal .content.content.content {
+    min-height: @entireFullscreenScrollingContentMaxHeightMobile;
+  }
+  .ui.legacy.entire.fullscreen.modal .content.content.content {
+    min-height: @legacyEntireFullscreenScrollingContentMaxHeightMobile;
+  }
+  .ui.entire.fullscreen.modal .scrolling.content.content.content {
+    max-height: @entireFullscreenScrollingContentMaxHeightMobile;
+  }
+  .ui.legacy.entire.fullscreen.modal .scrolling.content.content.content {
+    max-height: @legacyEntireFullscreenScrollingContentMaxHeightMobile;
   }
   .ui.modal > .content {
     display: block;
@@ -332,7 +344,15 @@
   top: auto !important;
 }
 
-
+.ui.legacy.entire.fullscreen.modal {
+  margin-top: -@scrollingMargin !important;
+}
+.ui.legacy.entire.fullscreen.modal .content {
+  min-height: @legacyEntireFullscreenScrollingContentMaxHeight;
+}
+.ui.legacy.entire.fullscreen.modal .scrolling.content {
+  max-height: @legacyEntireFullscreenScrollingContentMaxHeight;
+}
 
 /*******************************
              States
@@ -391,7 +411,7 @@
   overflow: auto;
   -webkit-overflow-scrolling: touch;
 }
-.modals.dimmer .ui.scrolling.modal {
+.modals.dimmer .ui.scrolling.modal:not(.fullscreen) {
   margin: @scrollingMargin auto;
 }
 
@@ -403,7 +423,7 @@
 .scrolling.undetached.dimmable.dimmed > .dimmer {
   overflow: hidden;
 }
-.scrolling.undetached.dimmable .ui.scrolling.modal {
+.scrolling.undetached.dimmable .ui.scrolling.modal:not(.fullscreen) {
   position: absolute;
   left: 50%;
   margin-top: @scrollingMargin !important;
@@ -414,15 +434,28 @@
   max-height: @scrollingContentMaxHeight;
   overflow: auto;
 }
+.ui.entire.fullscreen.modal .content {
+  min-height: @entireFullscreenScrollingContentMaxHeight;
+}
+.ui.entire.fullscreen.modal .scrolling.content {
+  max-height: @entireFullscreenScrollingContentMaxHeight;
+}
 
 /*--------------
    Full Screen
 ---------------*/
 
 .ui.fullscreen.modal {
-  width: @fullScreenWidth !important;
-  left: @fullScreenOffset !important;
+  width: @fullScreenWidth;
+  left: @fullScreenOffset;
   margin: @fullScreenMargin;
+}
+.ui.entire.fullscreen.modal {
+  width: 100%;
+  left: 0;
+  margin: 0 auto;
+  top: 0;
+  border-radius:0;
 }
 .ui.fullscreen.modal > .header {
   padding-right: @closeHitbox;

--- a/src/themes/default/modules/modal.variables
+++ b/src/themes/default/modules/modal.variables
@@ -127,10 +127,8 @@
 
 /* Scrolling Content */
 @scrollingContentMaxHeight: calc(80vh - 10rem);
-@entireFullscreenScrollingContentMaxHeight: calc(80vh - 9rem);
-@entireFullscreenScrollingContentMaxHeightMobile: calc(80vh - 8rem);
-@legacyEntireFullscreenScrollingContentMaxHeight: calc(80vh - 9.1rem);
-@legacyEntireFullscreenScrollingContentMaxHeightMobile: calc(80vh - 8.1rem);
+@entireFullscreenScrollingContentMaxHeight: calc(100vh - 9.1rem);
+@entireFullscreenScrollingContentMaxHeightMobile: calc(100vh - 8.1rem);
 
 /*-------------------
       Variations

--- a/src/themes/default/modules/modal.variables
+++ b/src/themes/default/modules/modal.variables
@@ -126,7 +126,11 @@
 @mobileScrollingMargin: @mobileTopAlignedMargin;
 
 /* Scrolling Content */
-@scrollingContentMaxHeight: calc(80vh - 10em);
+@scrollingContentMaxHeight: calc(80vh - 10rem);
+@entireFullscreenScrollingContentMaxHeight: calc(80vh - 9rem);
+@entireFullscreenScrollingContentMaxHeightMobile: calc(80vh - 8rem);
+@legacyEntireFullscreenScrollingContentMaxHeight: calc(80vh - 9.1rem);
+@legacyEntireFullscreenScrollingContentMaxHeightMobile: calc(80vh - 8.1rem);
 
 /*-------------------
       Variations

--- a/src/themes/default/modules/modal.variables
+++ b/src/themes/default/modules/modal.variables
@@ -127,8 +127,8 @@
 
 /* Scrolling Content */
 @scrollingContentMaxHeight: calc(80vh - 10rem);
-@entireFullscreenScrollingContentMaxHeight: calc(100vh - 9.1rem);
-@entireFullscreenScrollingContentMaxHeightMobile: calc(100vh - 8.1rem);
+@overlayFullscreenScrollingContentMaxHeight: calc(100vh - 9.1rem);
+@overlayFullscreenScrollingContentMaxHeightMobile: calc(100vh - 8.1rem);
 
 /*-------------------
       Variations


### PR DESCRIPTION
## Description
The current `fullscreen` modal was (according to the docs) supposed to "use the entire size of the screen". This was not really true, because there still was lots of margin left, so you could see the dimmer, and also modals with little content were not even close to fullscreen.

This PR makes it possible now and adds a new variant to the modal module:

`overlay fullscreen modal`

When used, it is now **really** using and overlaying the entire viewport, regardless of the content. 🙂 

## Testcase
https://jsfiddle.net/sbru45e1/

## Screenshot
![overlayfullscreenmodal](https://user-images.githubusercontent.com/18379884/53481542-bc8a1600-3a7d-11e9-9cfe-52d62b17946d.gif)

## Closes
#522 
