### PR TITLE
[Calendar] Adjustable shortyear to century calculation

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -1137,6 +1137,8 @@ $.fn.calendar.settings = {
   disabledDates      : [],         // specific day(s) which won't be selectable and contain additional information.
   disabledDaysOfWeek : [],         // day(s) which won't be selectable(s) (0 = Sunday)
   enabledDates       : [],         // specific day(s) which will be selectable, all other days will be disabled
+  centuryBreak       : 60,         // starting short year until 99 where it will be assumed to belong to the last century
+  currentCentury     : 2000,       // century to be added to 2-digit years (00 to {centuryBreak}-1)
   // popup options ('popup', 'on', 'hoverable', and show/hide callbacks are overridden)
   popupOptions: {
     position: 'bottom left',
@@ -1294,15 +1296,15 @@ $.fn.calendar.settings = {
           }
         }
 
-        //year > 59
+        //year > settings.centuryBreak
         for (i = 0; i < numbers.length; i++) {
           j = parseInt(numbers[i]);
           if (isNaN(j)) {
             continue;
           }
-          if (j > 59) {
-            if (j < 99) {
-              j += 1900;
+          if (j >= settings.centuryBreak && i === numbers.length-1) {
+            if (j <= 99) {
+              j += settings.currentCentury - 100;
             }
             year = j;
             numbers.splice(i, 1);
@@ -1339,15 +1341,15 @@ $.fn.calendar.settings = {
           }
         }
 
-        //year <= 59
+        //year <= settings.centuryBreak
         if (year < 0) {
           for (i = numbers.length - 1; i >= 0; i--) {
             j = parseInt(numbers[i]);
             if (isNaN(j)) {
               continue;
             }
-            if (j < 99) {
-              j += 2000;
+            if (j <= 99) {
+              j += settings.currentCentury;
             }
             year = j;
             numbers.splice(i, 1);


### PR DESCRIPTION
## Description
This PR adds the ability to adjust the calculation of entered shortyears to the belonging century by adding two new options
```javascript
// default values to stay backward compatible to current behavior
currentCentury: 2000,
centuryBreak: 60,
```
## Testcase
https://jsfiddle.net/7mhLw321/

## Screenshot
![calendar_century](https://user-images.githubusercontent.com/18379884/53515805-267cdc80-3acb-11e9-8594-3576967a5346.gif)

## Closes
#514 
