### PR TITLE
[Shape] Focussed Checkbox inside shape breaks animation

### DIFF
--- a/src/definitions/modules/shape.js
+++ b/src/definitions/modules/shape.js
@@ -57,6 +57,7 @@ $.fn.shape = function(parameters) {
         selector      = settings.selector,
         error         = settings.error,
         className     = settings.className,
+        regExp        = settings.regExp,
 
         // define namespaces for modules
         eventNamespace  = '.' + namespace,
@@ -197,6 +198,20 @@ $.fn.shape = function(parameters) {
           },
           hidden: function() {
             return $module.closest(':hidden').length > 0;
+          },
+          mobile: function() {
+            var
+                userAgent    = navigator.userAgent,
+                isMobile     = userAgent.match(regExp.mobile)
+            ;
+            if(isMobile) {
+              module.verbose('Browser was found to be mobile', userAgent);
+              return true;
+            }
+            else {
+              module.verbose('Browser is not mobile, using regular transition', userAgent);
+              return false;
+            }
           }
         },
 
@@ -764,7 +779,7 @@ $.fn.shape = function(parameters) {
           $inputs.blur();
           setTimeout(function(){
             module.invoke(query);
-          }, 100);
+          }, module.is.mobile() ? 150:100);
         } else {
           module.invoke(query);
         }
@@ -835,6 +850,10 @@ $.fn.shape.settings = {
     hidden    : 'hidden',
     loading   : 'loading',
     active    : 'active'
+  },
+
+  regExp: {
+    mobile       : /Mobile|iP(hone|od|ad)|Android|BlackBerry|IEMobile|Kindle|NetFront|Silk-Accelerated|(hpw|web)OS|Fennec|Minimo|Opera M(obi|ini)|Blazer|Dolfin|Dolphin|Skyfire|Zune/g
   },
 
   // selectors used

--- a/src/definitions/modules/shape.js
+++ b/src/definitions/modules/shape.js
@@ -57,7 +57,6 @@ $.fn.shape = function(parameters) {
         selector      = settings.selector,
         error         = settings.error,
         className     = settings.className,
-        regExp        = settings.regExp,
 
         // define namespaces for modules
         eventNamespace  = '.' + namespace,
@@ -198,20 +197,6 @@ $.fn.shape = function(parameters) {
           },
           hidden: function() {
             return $module.closest(':hidden').length > 0;
-          },
-          mobile: function() {
-            var
-                userAgent    = navigator.userAgent,
-                isMobile     = userAgent.match(regExp.mobile)
-            ;
-            if(isMobile) {
-              module.verbose('Browser was found to be mobile', userAgent);
-              return true;
-            }
-            else {
-              module.verbose('Browser is not mobile, using regular transition', userAgent);
-              return false;
-            }
           }
         },
 
@@ -779,7 +764,7 @@ $.fn.shape = function(parameters) {
           $inputs.blur();
           setTimeout(function(){
             module.invoke(query);
-          }, module.is.mobile() ? 150:100);
+          }, 150);
         } else {
           module.invoke(query);
         }
@@ -850,10 +835,6 @@ $.fn.shape.settings = {
     hidden    : 'hidden',
     loading   : 'loading',
     active    : 'active'
-  },
-
-  regExp: {
-    mobile       : /Mobile|iP(hone|od|ad)|Android|BlackBerry|IEMobile|Kindle|NetFront|Silk-Accelerated|(hpw|web)OS|Fennec|Minimo|Opera M(obi|ini)|Blazer|Dolfin|Dolphin|Skyfire|Zune/g
   },
 
   // selectors used

--- a/src/definitions/modules/shape.js
+++ b/src/definitions/modules/shape.js
@@ -759,7 +759,15 @@ $.fn.shape = function(parameters) {
         if(instance === undefined) {
           module.initialize();
         }
-        module.invoke(query);
+        var $inputs = $module.find('input');
+        if( $inputs.length > 0) {
+          $inputs.blur();
+          setTimeout(function(){
+            module.invoke(query);
+          }, 100);
+        } else {
+          module.invoke(query);
+        }
       }
       else {
         if(instance !== undefined) {


### PR DESCRIPTION
## Description
When a shape had a focussed input inside, any animation was broken.
Previously, you had to click outside of the shape to blur the input to make the animation work again.

Although in the example below, the checkbox indeed gets blurred right before the button to animate the shape is clicked, it seems the browser engine still gets confused and does not recognize the change early enough.
This PR now delays the animation for a short time in case of input being part of the the shape, so the blurred checkout is also recognized by the browser engine at animation time

## Testcase
Check/uncheck the checkbox. Then **quickly** (means don't hold the mousebutton for too long) click the Button to trigger the animation

### Broken
https://jsfiddle.net/o5tqeuha/

### Fixed
https://jsfiddle.net/xr2jvnof/

## Screenshot 
|Broken|Fixed|
|-|-|
|![checkbox_shape_broken](https://user-images.githubusercontent.com/18379884/53579344-abbeca80-3b79-11e9-9583-cc1ef87531df.gif)|![checkbox_shape_fixed](https://user-images.githubusercontent.com/18379884/53579358-b37e6f00-3b79-11e9-8620-8da136ff309c.gif)|

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6583

