### PR TITLE
[Dropdown] Missing event property in focus event raises JS error in firefox

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1062,7 +1062,7 @@ $.fn.dropdown = function(parameters) {
             }
           },
           search: {
-            focus: function() {
+            focus: function(event) {
               activated = true;
               if(module.is.multiple()) {
                 module.remove.activeLabel();

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1067,7 +1067,7 @@ $.fn.dropdown = function(parameters) {
               if(module.is.multiple()) {
                 module.remove.activeLabel();
               }
-              if(settings.showOnFocus || event.type !== 'focus') {
+              if(settings.showOnFocus || (event.type !== 'focus' && event.type !== 'focusin')) {
                 module.search();
               }
             },


### PR DESCRIPTION
## Description
Because the global event object is not available in firefox but is supplied as property to the event method and the focus event was missing this property, firefox raises a JS error at the console.
This has now been catched by correctly adding the event property to the focus event function.

## Testcase
-  Use Firefox
- Open the modal by clicking the button
- Watch the console

### Broken
https://jsfiddle.net/dutrieux/7gwko0L6/14/

### Fixed
https://jsfiddle.net/zhgwbLjd/

## Screenshot
![dialog](https://user-images.githubusercontent.com/1622751/53684367-9c23bb00-3d0c-11e9-9522-8a3a5376d497.gif)

## Closes
#533 
