### PR TITLE
[Button] Basic button loop always used "primary" for margin

### DIFF
--- a/src/definitions/elements/button.less
+++ b/src/definitions/elements/button.less
@@ -1771,7 +1771,7 @@ each(@colors, {
     box-shadow: 0 0 0 @basicColoredBorderSize @@_backgroundColorDown inset;
     color: @@_backgroundColorDown;
   }
-  .ui.buttons:not(.vertical) > .basic.primary.button:not(:first-child) {
+  .ui.buttons:not(.vertical) > .basic.@{consequence}.button:not(:first-child) {
     margin-left: -@basicColoredBorderSize;
   }
 }


### PR DESCRIPTION
## Description
Thanks to @dylmye for the hint

The consequences loop for basic buttons always used "primary" when setting the margin instead of the supplied consequences name .

## Closes
https://github.com/Semantic-Org/Semantic-UI/pull/6766
