### PR TITLE
[Formvalidation] Support checkbox groups for "checked" rule like radio groups

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1040,9 +1040,9 @@ $.fn.form = function(parameters) {
               ruleName     = module.get.ruleName(rule),
               ruleFunction = settings.rules[ruleName],
               invalidFields = [],
-              isRadio = $field.is(selector.radio),
+              isCheckbox = $field.is(selector.checkbox),
               isValid = function(field){
-                var value = (isRadio ? $(field).filter(':checked').val() : $(field).val());
+                var value = (isCheckbox ? $(field).filter(':checked').val() : $(field).val());
                 // cast to string avoiding encoding special values
                 value = (value === undefined || value === '' || value === null)
                     ? ''
@@ -1055,7 +1055,7 @@ $.fn.form = function(parameters) {
               module.error(error.noRule, ruleName);
               return;
             }
-            if(isRadio) {
+            if(isCheckbox) {
               if (!isValid($field)) {
                 invalidFields = $field;
               }


### PR DESCRIPTION
## Description
Checkbox groups where the checkboxes share the same name property were only "checked" validated if every single checkbox within the group was checked. This is wrong, it should behave the same as the radio group "checked" validation (SUI does it)

> Hint: The example uses the same name attribute for each checkbox also with a bracket suffix "[]"
The form validator already supports using this selector by putting it into quotes .
> Hint 2: selector.checkbox covers checkbox and radiobutton aswell..in case you wonder if the old behavior with radio still works 

```javascript
fields: {
    "sizes[]": 'checked'
  },
```

## Testcase
### Broken
Every toggle checkbox has to be checked to pass the validation
https://jsfiddle.net/ogz73ks5/

### Fixed
Only one checkbox has to be checked to pass validation
https://jsfiddle.net/ogz73ks5/2/

## Screenshot
|Broken|Fixed|
|-|-|
|![checkboxgroup_bad](https://user-images.githubusercontent.com/18379884/53899612-e1acf480-403a-11e9-9d4a-53cacacc62a1.gif)|![checkboxgroup_good](https://user-images.githubusercontent.com/18379884/53899622-e5d91200-403a-11e9-8726-9b1078d83ddf.gif)|




