### PR TITLE
[Checkbox] Proper check for non existent event object in Firefox

### DIFF
--- a/src/definitions/modules/checkbox.js
+++ b/src/definitions/modules/checkbox.js
@@ -175,7 +175,7 @@ $.fn.checkbox = function(parameters) {
         },
 
         preventDefaultOnInputTarget: function() {
-          if(event && $(event.target).is(selector.input)) {
+          if(typeof event !== 'undefined' && $(event.target).is(selector.input)) {
             module.verbose('Preventing default check action after manual check action');
             event.preventDefault();
           }


### PR DESCRIPTION
## Description
The fix in #509 (which fixes a IE only behavior) did not fetch a possible call by firefox, which in turn does not provide the global "event" object.
The original fix was done in a method that is not necessarily called by an event, so a proper check for an existing `event` variable was missing, as it is only needed for IE.

## Testcase
This is the original fiddle adjusted by the fix from this PR. Open this on firefox and it will raise a console error when trying to hover or change the checkbox  😢 

### Broken (on Firefox only)
https://jsfiddle.net/06kde5fg/

### Fixed
https://jsfiddle.net/q48rLgap/

## Closes
#543 
