### PR TITLE
[Form validation] Check if `validation[field] !== undefined` before accessing any of it's properties

### DIFF
--- a/dist/components/form.js
+++ b/dist/components/form.js
@@ -764,12 +764,12 @@ $.fn.form = function(parameters) {
                 ? rule
                 : [rule]
             ;
-            if(validation[field] === undefined || !Array.isArray(validation[field].rules)) {
-              return;
-            }
-            if(rule === undefined) {
+            if(rule == undefined) {
               module.debug('Removed all rules');
               validation[field].rules = [];
+              return;
+            }
+            if(validation[field] == undefined || !Array.isArray(validation[field].rules)) {
               return;
             }
             $.each(validation[field].rules, function(index, rule) {

--- a/dist/components/form.js
+++ b/dist/components/form.js
@@ -764,12 +764,12 @@ $.fn.form = function(parameters) {
                 ? rule
                 : [rule]
             ;
-            if(rule == undefined) {
-              module.debug('Removed all rules');
-              validation[field].rules = [];
+            if(validation[field] === undefined || !Array.isArray(validation[field].rules)) {
               return;
             }
-            if(validation[field] == undefined || !Array.isArray(validation[field].rules)) {
+            if(rule === undefined) {
+              module.debug('Removed all rules');
+              validation[field].rules = [];
               return;
             }
             $.each(validation[field].rules, function(index, rule) {

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -762,12 +762,12 @@ $.fn.form = function(parameters) {
                 ? rule
                 : [rule]
             ;
-            if(rule == undefined) {
-              module.debug('Removed all rules');
-              validation[field].rules = [];
+            if(validation[field] === undefined || !Array.isArray(validation[field].rules)) {
               return;
             }
-            if(validation[field] == undefined || !Array.isArray(validation[field].rules)) {
+            if(rule === undefined) {
+              module.debug('Removed all rules');
+              validation[field].rules = [];
               return;
             }
             $.each(validation[field].rules, function(index, rule) {


### PR DESCRIPTION


<!--
  Please read the contibuting guide before you submit a pull request
  https://github.com/fomantic/Fomantic-UI/blob/master/CONTRIBUTING.md
-->

## Description
When executing `form("remove fields", field) check if `validation[field] !== undefined` before accessing any of it's properties

## Testcase
<!-- Fork https://jsfiddle.net/31d6y7mn -->

## Screenshot (when possible)
![]()
