### PR TITLE
[Slider] Don't conflict with checkbox

### DIFF
--- a/src/definitions/modules/slider.less
+++ b/src/definitions/modules/slider.less
@@ -7,16 +7,16 @@
 
  @import (multiple) '../../theme.config';
 
-.ui.slider:not(.vertical) {
+.ui.slider:not(.vertical):not(.checkbox) {
   width: 100%;
   padding: @padding;
 }
 
-.ui.slider {
+.ui.slider:not(.checkbox) {
   position: relative;
 }
 
-.ui.slider:focus {
+.ui.slider:not(.checkbox):focus {
   outline: 0;
 }
 
@@ -89,7 +89,7 @@
      Disabled
 ---------------*/
 
-.ui.disabled.slider {
+.ui.disabled.slider:not(.checkbox) {
   opacity: @disabledOpactiy;
 }
 


### PR DESCRIPTION
## Description
The `slider` component conflicts with the existing `slider checkbox` especially in terms of padding

## Screenshots
|Single example|Table example|
|-|-|
|![slider_checkbox_bad](https://user-images.githubusercontent.com/18379884/54063339-f4c2ee80-420b-11e9-8c0d-224be4b5c7b4.gif)|![slider_checkbox_bad2](https://user-images.githubusercontent.com/18379884/54063348-f987a280-420b-11e9-96e9-8a2cdc862e1e.gif)|


## Closes
#547 
