### PR TITLE
[Formvalidation] Safari was not showing error message

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -277,7 +277,8 @@
 
 .ui.form .success.message,
 .ui.form .warning.message,
-.ui.form .error.message {
+.ui.form .error.message,
+.ui.form .error.message:empty {
   display: none;
 }
 


### PR DESCRIPTION
## Description
Because of an unclear CSS definition for `:empty` and `:not(:empty)`, Safari was never displaying any error message on form validation

## Testcase
https://jsfiddle.net/43kLfupd/5/
- Open in Safari
- Click on "Login" -> Error Message below the form appears as expected
- Remove the CSS Block
- Re-Run the jsfiddle
- Click on "Login" -> Error Message is not shown


## Closes
#557 
https://github.com/Semantic-Org/Semantic-UI/issues/6668
