### PR TITLE
[Site] Remove unknown CSS property: font-smoothing

### DIFF
--- a/src/definitions/globals/site.less
+++ b/src/definitions/globals/site.less
@@ -43,7 +43,6 @@ body {
   font-size: @fontSize;
   line-height: @lineHeight;
   color: @textColor;
-  font-smoothing: @fontSmoothing;
 }
 
 /*******************************

--- a/src/themes/default/globals/site.variables
+++ b/src/themes/default/globals/site.variables
@@ -7,7 +7,6 @@
 --------------------*/
 
 @fontName          : 'Lato';
-@fontSmoothing     : antialiased;
 
 @headerFont        : @fontName, 'Helvetica Neue', Arial, Helvetica, sans-serif;
 @pageFont          : @fontName, 'Helvetica Neue', Arial, Helvetica, sans-serif;

--- a/src/themes/flat/globals/site.variables
+++ b/src/themes/flat/globals/site.variables
@@ -15,7 +15,6 @@
 
 @headerFont    : "Open Sans", "Helvetica Neue", Arial, Helvetica, sans-serif;
 @pageFont      : "Open Sans", "Helvetica Neue", Arial, Helvetica, sans-serif;
-@fontSmoothing : antialiased;
 
 /*-------------------
       Site Colors


### PR DESCRIPTION
## Description

The unknown CSS property `font-smoothing` was found during introducing stylelint (linter for CSS and alt-CSSs like LESS) to FUI by the [`property-no-unknown` rule](https://stylelint.io/user-guide/rules/property-no-unknown/).
According to git history, the line had been added by jlukic in 2014 but not sure why.

[According to MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/font-smooth), there is no such property `font-smoothing` but `font-smooth`, `-webkit-font-smoothing` and `-moz-osx-font-smoothing`.
I think it is better to remove the invalid property.

Reasons
* It seems not working even on macOS because wrong name (just my guess, I don't have macOS), so removing it may not be a breaking change.
* Supported features are incompatible even between `-webkit-` and `-moz-`.
* Other browsers are unlikely to implement it.

## Closes
N/A