### PR TITLE
[Site] Support dpi > 100% for media queries

### DIFF
--- a/src/themes/default/globals/site.variables
+++ b/src/themes/default/globals/site.variables
@@ -781,10 +781,10 @@
 
 
 /* Responsive */
-@largestMobileScreen : (@tabletBreakpoint - 1px);
-@largestTabletScreen : (@computerBreakpoint - 1px);
-@largestSmallMonitor : (@largeMonitorBreakpoint - 1px);
-@largestLargeMonitor : (@widescreenMonitorBreakpoint - 1px);
+@largestMobileScreen : (@tabletBreakpoint - 0.01px);
+@largestTabletScreen : (@computerBreakpoint - 0.01px);
+@largestSmallMonitor : (@largeMonitorBreakpoint - 0.01px);
+@largestLargeMonitor : (@widescreenMonitorBreakpoint - 0.01px);
 
 
 /*-------------------


### PR DESCRIPTION
## Description
Using higher Screen-DPI Settings (on Windows) than 100% leads to some possible "floating value pixels" for width like "767.2px" 
The current breakpoints for every component are always set in full 1px difference. This creates a uncovered gap between 767 and 767.99 now where no media query covers a different visibility setting making every usually hidden element appear.

## Testcase
For simplicity the jsfiddle only covers the grid-element. But the PR just changes the breakpoints so every other element using media queries will get fixed at compile time aswell

### Broken
https://jsfiddle.net/o04hrpfL/1/show
- Use Windows
- Set your screen DPI Setting to 125%
- Use Chrome
- Resize the screen to 767.2 Pixel (yes, that's possible... just be patient when resizing the window 🙂 )

### Fixed
https://jsfiddle.net/o04hrpfL/show

## Screenshot
![image](https://user-images.githubusercontent.com/32823510/53306634-8ec68680-385d-11e9-95ea-0b31631e50ac.png)

## Closes
#385 
