### PR TITLE
[Dimmer] Loader inside simple inverted dimmer was still visible even when parent was not dimmed

### DIFF
--- a/src/definitions/modules/dimmer.less
+++ b/src/definitions/modules/dimmer.less
@@ -235,7 +235,7 @@ body.dimmable > .dimmer {
 .ui.simple.dimmer {
   display: block;
   overflow: hidden;
-  opacity: 1;
+  opacity: 0;
   width: 0;
   height: 0;
   z-index: -100;


### PR DESCRIPTION
## Description
According to the [docs](https://fomantic-ui.com/modules/dimmer.html#simple-dimmer), a `simple dimmer` should completely hide all of its content when the parent element is not `dimmed`

Unfortunately a possible loader inside the dimmer was still shown and got especially visible when used in a `simple inverted dimmer`

## Testcase
https://jsfiddle.net/2Lgukfc0/

Remove CSS to see the issue

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6257
