### PR TITLE
[Table] Inverted Table fixes for sortable header and disabled colored rows/cells

### DIFF
--- a/src/definitions/collections/table.less
+++ b/src/definitions/collections/table.less
@@ -875,7 +875,7 @@ each(@colors, {
   color: @invertedCellColor;
   border: @invertedBorder;
 }
-.ui.inverted.table th {
+.ui.ui.inverted.table th {
   background-color: @invertedHeaderBackground;
   border-color: @invertedHeaderBorderColor;
   color: @invertedHeaderColor;
@@ -891,7 +891,12 @@ each(@colors, {
   pointer-events: none;
   color: @invertedDisabledTextColor;
 }
-
+.ui.inverted.table tr td.disabled:not([class="disabled"]),
+.ui.inverted.table tr.disabled:not([class="disabled"]) td,
+.ui.inverted.table tr.disabled td[class]:not(.disabled),
+.ui.inverted.table tr:hover td.disabled:not([class="disabled"]) {
+  color: @disabledTextColor;
+}
 /* Definition */
 .ui.inverted.definition.table tfoot:not(.full-width) th:first-child,
 .ui.inverted.definition.table thead:not(.full-width) th:first-child {
@@ -964,6 +969,9 @@ each(@colors, {
 .ui.celled.table tr th,
 .ui.celled.table tr td {
   border-left: @cellBorder;
+}
+.ui.inverted.celled.table tr td {
+  border-left: @invertedCellBorder;
 }
 .ui.celled.table tr th:first-child,
 .ui.celled.table tr td:first-child {

--- a/src/themes/default/collections/table.variables
+++ b/src/themes/default/collections/table.variables
@@ -206,6 +206,7 @@
 /* Inverted */
 @invertedBackground: #333333;
 @invertedBorder: none;
+@invertedCellBorder: 1px solid @whiteBorderColor;
 @invertedCellBorderColor: @whiteBorderColor;
 @invertedCellColor: @invertedTextColor;
 


### PR DESCRIPTION
## Description
A few fixes for `inverted table`

- `sortable table` header still had black text color
- `disabled` rows or cells on (also) colored rows/cells had unreadable text color
- `celled` cells still had the same, thus too dark, left cell border from the non-inverted variant

## Testcase
https://jsfiddle.net/63g1y07j/5/

Remove CSS to see issues

## Screenshot 
### Broken
![image](https://user-images.githubusercontent.com/18379884/54857263-9f540a80-4cfe-11e9-8e13-b7345a4874d1.png)

### Fixed
![image](https://user-images.githubusercontent.com/18379884/54857232-759ae380-4cfe-11e9-822c-44aa3843f52b.png)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6778
