### PR TITLE
[Progress] Allow multiple bars

### DIFF
--- a/src/definitions/modules/progress.js
+++ b/src/definitions/modules/progress.js
@@ -259,6 +259,7 @@ $.fn.progress = function(parameters) {
               .replace('{total}', total)
               .replace('{left}', left)
               .replace('{percent}', percent)
+              .replace('{bar}', settings.text.bars[index] || '')
             ;
             module.verbose('Adding variables to progress bar text', templateText);
             return templateText;
@@ -985,7 +986,8 @@ $.fn.progress.settings = {
     success : false,
     warning : false,
     percent : '{percent}%',
-    ratio   : '{value} of {total}'
+    ratio   : '{value} of {total}',
+    bars    : ['']
   },
 
   className : {

--- a/src/definitions/modules/progress.js
+++ b/src/definitions/modules/progress.js
@@ -188,20 +188,16 @@ $.fn.progress = function(parameters) {
             newValue
           ;
           if( module.has.total() ) {
-            module.debug("has total");
             startValue     = module.get.value();
             incrementValue = incrementValue || 1;
-            newValue       = startValue + incrementValue;
           }
           else {
-            module.debug("do not have total");
             startValue     = module.get.percent();
             incrementValue = incrementValue || module.get.randomValue();
-            newValue       = startValue + incrementValue;
           }
-          module.debug('Incrementing percentage by start:', startValue, 'new:',newValue, 'step:', incrementValue);
+          newValue = startValue + incrementValue;
+          module.debug('Incrementing percentage by', startValue, newValue, incrementValue);
           newValue = module.get.normalizedValue(newValue);
-          module.debug('normalized:', newValue);
           module.set.progress(newValue);
         },
         decrement: function(decrementValue) {

--- a/src/definitions/modules/progress.js
+++ b/src/definitions/modules/progress.js
@@ -24,7 +24,7 @@ window = (typeof window != 'undefined' && window.Math == Math)
 ;
 
 function toArray(element) {
-  return $.isArray(element)
+  return Array.isArray(element)
     ? element
     : typeof element == 'string'
       ? element.split(',')

--- a/src/definitions/modules/progress.js
+++ b/src/definitions/modules/progress.js
@@ -250,7 +250,7 @@ $.fn.progress = function(parameters) {
               .replace('{total}', total)
               .replace('{left}', left)
               .replace('{percent}', percent)
-              .replace('{bar}', settings.text.bars[index] || '')
+              .replace('{bar}', settings.text.bars[index_] || '')
             ;
             module.verbose('Adding variables to progress bar text', templateText);
             return templateText;

--- a/src/definitions/modules/progress.js
+++ b/src/definitions/modules/progress.js
@@ -71,7 +71,7 @@ $.fn.progress = function(parameters) {
 
         $module         = $(this),
         $bars           = $(this).find(selector.bar),
-        $progresss      = $(this).find(selector.progress),
+        $progresses     = $(this).find(selector.progress),
         $label          = $(this).find(selector.label),
 
         element         = this,
@@ -582,7 +582,7 @@ $.fn.progress = function(parameters) {
             }
           },
           barLabel: function(text) {
-            $progresss.map(function(index, element){
+            $progresses.map(function(index, element){
               var $progress = $(element);
               if (text !== undefined) {
                 $progress.text( module.get.text(text, index) );

--- a/src/definitions/modules/progress.js
+++ b/src/definitions/modules/progress.js
@@ -443,27 +443,21 @@ $.fn.progress = function(parameters) {
                     firstNonZeroIndex = index;
                   }
                   lastNonZeroIndex = index;
-                  $bar.css('display', 'block');
-                  $bar.css('width', value + '%');
+                  $bar.css({
+                    display: 'block',
+                    width: value + '%'
+                  });
                 }
                 return parseInt(value, 10);
               });
               values.forEach(function(_, index) {
                 var $bar = $($bars[index]);
-                if (index == firstNonZeroIndex) {
-                  $bar.css('border-top-left-radius', '');
-                  $bar.css('border-bottom-left-radius', '');
-                } else {
-                  $bar.css('border-top-left-radius', 0);
-                  $bar.css('border-bottom-left-radius', 0);
-                }
-                if (index == lastNonZeroIndex) {
-                  $bar.css('border-top-right-radius', '');
-                  $bar.css('border-bottom-right-radius', '');
-                } else {
-                  $bar.css('border-top-right-radius', 0);
-                  $bar.css('border-bottom-right-radius', 0);
-                }
+                $bar.css({
+                  borderTopLeftRadius: index == firstNonZeroIndex ? '' : 0,
+                  borderBottomLeftRadius: index == firstNonZeroIndex ? '' : 0,
+                  borderTopRightRadius: index == lastNonZeroIndex ? '' : 0,
+                  borderBottomRightRadius: index == lastNonZeroIndex ? '' : 0
+                });
               });
               $module
                 .attr('data-percent', percents)

--- a/src/definitions/modules/progress.less
+++ b/src/definitions/modules/progress.less
@@ -414,15 +414,11 @@ each(@colors, {
   @c: @colors[@@color][color];
   @l: @colors[@@color][light];
 
-  .ui.@{color}.progress .bar {
-    background-color: @c;
-  }
-  .ui.@{color}.inverted.progress .bar {
-    background-color: @l;
-  }
+  .ui.@{color}.progress .bar,
   .ui.progress .@{color}.bar {
     background-color: @c;
   }
+  .ui.@{color}.inverted.progress .bar,
   .ui.inverted.progress .@{color}.bar {
     background-color: @l;
   }

--- a/src/definitions/modules/progress.less
+++ b/src/definitions/modules/progress.less
@@ -55,6 +55,7 @@
   background: @barBackground;
   border-radius: @barBorderRadius;
   transition: @barTransition;
+  overflow: hidden;
 }
 .ui.ui.ui.progress:not([data-percent]) .bar,
 .ui.ui.ui.progress[data-percent="0"] .bar {

--- a/src/definitions/modules/progress.less
+++ b/src/definitions/modules/progress.less
@@ -221,6 +221,11 @@
   color: @successHeaderColor;
 }
 
+/* Multiple */
+.ui.multiple.progress {
+  display: flex;
+}
+
 /*******************************
              States
 *******************************/
@@ -412,6 +417,12 @@ each(@colors, {
     background-color: @c;
   }
   .ui.@{color}.inverted.progress .bar {
+    background-color: @l;
+  }
+  .ui.progress .@{color}.bar {
+    background-color: @c;
+  }
+  .ui.inverted.progress .@{color}.bar {
     background-color: @l;
   }
 })


### PR DESCRIPTION
## Description

Allow `progress` modue to have multiple bars.

* `data-percent` and `data-value` are extended to have multiple values like `data-pecent="30,0,70"`
* Bar of 0 width are hidden for readability.
* `{bar}` placeholder are added to indicate name of bars so that end-users can ditinguish bars.

## Screenshot (when possible)
![image](https://user-images.githubusercontent.com/127635/54867002-d12ca600-4dbe-11e9-9063-3431bb44b438.png)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6160

