### PR TITLE
[Step] Show step pointer and border also on stacked mobile for consistent look

### DIFF
--- a/src/definitions/elements/step.less
+++ b/src/definitions/elements/step.less
@@ -263,6 +263,8 @@
     flex-direction: column;
     border-radius: @borderRadius;
     padding: @verticalPadding @horizontalPadding;
+    border-right: none;
+    border-bottom: @stepsBorder;
   }
   .ui.steps:not(.unstackable) .step:first-child {
     padding: @verticalPadding @horizontalPadding;
@@ -270,13 +272,19 @@
   }
   .ui.steps:not(.unstackable) .step:last-child {
     border-radius: 0 0 @stepsBorderRadius @stepsBorderRadius;
+    border-bottom: none;
   }
 
   /* Arrow */
   .ui.steps:not(.unstackable) .step:after {
-    display: none !important;
+    top: unset;
+    bottom: -@arrowSize;
+    right: 50%;
+    transform: translateY(-50%) translateX(50%) rotate(45deg);
   }
-
+  .ui.vertical.steps .active.step:last-child:after {
+    display: none;
+  }
   /* Content */
   .ui.steps:not(.unstackable) .step .content {
     text-align: center;
@@ -394,6 +402,8 @@
   flex-direction: column;
   border-radius: @borderRadius;
   padding: @verticalPadding @horizontalPadding;
+  border-right: none;
+  border-bottom: @stepsBorder;
 }
 .ui[class*="tablet stackable"].steps .step:first-child {
   padding: @verticalPadding @horizontalPadding;
@@ -401,11 +411,15 @@
 }
 .ui[class*="tablet stackable"].steps .step:last-child {
   border-radius: 0 0 @stepsBorderRadius @stepsBorderRadius;
+  border-bottom: none;
 }
 
 /* Arrow */
 .ui[class*="tablet stackable"].steps .step:after {
-  display: none !important;
+  top: unset;
+  bottom: -@arrowSize;
+  right: 50%;
+  transform: translateY(-50%) translateX(50%) rotate(45deg);
 }
 
 /* Content */


### PR DESCRIPTION
## Description
Thanks to @Alamantus for the [original SUI-PR](https://github.com/Semantic-Org/Semantic-UI/pull/5929)

> Fix step borders by moving it below steps instead of bunching them all up to the right.
> This provides a consistent look for the steps when stacked and also remains separate from the "vertical" styled steps.

I also added an additional fix to still hide the pointer in the last active item in the forced vertical variant

## Testcase
- Size your screen to mobile size to force stacking of the steps. The arrow in active step will also appear now and the border is consistent now
https://jsfiddle.net/ochbq14w/

## Screenshot
### Desktop Steps as usual
![image](https://user-images.githubusercontent.com/18379884/54881840-91180280-4e54-11e9-8179-e4b32ce2bab2.png)

Notice the following changes on mobile:
- Step on Desktop always have a vertical 1px border divider which are missing on mobile
- On mobile the right border was doubled, thus bolder, if not the last disabled step
- The step pointer for the active step was missing on mobile


### Mobile steps were not consistent
|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/54881809-38e10080-4e54-11e9-95c4-581f894045db.png)|![image](https://user-images.githubusercontent.com/18379884/54881817-5b731980-4e54-11e9-8f8d-0bd5bbc465db.png)|

## Closes
https://github.com/Semantic-Org/Semantic-UI/pull/5929
