### PR TITLE
[Button] Fixed padding for fluid right/left labeled icon buttons

### DIFF
--- a/src/definitions/elements/button.less
+++ b/src/definitions/elements/button.less
@@ -1039,13 +1039,6 @@
   border-bottom-left-radius: @borderRadius;
 }
 
-/* Fluid Labeled */
-.ui.fluid[class*="left labeled"].icon.button,
-.ui.fluid[class*="right labeled"].icon.button {
-  padding-left: @horizontalPadding !important;
-  padding-right: @horizontalPadding !important;
-}
-
 /* Loading Icon in Labeled Button */
 .ui.labeled.icon.button > .loading.icon:before {
   animation: loader 2s linear infinite;


### PR DESCRIPTION
## Description
A `fluid left/right labeled icon button` always had a fixed equal padding on both sides without respecting the width of the label icon.
Infact this is basically already covered by the framework, because it's correctly adjusted for the non-fluid variant, but for some unknown and un-reproducable reason the padding was additionally overridden to the same value on both sides for the `fluid` variant, which is not neccessary and most important wrong.

## Testcase
https://jsfiddle.net/7bo0zyck/1/
Remove the CSS to see the issue

## Screenshot
|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/54884981-62f7ea00-4e77-11e9-82e4-cfdd04fd6cd0.png)|![image](https://user-images.githubusercontent.com/18379884/54884971-4d82c000-4e77-11e9-8025-bf20170798d8.png)|

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5181
