### PR TITLE
[Chore] Update jquery dependency for bower to the same version as for npm

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "web"  : "http://www.jacklukic.com"
   },
   "dependencies": {
-    "jquery"      : ">=1.8"
+    "jquery"      : "^3.2.1"
   },
   "main": [
     "src/semantic.less",


### PR DESCRIPTION
## Description
Increasing the jquery dependency for bower installations to the same version as for the usual npm package (^3.2.1) "fixes" an issue with animations used for example in accordion in case one is still using jquery 1.8
More info in the related SUI issue

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5731
