### PR TITLE
[Dropdown] Columnar dropdown variation

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -1147,6 +1147,27 @@ select.ui.dropdown {
 }
 
 /*--------------
+     Columnar
+---------------*/
+.ui.dropdown[class*="two column"] > .menu > .item {
+  display: inline-block;
+  width: 50%;
+}
+.ui.dropdown[class*="three column"] > .menu > .item {
+  display: inline-block;
+  width: 33%;
+}
+.ui.dropdown[class*="four column"] > .menu > .item {
+  display: inline-block;
+  width: 25%;
+}
+.ui.dropdown[class*="five column"] > .menu > .item {
+  display: inline-block;
+  width: 20%;
+}
+
+
+/*--------------
      Simple
 ---------------*/
 


### PR DESCRIPTION
## Description

This PR adds columnar variation to dropdown module like `two column dropdown` in the same manner as `two column grid`, so that more items can be glanced at once.
This is helpful if dropdown have tons of items (e.g. Countries, States/Providences, Divisions, something like that).

Numbers of columns can vary between 2 (`50%` for each item) and 5 (`20%` for each).

## Screenshot (when possible)
### Standard dropdown of 2 columns
![standard-two-col](https://user-images.githubusercontent.com/127635/54887966-f236e900-4edb-11e9-8236-d89b24a9d5dd.gif)

### Fluid search dropdown of 3 columns
![fluid-search-three-col](https://user-images.githubusercontent.com/127635/54887963-ea774480-4edb-11e9-8812-52c2e30e0392.gif)

 


## Closes
Related to #545 (taller dropdown) but different approach and different use-case .
