### PR TITLE
[Dropdown] Height variation

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -439,20 +439,44 @@ select.ui.dropdown {
   .ui.selection.dropdown .menu {
     max-height: @selectionMobileMaxMenuHeight;
   }
+  .ui.selection.dropdown.higher .menu {
+    max-height: @selectionMobileMaxMenuHeight * 2;
+  }
+  .ui.selection.dropdown.highest .menu {
+    max-height: @selectionMobileMaxMenuHeight * 3;
+  }
 }
 @media only screen and (min-width: @tabletBreakpoint) {
   .ui.selection.dropdown .menu {
     max-height: @selectionTabletMaxMenuHeight;
+  }
+  .ui.selection.dropdown.higher .menu {
+    max-height: @selectionTabletMaxMenuHeight * 2;
+  }
+  .ui.selection.dropdown.highest .menu {
+    max-height: @selectionTabletMaxMenuHeight * 3;
   }
 }
 @media only screen and (min-width: @computerBreakpoint) {
   .ui.selection.dropdown .menu {
     max-height: @selectionComputerMaxMenuHeight;
   }
+  .ui.selection.dropdown.higher .menu {
+    max-height: @selectionComputerMaxMenuHeight * 2;
+  }
+  .ui.selection.dropdown.highest .menu {
+    max-height: @selectionComputerMaxMenuHeight * 3;
+  }
 }
 @media only screen and (min-width: @widescreenMonitorBreakpoint) {
   .ui.selection.dropdown .menu {
     max-height: @selectionWidescreenMaxMenuHeight;
+  }
+  .ui.selection.dropdown.higher .menu {
+    max-height: @selectionWidescreenMaxMenuHeight * 2;
+  }
+  .ui.selection.dropdown.highest .menu {
+    max-height: @selectionWidescreenMaxMenuHeight * 3;
   }
 }
 

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -439,10 +439,10 @@ select.ui.dropdown {
   .ui.selection.dropdown .menu {
     max-height: @selectionMobileMaxMenuHeight;
   }
-  .ui.selection.dropdown.higher .menu {
+  .ui.selection.dropdown.long .menu {
     max-height: @selectionMobileMaxMenuHeight * 2;
   }
-  .ui.selection.dropdown.highest .menu {
+  .ui.selection.dropdown[class*="very long"] .menu {
     max-height: @selectionMobileMaxMenuHeight * 3;
   }
 }
@@ -450,10 +450,10 @@ select.ui.dropdown {
   .ui.selection.dropdown .menu {
     max-height: @selectionTabletMaxMenuHeight;
   }
-  .ui.selection.dropdown.higher .menu {
+  .ui.selection.dropdown.long .menu {
     max-height: @selectionTabletMaxMenuHeight * 2;
   }
-  .ui.selection.dropdown.highest .menu {
+  .ui.selection.dropdown[class*="very long"] .menu {
     max-height: @selectionTabletMaxMenuHeight * 3;
   }
 }
@@ -461,10 +461,10 @@ select.ui.dropdown {
   .ui.selection.dropdown .menu {
     max-height: @selectionComputerMaxMenuHeight;
   }
-  .ui.selection.dropdown.higher .menu {
+  .ui.selection.dropdown.long .menu {
     max-height: @selectionComputerMaxMenuHeight * 2;
   }
-  .ui.selection.dropdown.highest .menu {
+  .ui.selection.dropdown[class*="very long"] .menu {
     max-height: @selectionComputerMaxMenuHeight * 3;
   }
 }
@@ -472,10 +472,10 @@ select.ui.dropdown {
   .ui.selection.dropdown .menu {
     max-height: @selectionWidescreenMaxMenuHeight;
   }
-  .ui.selection.dropdown.higher .menu {
+  .ui.selection.dropdown.long .menu {
     max-height: @selectionWidescreenMaxMenuHeight * 2;
   }
-  .ui.selection.dropdown.highest .menu {
+  .ui.selection.dropdown[class*="very long"] .menu {
     max-height: @selectionWidescreenMaxMenuHeight * 3;
   }
 }

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -436,6 +436,12 @@ select.ui.dropdown {
 }
 
 @media only screen and (max-width : @largestMobileScreen) {
+  .ui.selection.dropdown[class*="very short"] .menu {
+    max-height: @selectionMobileMaxMenuHeight * 0.5;
+  }
+  .ui.selection.dropdown.short .menu {
+    max-height: @selectionMobileMaxMenuHeight * 0.75;
+  }
   .ui.selection.dropdown .menu {
     max-height: @selectionMobileMaxMenuHeight;
   }
@@ -447,6 +453,12 @@ select.ui.dropdown {
   }
 }
 @media only screen and (min-width: @tabletBreakpoint) {
+  .ui.selection.dropdown[class*="very short"] .menu {
+    max-height: @selectionTabletMaxMenuHeight * 0.5;
+  }
+  .ui.selection.dropdown.short .menu {
+    max-height: @selectionTabletMaxMenuHeight * 0.75;
+  }
   .ui.selection.dropdown .menu {
     max-height: @selectionTabletMaxMenuHeight;
   }
@@ -458,6 +470,12 @@ select.ui.dropdown {
   }
 }
 @media only screen and (min-width: @computerBreakpoint) {
+  .ui.selection.dropdown[class*="very short"] .menu {
+    max-height: @selectionComputerMaxMenuHeight * 0.5;
+  }
+  .ui.selection.dropdown.short .menu {
+    max-height: @selectionComputerMaxMenuHeight * 0.75;
+  }
   .ui.selection.dropdown .menu {
     max-height: @selectionComputerMaxMenuHeight;
   }
@@ -469,6 +487,12 @@ select.ui.dropdown {
   }
 }
 @media only screen and (min-width: @widescreenMonitorBreakpoint) {
+  .ui.selection.dropdown[class*="very short"] .menu {
+    max-height: @selectionWidescreenMaxMenuHeight * 0.5;
+  }
+  .ui.selection.dropdown.short .menu {
+    max-height: @selectionWidescreenMaxMenuHeight * 0.75;
+  }
   .ui.selection.dropdown .menu {
     max-height: @selectionWidescreenMaxMenuHeight;
   }


### PR DESCRIPTION
## Description

This PR adds height variation to dropdown module so that more items can be glanced at once.
This is helpful if dropdown have tons of items (e.g. Countries, States/Providences, Divisions, something like that).

This is usable if every items can be shown at once within the height of window without scroll bar.
If there are so many items that requires scroll bar, user can consider columnar variation proposed in #586.

## Screenshot (when possible)

 
![image](https://user-images.githubusercontent.com/127635/54889431-f1a44f80-4ee7-11e9-9a9c-207e8f4a521f.png)



## Closes
Closes #545