### PR TITLE
[Dropdown] click-event was locked when single selection had allowAdditions enabled

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -529,6 +529,8 @@ $.fn.dropdown = function(parameters) {
                 callback.call(element);
               });
             }
+          } else if( module.can.click() ) {
+              module.unbind.intent();
           }
         },
 


### PR DESCRIPTION
## Description
When a single selection dropdown allowed additions which are not available in the dropdown itself by configuring the dropdown using `allowAdditions:true` and such non-existing value was entered, it was not possible to click anywhere else in the document anymore, because the click-event was swallowed.

Reason for this was that the dropdownmenu was not active but still visible. The empty dropdown was not animated to be hidden anymore and the unbinding of the click event  (which prevented any other click event)  did not take place, keeping all following clicks for the whole document in a trap. 

## Testcase
- Enter anything in the dropdown which does not exist, for example `foobar`.
- Try to click on the `clickaway` link which should open google in a  new blank browser window

### Broken
- Nothing happens, the click event is swallowed
https://jsfiddle.net/zwceqvtm

### Fixed
- the Link is opened in another window as expected
https://jsfiddle.net/zwceqvtm/1/

## Closes
#591 
