### PR TITLE
[Dropdown] prevent submenu vanishing for simple dropdowns

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -227,7 +227,7 @@
 ---------------*/
 
 .ui.dropdown .menu .menu {
-  top: @subMenuTop !important;
+  top: @subMenuTop;
   left: @subMenuLeft;
   right: @subMenuRight;
   margin: @subMenuMargin !important;


### PR DESCRIPTION
## Description
Simple dropdowns had a vanishing submenu if one item was hovered and this item overlapped another submenu.

## Testcase
As the fix is done by removing an unneccessary !important statement, i cannot provide a immediatly working fiddle.  You have to remove the `!important` from `top:0 !important;` of the `.ui.dropdown .menu .menu` selector via devtools. See screenshot.
https://jsfiddle.net/L7eabtcj/3/show

## Screenshot
![simple_dd_submenu_vanish](https://user-images.githubusercontent.com/18379884/55143752-b00de180-513f-11e9-95f8-f376272f38b1.gif)

## Closes
#590 
