### PR TITLE
[Modal] Don't wrap image content direct images

### DIFF
--- a/src/definitions/modules/modal.less
+++ b/src/definitions/modules/modal.less
@@ -116,7 +116,6 @@
 .ui.modal > .image.content {
   display: flex;
   flex-direction: row;
-  flex-wrap: wrap;
 }
 
 /* Image */


### PR DESCRIPTION
## Description
`image content` was wrongly fixed by #209. It set a forced flex wrapper although `image content` is supposed to stay in a row by using `flex-direction :row`.
This PR partly reverts #209 for this reason. Anyhow the issue in the mentioned SUI issue only occurs when the related images were very large. To still fix this i provided 3 workarounds, see testcases.

## Testcases
###  Fix for #599
Text is set next to the image (in a row) as expected and as it was until 2.6.4. It is not force-wrapping anymore
https://jsfiddle.net/kdvum7ho/2/

Remove CSS (or watch the scrolling modal example at http://localhost:99/modules/modal.html#scrolling-modal ) to see the issue

###  Workaround 1 for the old reverted PR. 
Wrapping the image into a `ui image` div
https://jsfiddle.net/kdvum7ho/

###  Workaround 2 for the old reverted PR. 
Force wrapping by using `content` instead of `image content` 
https://jsfiddle.net/kdvum7ho/1/

###  Workaround 3 for the old reverted PR. 
Make sure the image is not oversized by using one of the image sizers like `ui medium image` instead of only `image`
https://jsfiddle.net/kdvum7ho/4/

## Closes
#599 

## Related
#209 
https://github.com/Semantic-Org/Semantic-UI/issues/6636
