### PR TITLE
[Button] Fix padding for compact labeled icon button icon

### DIFF
--- a/src/definitions/elements/button.less
+++ b/src/definitions/elements/button.less
@@ -656,6 +656,10 @@
 .ui.compact.labeled.icon.button {
   padding: @compactVerticalPadding (@compactHorizontalPadding + @labeledIconWidth) ( @compactVerticalPadding + @shadowOffset );
 }
+.ui.compact.labeled.icon.buttons .button > .icon,
+.ui.compact.labeled.icon.button > .icon {
+  padding: @compactVerticalPadding 0 @compactVerticalPadding 0;
+}
 
 /*-------------------
         Sizes


### PR DESCRIPTION
## Description
The icon padding had to be adjusted for `compact labeled icon button`, because the positioning of the icon was optimized to support loading icons in #361 

## Testcase
http://jsfiddle.net/0vp6kz2g/

Remove CSS to see the issue

## Screenshot
|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/55268160-9bd4fc00-5287-11e9-9aa7-90b8fe6152db.png)|![image](https://user-images.githubusercontent.com/18379884/55268145-84960e80-5287-11e9-9a01-481360ee776c.png)|

## Closes
#598 
