### PR TITLE
[Table] Definition table footer had wrong box-shadow to the left

### DIFF
--- a/src/definitions/collections/table.less
+++ b/src/definitions/collections/table.less
@@ -261,7 +261,7 @@
   background: @definitionFooterBackground;
   font-weight: @definitionFooterFontWeight;
   color: @definitionFooterColor;
-  box-shadow: @borderWidth @borderWidth 0 @borderWidth @definitionPageBackground;
+  box-shadow: -@borderWidth @borderWidth 0 @borderWidth @definitionPageBackground;
 }
 
 /* Remove Border */


### PR DESCRIPTION
## Description
A `definition table` footer had a box-shadow set to the left. It should look like the header.

Thanks to @Banandrew for the finding and original fix (2 years ago... 🙄 )

## Testcase
http://jsfiddle.net/cLraoj6x/
Remove CSS to see the issue

## Screenshot
|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/55280093-09813680-5321-11e9-827d-de34d0a8a32c.png)|![image](https://user-images.githubusercontent.com/18379884/55280086-ef475880-5320-11e9-9c16-9cfa79324d9f.png)|


