### PR TITLE
[Chore] Switched comment blocks to Fomantic UI references

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -31,7 +31,7 @@ Each gulp task can be imported into your own Gulpfile using `require`
 ```javascript
 const watch = require('path/to/semantic/tasks/watch');
 
-gulp.task('watch ui', 'Watch Fomantic UI', watch));
+gulp.task('watch ui', 'Watch Fomantic-UI', watch));
 ```
 
 #### Importing LESS
@@ -79,7 +79,7 @@ Files in the  `examples/` folder of your project can be useful for testing out c
 #### Inheritance
 
 There are three levels of inheritance in Fomantic
-* Default theme - Fomantic UI's neutral default theme
+* Default theme - Fomantic-UI's neutral default theme
 * Packaged theme - A specified packaged theme, like "amazon", or "material"
 * Site theme - A theme specific to your site
 

--- a/src/README.md
+++ b/src/README.md
@@ -2,13 +2,13 @@
 
 ### Built-In Tools
 
-From the Semantic directory you can setup gulp to build Semantic by running.
+From the Fomantic directory you can setup gulp to build Fomantic by running.
 
 ```bash
 npm install
 ```
 
-Semantic will automatically configure itself using a `post-install` script built into the package.
+Fomantic will automatically configure itself using a `post-install` script built into the package.
 
 After set-up can use gulp to build your project's css:
 
@@ -31,7 +31,7 @@ Each gulp task can be imported into your own Gulpfile using `require`
 ```javascript
 const watch = require('path/to/semantic/tasks/watch');
 
-gulp.task('watch ui', 'Watch Semantic UI', watch));
+gulp.task('watch ui', 'Watch Fomantic UI', watch));
 ```
 
 #### Importing LESS
@@ -40,7 +40,7 @@ gulp.task('watch ui', 'Watch Semantic UI', watch));
 
 Before using source files you will need to create a `theme.config` by renaming `theme.config.example`, and a site folder by renaming `_site/` to `site/`
 
-You can then import Semantic from your own LESS files:
+You can then import Fomantic from your own LESS files:
 
 ```less
 /* Import all components */
@@ -66,7 +66,7 @@ filename | usage | Initial Name
 
 ### Workflow
 
-You will only need to use Semantic's build tools while refining your UI. When designing pages, you can rely on the compiled css packages in  `dist/`.
+You will only need to use Fomantic's build tools while refining your UI. When designing pages, you can rely on the compiled css packages in  `dist/`.
 
 When creating your UI you can try <a href="http://www.learnsemantic.com/themes/creating.html">downloading different themes</a>, adjusting your <a href="http://www.learnsemantic.com/developing/customizing.html#setting-global-variables">site-wide settings</a> (font-family, colors, etc) and tweaking components in your site's <a href="http://www.learnsemantic.com/developing/customizing.html#designing-for-the-long-now">component overrides</a>.
 
@@ -78,15 +78,15 @@ Files in the  `examples/` folder of your project can be useful for testing out c
 
 #### Inheritance
 
-There are three levels of inheritance in Semantic
-* Default theme - Semantic UI's neutral default theme
+There are three levels of inheritance in Fomantic
+* Default theme - Fomantic UI's neutral default theme
 * Packaged theme - A specified packaged theme, like "amazon", or "material"
 * Site theme - A theme specific to your site
 
 #### Folder Structure
 
 * `definitions/` contains the `css` and `javascript` definitions for each component
-* `themes/` contains *pre-packaged themes* including Semantic's default theme
+* `themes/` contains *pre-packaged themes* including Fomantic's default theme
 * `site/` contains your current site's theme
 
 View the [Theming Guide](http://learnsemantic.com/themes/overview.html) for a more in-depth look

--- a/src/definitions/behaviors/api.js
+++ b/src/definitions/behaviors/api.js
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - API
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - API
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/behaviors/api.js
+++ b/src/definitions/behaviors/api.js
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - API
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - API
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Form Validation
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Form Validation
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Form Validation
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Form Validation
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/behaviors/state.js
+++ b/src/definitions/behaviors/state.js
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - State
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - State
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/behaviors/state.js
+++ b/src/definitions/behaviors/state.js
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - State
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - State
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/behaviors/visibility.js
+++ b/src/definitions/behaviors/visibility.js
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Visibility
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Visibility
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/behaviors/visibility.js
+++ b/src/definitions/behaviors/visibility.js
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Visibility
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Visibility
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/collections/breadcrumb.less
+++ b/src/definitions/collections/breadcrumb.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Breadcrumb
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Breadcrumb
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/collections/breadcrumb.less
+++ b/src/definitions/collections/breadcrumb.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Breadcrumb
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Breadcrumb
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Form
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Form
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Form
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Form
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/collections/grid.less
+++ b/src/definitions/collections/grid.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Grid
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Grid
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/collections/grid.less
+++ b/src/definitions/collections/grid.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Grid
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Grid
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -1,6 +1,6 @@
 /*
- * # Semantic - Menu
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic - Menu
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Copyright 2015 Contributor

--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -1,6 +1,6 @@
 /*
  * # Fomantic - Menu
- * http://github.com/fomantic/fomantic-ui/
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Copyright 2015 Contributor

--- a/src/definitions/collections/message.less
+++ b/src/definitions/collections/message.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Message
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Message
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/collections/message.less
+++ b/src/definitions/collections/message.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Message
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Message
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/collections/table.less
+++ b/src/definitions/collections/table.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Table
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Table
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/collections/table.less
+++ b/src/definitions/collections/table.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Table
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Table
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/elements/button.less
+++ b/src/definitions/elements/button.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Button
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Button
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/elements/button.less
+++ b/src/definitions/elements/button.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Button
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Button
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/elements/container.less
+++ b/src/definitions/elements/container.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Container
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Container
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/elements/container.less
+++ b/src/definitions/elements/container.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Container
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Container
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/elements/divider.less
+++ b/src/definitions/elements/divider.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Divider
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Divider
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/elements/divider.less
+++ b/src/definitions/elements/divider.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Divider
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Divider
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/elements/flag.less
+++ b/src/definitions/elements/flag.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Flag
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Flag
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/elements/flag.less
+++ b/src/definitions/elements/flag.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Flag
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Flag
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/elements/header.less
+++ b/src/definitions/elements/header.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Header
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Header
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/elements/header.less
+++ b/src/definitions/elements/header.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Header
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Header
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Icon
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Icon
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Icon
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Icon
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/elements/image.less
+++ b/src/definitions/elements/image.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Image
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Image
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/elements/image.less
+++ b/src/definitions/elements/image.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Image
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Image
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/elements/input.less
+++ b/src/definitions/elements/input.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Input
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Input
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/elements/input.less
+++ b/src/definitions/elements/input.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Input
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Input
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/elements/label.less
+++ b/src/definitions/elements/label.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Label
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Label
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/elements/label.less
+++ b/src/definitions/elements/label.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Label
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Label
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/elements/list.less
+++ b/src/definitions/elements/list.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - List
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - List
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/elements/list.less
+++ b/src/definitions/elements/list.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - List
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - List
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/elements/loader.less
+++ b/src/definitions/elements/loader.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Loader
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Loader
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/elements/loader.less
+++ b/src/definitions/elements/loader.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Loader
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Loader
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/elements/placeholder.less
+++ b/src/definitions/elements/placeholder.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Loader
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Loader
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/elements/placeholder.less
+++ b/src/definitions/elements/placeholder.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Loader
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Loader
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/elements/rail.less
+++ b/src/definitions/elements/rail.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Rail
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Rail
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/elements/rail.less
+++ b/src/definitions/elements/rail.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Rail
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Rail
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/elements/reveal.less
+++ b/src/definitions/elements/reveal.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Reveal
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Reveal
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/elements/reveal.less
+++ b/src/definitions/elements/reveal.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Reveal
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Reveal
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Segment
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Segment
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Segment
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Segment
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/elements/step.less
+++ b/src/definitions/elements/step.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Step
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Step
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/elements/step.less
+++ b/src/definitions/elements/step.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Step
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Step
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/elements/text.less
+++ b/src/definitions/elements/text.less
@@ -1,5 +1,5 @@
 /*!
- * # Fomantic UI - Text
+ * # Fomantic-UI - Text
  * http://github.com/fomantic/Fomantic-UI/
  *
  *

--- a/src/definitions/globals/reset.less
+++ b/src/definitions/globals/reset.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Reset
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Reset
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/globals/reset.less
+++ b/src/definitions/globals/reset.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Reset
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Reset
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/globals/site.js
+++ b/src/definitions/globals/site.js
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Site
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Site
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/globals/site.js
+++ b/src/definitions/globals/site.js
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Site
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Site
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/globals/site.less
+++ b/src/definitions/globals/site.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Site
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Site
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/globals/site.less
+++ b/src/definitions/globals/site.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Site
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Site
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/accordion.js
+++ b/src/definitions/modules/accordion.js
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Accordion
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Accordion
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/accordion.js
+++ b/src/definitions/modules/accordion.js
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Accordion
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Accordion
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/accordion.less
+++ b/src/definitions/modules/accordion.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Accordion
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Accordion
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/accordion.less
+++ b/src/definitions/modules/accordion.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Accordion
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Accordion
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Calendar
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Calendar
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Calendar
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Calendar
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/calendar.less
+++ b/src/definitions/modules/calendar.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Calendar
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Calendar
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/calendar.less
+++ b/src/definitions/modules/calendar.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Calendar
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Calendar
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/checkbox.js
+++ b/src/definitions/modules/checkbox.js
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Checkbox
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Checkbox
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/checkbox.js
+++ b/src/definitions/modules/checkbox.js
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Checkbox
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Checkbox
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/checkbox.less
+++ b/src/definitions/modules/checkbox.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Checkbox
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Checkbox
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/checkbox.less
+++ b/src/definitions/modules/checkbox.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Checkbox
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Checkbox
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/dimmer.js
+++ b/src/definitions/modules/dimmer.js
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Dimmer
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Dimmer
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/dimmer.js
+++ b/src/definitions/modules/dimmer.js
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Dimmer
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Dimmer
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/dimmer.less
+++ b/src/definitions/modules/dimmer.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Dimmer
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Dimmer
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/dimmer.less
+++ b/src/definitions/modules/dimmer.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Dimmer
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Dimmer
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Dropdown
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Dropdown
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Dropdown
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Dropdown
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Dropdown
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Dropdown
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Dropdown
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Dropdown
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/embed.js
+++ b/src/definitions/modules/embed.js
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Embed
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Embed
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/embed.js
+++ b/src/definitions/modules/embed.js
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Embed
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Embed
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/embed.less
+++ b/src/definitions/modules/embed.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Video
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Video
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/embed.less
+++ b/src/definitions/modules/embed.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Video
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Video
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Modal
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Modal
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Modal
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Modal
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/modal.less
+++ b/src/definitions/modules/modal.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Modal
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Modal
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/modal.less
+++ b/src/definitions/modules/modal.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Modal
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Modal
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/nag.js
+++ b/src/definitions/modules/nag.js
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Nag
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Nag
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/nag.js
+++ b/src/definitions/modules/nag.js
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Nag
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Nag
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/nag.less
+++ b/src/definitions/modules/nag.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Nag
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Nag
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/nag.less
+++ b/src/definitions/modules/nag.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Nag
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Nag
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Popup
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Popup
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Popup
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Popup
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/popup.less
+++ b/src/definitions/modules/popup.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Popup
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Popup
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/popup.less
+++ b/src/definitions/modules/popup.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Popup
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Popup
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/progress.js
+++ b/src/definitions/modules/progress.js
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Progress
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Progress
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/progress.js
+++ b/src/definitions/modules/progress.js
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Progress
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Progress
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/progress.less
+++ b/src/definitions/modules/progress.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Progress Bar
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Progress Bar
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/progress.less
+++ b/src/definitions/modules/progress.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Progress Bar
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Progress Bar
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/rating.js
+++ b/src/definitions/modules/rating.js
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Rating
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Rating
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/rating.js
+++ b/src/definitions/modules/rating.js
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Rating
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Rating
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/rating.less
+++ b/src/definitions/modules/rating.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Rating
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Rating
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/rating.less
+++ b/src/definitions/modules/rating.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Rating
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Rating
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Search
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Search
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Search
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Search
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/search.less
+++ b/src/definitions/modules/search.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Search
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Search
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/search.less
+++ b/src/definitions/modules/search.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Search
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Search
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/shape.js
+++ b/src/definitions/modules/shape.js
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Shape
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Shape
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/shape.js
+++ b/src/definitions/modules/shape.js
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Shape
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Shape
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/shape.less
+++ b/src/definitions/modules/shape.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Shape
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Shape
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/shape.less
+++ b/src/definitions/modules/shape.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Shape
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Shape
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/sidebar.js
+++ b/src/definitions/modules/sidebar.js
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Sidebar
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Sidebar
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/sidebar.js
+++ b/src/definitions/modules/sidebar.js
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Sidebar
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Sidebar
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/sidebar.less
+++ b/src/definitions/modules/sidebar.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Sidebar
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Sidebar
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/sidebar.less
+++ b/src/definitions/modules/sidebar.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Sidebar
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Sidebar
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Slider
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Slider
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Slider
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Slider
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/sticky.js
+++ b/src/definitions/modules/sticky.js
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Sticky
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Sticky
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/sticky.js
+++ b/src/definitions/modules/sticky.js
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Sticky
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Sticky
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/sticky.less
+++ b/src/definitions/modules/sticky.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Sticky
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Sticky
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/sticky.less
+++ b/src/definitions/modules/sticky.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Sticky
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Sticky
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/tab.js
+++ b/src/definitions/modules/tab.js
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Tab
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Tab
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/tab.js
+++ b/src/definitions/modules/tab.js
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Tab
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Tab
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/tab.less
+++ b/src/definitions/modules/tab.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Tab
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Tab
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/tab.less
+++ b/src/definitions/modules/tab.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Tab
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Tab
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/toast.js
+++ b/src/definitions/modules/toast.js
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Toast
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Toast
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/toast.js
+++ b/src/definitions/modules/toast.js
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Toast
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Toast
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/toast.less
+++ b/src/definitions/modules/toast.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Toast
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Toast
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/toast.less
+++ b/src/definitions/modules/toast.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Toast
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Toast
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/transition.js
+++ b/src/definitions/modules/transition.js
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Transition
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Transition
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/transition.js
+++ b/src/definitions/modules/transition.js
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Transition
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Transition
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/transition.less
+++ b/src/definitions/modules/transition.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Transition
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Transition
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/modules/transition.less
+++ b/src/definitions/modules/transition.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Transition
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Transition
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/views/ad.less
+++ b/src/definitions/views/ad.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Ad
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Ad
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Copyright 2013 Contributors

--- a/src/definitions/views/ad.less
+++ b/src/definitions/views/ad.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Ad
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Ad
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Copyright 2013 Contributors

--- a/src/definitions/views/card.less
+++ b/src/definitions/views/card.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Card
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Card
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/views/card.less
+++ b/src/definitions/views/card.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Card
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Card
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/views/comment.less
+++ b/src/definitions/views/comment.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Comment
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Comment
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/views/comment.less
+++ b/src/definitions/views/comment.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Comment
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Comment
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/views/feed.less
+++ b/src/definitions/views/feed.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Feed
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Feed
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/views/feed.less
+++ b/src/definitions/views/feed.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Feed
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Feed
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/views/item.less
+++ b/src/definitions/views/item.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Item
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Item
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/views/item.less
+++ b/src/definitions/views/item.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Item
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Item
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/definitions/views/statistic.less
+++ b/src/definitions/views/statistic.less
@@ -1,6 +1,6 @@
 /*!
- * # Fomantic UI - Statistic
- * http://github.com/fomantic/fomantic-ui/
+ * # Fomantic-UI - Statistic
+ * http://github.com/fomantic/Fomantic-UI/
  *
  *
  * Released under the MIT license

--- a/src/definitions/views/statistic.less
+++ b/src/definitions/views/statistic.less
@@ -1,6 +1,6 @@
 /*!
- * # Semantic UI - Statistic
- * http://github.com/semantic-org/semantic-ui/
+ * # Fomantic UI - Statistic
+ * http://github.com/fomantic/fomantic-ui/
  *
  *
  * Released under the MIT license

--- a/src/semantic.less
+++ b/src/semantic.less
@@ -7,7 +7,7 @@
 ███████║███████╗██║ ╚═╝ ██║██║  ██║██║ ╚████║   ██║   ██║╚██████╗    ╚██████╔╝██║
 ╚══════╝╚══════╝╚═╝     ╚═╝╚═╝  ╚═╝╚═╝  ╚═══╝   ╚═╝   ╚═╝ ╚═════╝     ╚═════╝ ╚═╝
 
-  Import this file into your LESS project to use Fomantic UI without build tools
+  Import this file into your LESS project to use Fomantic-UI without build tools
 */
 
 /* Global */

--- a/src/semantic.less
+++ b/src/semantic.less
@@ -7,7 +7,7 @@
 ███████║███████╗██║ ╚═╝ ██║██║  ██║██║ ╚████║   ██║   ██║╚██████╗    ╚██████╔╝██║
 ╚══════╝╚══════╝╚═╝     ╚═╝╚═╝  ╚═╝╚═╝  ╚═══╝   ╚═╝   ╚═╝ ╚═════╝     ╚═════╝ ╚═╝
 
-  Import this file into your LESS project to use Semantic UI without build tools
+  Import this file into your LESS project to use Fomantic UI without build tools
 */
 
 /* Global */

--- a/src/themes/default/elements/icon.overrides
+++ b/src/themes/default/elements/icon.overrides
@@ -5,7 +5,7 @@
 
 /*******************************
 
-Semantic-UI integration of font-awesome :
+Fomantic-UI integration of font-awesome :
 
 ///class names are separated
 i.icon.circle => i.icon.circle


### PR DESCRIPTION
## Description
This PR just changes all Semantic UI References in code comment block headers (and in some parts of the readme) to Fomantic-UI references instead. Also in terms of separate npm/cdnjs/jsdlivr usage and the current situation of fomantic surpassing semantic by > 300 bugfixes and enhancements, i think this should be adjusted as long as fomantic will stay separate.

Feel free to decline this PR if you disagree.
