### PR TITLE
[Table] Don't break style when nested tables like calendar are used (or having different variants)

### DIFF
--- a/src/definitions/collections/table.less
+++ b/src/definitions/collections/table.less
@@ -43,8 +43,8 @@
 .ui.table:last-child {
   margin-bottom: 0;
 }
-.ui.table thead,
-.ui.table tbody {
+.ui.table > thead,
+.ui.table > tbody {
   text-align: inherit;
   vertical-align: inherit;
 }
@@ -60,10 +60,10 @@
 }
 
 /* Headers */
-.ui.table thead {
+.ui.table > thead {
   box-shadow: @headerBoxShadow;
 }
-.ui.table thead th {
+.ui.table > thead > th {
   cursor: auto;
   background: @headerBackground;
   text-align: @headerAlign;
@@ -77,25 +77,25 @@
   border-left: @headerDivider;
 }
 
-.ui.table thead tr > th:first-child {
+.ui.table > thead > tr > th:first-child {
   border-left: none;
 }
 
-.ui.table thead tr:first-child > th:first-child {
+.ui.table > thead > tr:first-child > th:first-child {
   border-radius: @borderRadius 0 0 0;
 }
-.ui.table thead tr:first-child > th:last-child {
+.ui.table > thead > tr:first-child > th:last-child {
   border-radius: 0 @borderRadius 0 0;
 }
-.ui.table thead tr:first-child > th:only-child {
+.ui.table > thead > tr:first-child > th:only-child {
   border-radius: @borderRadius @borderRadius 0 0;
 }
 
 /* Footer */
-.ui.table tfoot {
+.ui.table > tfoot {
   box-shadow: @footerBoxShadow;
 }
-.ui.table tfoot th {
+.ui.table > tfoot > th {
   cursor: auto;
   border-top: @footerBorder;
   background: @footerBackground;
@@ -107,34 +107,37 @@
   font-weight: @footerFontWeight;
   text-transform: @footerTextTransform;
 }
-.ui.table tfoot tr > th:first-child {
+.ui.table > tfoot > tr > th:first-child {
   border-left: none;
 }
-.ui.table tfoot tr:first-child > th:first-child {
+.ui.table > tfoot > tr:first-child > th:first-child {
   border-radius: 0 0 0 @borderRadius;
 }
-.ui.table tfoot tr:first-child > th:last-child {
+.ui.table > tfoot > tr:first-child > th:last-child {
   border-radius: 0 0 @borderRadius 0;
 }
-.ui.table tfoot tr:first-child > th:only-child {
+.ui.table > tfoot > tr:first-child > th:only-child {
   border-radius: 0 0 @borderRadius @borderRadius;
 }
 
 /* Table Row */
-.ui.table tr td {
+.ui.table > tr > td,
+.ui.table > tbody > tr > td {
   border-top: @rowBorder;
 }
-.ui.table tr:first-child td {
+.ui.table > tr:first-child > td,
+.ui.table > tbody > tr:first-child > td {
   border-top: none;
 }
 
 /* Repeated tbody */
-.ui.table tbody + tbody tr:first-child td {
+.ui.table > tbody + tbody tr:first-child > td {
   border-top: @rowBorder;
 }
 
 /* Table Cells */
-.ui.table td {
+.ui.table > tbody > tr > td,
+.ui.table > tr > td {
   padding: @cellVerticalPadding @cellHorizontalPadding;
   text-align: @cellTextAlign;
 }
@@ -165,40 +168,57 @@
     width: 100%;
     padding: 0;
   }
-  .ui.table:not(.unstackable) tbody,
-  .ui.table:not(.unstackable) tr,
-  .ui.table:not(.unstackable) tr > th,
-  .ui.table:not(.unstackable) tr > td  {
+  .ui.table:not(.unstackable) > tbody,
+  .ui.table:not(.unstackable) > tr,
+  .ui.table:not(.unstackable) > tbody > tr,
+  .ui.table:not(.unstackable) > tr > th,
+  .ui.table:not(.unstackable) > thead > tr > th,
+  .ui.table:not(.unstackable) > tbody > tr > th,
+  .ui.table:not(.unstackable) > tfoot > tr > th,
+  .ui.table:not(.unstackable) > tr > td,
+  .ui.table:not(.unstackable) > tbody > tr > td {
     display: block !important;
     width: auto !important;
   }
 
-  .ui.table:not(.unstackable) thead {
+  .ui.table:not(.unstackable) > thead {
     display: @responsiveHeaderDisplay;
   }
-  .ui.table:not(.unstackable) tfoot {
+  .ui.table:not(.unstackable) > tfoot {
     display: @responsiveFooterDisplay;
   }
-  .ui.table:not(.unstackable) tr {
+  .ui.table:not(.unstackable) > tr,
+  .ui.table:not(.unstackable) > thead > tr,
+  .ui.table:not(.unstackable) > tbody > tr,
+  .ui.table:not(.unstackable) > tfoot > tr {
     padding-top: @responsiveRowVerticalPadding;
     padding-bottom: @responsiveRowVerticalPadding;
     box-shadow: @responsiveRowBoxShadow;
   }
 
-  .ui.table:not(.unstackable) tr > th,
-  .ui.ui.ui.ui.table:not(.unstackable) tr > td {
+  .ui.table:not(.unstackable) > tr > th,
+  .ui.table:not(.unstackable) > thead > tr > th,
+  .ui.table:not(.unstackable) > tbody > tr > th,
+  .ui.table:not(.unstackable) > tfoot > tr > th,
+  .ui.ui.ui.ui.table:not(.unstackable) > tr > td,
+  .ui.ui.ui.ui.table:not(.unstackable) > tbody > tr > td {
     background: none;
     border: none;
     padding: @responsiveCellVerticalPadding @responsiveCellHorizontalPadding;
     box-shadow: @responsiveCellBoxShadow;
   }
-  .ui.table:not(.unstackable) th:first-child,
-  .ui.table:not(.unstackable) td:first-child {
+  .ui.table:not(.unstackable) > tr > th:first-child,
+  .ui.table:not(.unstackable) > thead > th:first-child,
+  .ui.table:not(.unstackable) > tbody > th:first-child,
+  .ui.table:not(.unstackable) > tfoot > th:first-child,
+  .ui.table:not(.unstackable) > td:first-child,
+  .ui.table:not(.unstackable) > tr > td:first-child,
+  .ui.table:not(.unstackable) > tbody > tr > td:first-child {
     font-weight: @responsiveCellHeaderFontWeight;
   }
 
   /* Definition Table */
-  .ui.definition.table:not(.unstackable) thead th:first-child {
+  .ui.definition.table:not(.unstackable) > thead > th:first-child {
     box-shadow: none !important;
   }
 }
@@ -226,20 +246,27 @@
 .ui.structured.table {
   border-collapse: collapse;
 }
-.ui.structured.table thead th {
+.ui.structured.table > thead > tr > th {
   border-left: @headerDivider;
   border-right: @headerDivider;
 }
-.ui.structured.sortable.table thead th {
+.ui.structured.sortable.table > thead > tr > th {
   border-left: @sortableBorder;
   border-right: @sortableBorder;
 }
-.ui.structured.basic.table th {
+.ui.structured.basic.table > tr > th,
+.ui.structured.basic.table > thead > tr > th,
+.ui.structured.basic.table > tbody > tr > th,
+.ui.structured.basic.table > tfoot > tr > th {
   border-left: @basicTableHeaderDivider;
   border-right: @basicTableHeaderDivider;
 }
-.ui.structured.celled.table tr th,
-.ui.structured.celled.table tr td {
+.ui.structured.celled.table > tr > th,
+.ui.structured.celled.table > thead > tr > th,
+.ui.structured.celled.table > tbody > tr > th,
+.ui.structured.celled.table > tfoot > tr > th,
+.ui.structured.celled.table > tr > td,
+.ui.structured.celled.table > tbody > tr > td {
   border-left: @cellBorder;
   border-right: @cellBorder;
 }
@@ -248,7 +275,7 @@
    Definition
 ---------------*/
 
-.ui.definition.table thead:not(.full-width) th:first-child {
+.ui.definition.table > thead:not(.full-width) > tr > th:first-child {
   pointer-events: none;
   background: @definitionHeaderBackground;
   font-weight: @definitionHeaderFontWeight;
@@ -256,7 +283,7 @@
   box-shadow: -@borderWidth -@borderWidth 0 @borderWidth @definitionPageBackground;
 }
 
-.ui.definition.table tfoot:not(.full-width) th:first-child {
+.ui.definition.table > tfoot:not(.full-width) > tr > th:first-child {
   pointer-events: none;
   background: @definitionFooterBackground;
   font-weight: @definitionFooterFontWeight;
@@ -265,15 +292,16 @@
 }
 
 /* Remove Border */
-.ui.celled.definition.table thead:not(.full-width) th:first-child {
+.ui.celled.definition.table > thead:not(.full-width) > tr > th:first-child {
   box-shadow: 0 -@borderWidth 0 @borderWidth @definitionPageBackground;
 }
-.ui.celled.definition.table tfoot:not(.full-width) th:first-child {
+.ui.celled.definition.table > tfoot:not(.full-width) > tr > th:first-child {
   box-shadow: 0 @borderWidth 0 @borderWidth @definitionPageBackground;
 }
 
 /* Highlight Defining Column */
-.ui.definition.table tr td:first-child:not(.ignored),
+.ui.definition.table > tr > td:first-child:not(.ignored),
+.ui.definition.table > tbody > tr > td:first-child:not(.ignored),
 .ui.definition.table tr td.definition {
   background: @definitionColumnBackground;
   font-weight: @definitionColumnFontWeight;
@@ -288,13 +316,14 @@
 
 
 /* Fix 2nd Column */
-.ui.definition.table thead:not(.full-width) th:nth-child(2) {
+.ui.definition.table > thead:not(.full-width) > tr > th:nth-child(2) {
   border-left: @borderWidth solid @borderColor;
 }
-.ui.definition.table tfoot:not(.full-width) th:nth-child(2) {
+.ui.definition.table > tfoot:not(.full-width) > tr > th:nth-child(2) {
   border-left: @borderWidth solid @borderColor;
 }
-.ui.definition.table td:nth-child(2) {
+.ui.definition.table > tr > td:nth-child(2),
+.ui.definition.table > tbody > tr > td:nth-child(2) {
   border-left: @borderWidth solid @borderColor;
 }
 
@@ -383,10 +412,15 @@
 @media only screen and (max-width : @largestTabletScreen) {
 
   .ui[class*="tablet stackable"].table,
-  .ui[class*="tablet stackable"].table tbody,
-  .ui[class*="tablet stackable"].table tr,
-  .ui[class*="tablet stackable"].table tr > th,
-  .ui[class*="tablet stackable"].table tr > td  {
+  .ui[class*="tablet stackable"].table > tbody,
+  .ui[class*="tablet stackable"].table > tbody > tr,
+  .ui[class*="tablet stackable"].table > tr,
+  .ui[class*="tablet stackable"].table > thead > tr > th,
+  .ui[class*="tablet stackable"].table > tbody > tr > th,
+  .ui[class*="tablet stackable"].table > tfoot > tr > th,
+  .ui[class*="tablet stackable"].table > tr > th,
+  .ui[class*="tablet stackable"].table > tbody > tr > td,
+  .ui[class*="tablet stackable"].table > tr > td  {
     display: block !important;
     width: 100% !important;
   }
@@ -394,19 +428,26 @@
   .ui[class*="tablet stackable"].table {
     padding: 0;
   }
-  .ui[class*="tablet stackable"].table thead {
+  .ui[class*="tablet stackable"].table > thead {
     display: @responsiveHeaderDisplay;
   }
-  .ui[class*="tablet stackable"].table tfoot {
+  .ui[class*="tablet stackable"].table > tfoot {
     display: @responsiveFooterDisplay;
   }
-  .ui[class*="tablet stackable"].table tr {
+  .ui[class*="tablet stackable"].table > thead > tr,
+  .ui[class*="tablet stackable"].table > tbody > tr,
+  .ui[class*="tablet stackable"].table > tfoot > tr,
+  .ui[class*="tablet stackable"].table > tr {
     padding-top: @responsiveRowVerticalPadding;
     padding-bottom: @responsiveRowVerticalPadding;
     box-shadow: @responsiveRowBoxShadow;
   }
-  .ui[class*="tablet stackable"].table tr > th,
-  .ui[class*="tablet stackable"].table tr > td {
+  .ui[class*="tablet stackable"].table > thead > tr > th,
+  .ui[class*="tablet stackable"].table > tbody > tr > th,
+  .ui[class*="tablet stackable"].table > tfoot > tr > th,
+  .ui[class*="tablet stackable"].table > tr > th,
+  .ui[class*="tablet stackable"].table > tbody > tr > td,
+  .ui[class*="tablet stackable"].table > tr > td {
     background: none;
     border: none !important;
     padding: @responsiveCellVerticalPadding @responsiveCellHorizontalPadding;
@@ -414,7 +455,7 @@
   }
 
   /* Definition Table */
-  .ui.definition[class*="tablet stackable"].table thead th:first-child {
+  .ui.definition[class*="tablet stackable"].table > thead > tr > th:first-child {
     box-shadow: none !important;
   }
 }
@@ -482,12 +523,12 @@
    Selectable
 ---------------*/
 
-.ui.ui.selectable.table tbody tr:hover,
+.ui.ui.selectable.table > tbody > tr:hover,
 .ui.table tbody tr td.selectable:hover {
   background: @selectableBackground;
   color: @selectableTextColor;
 }
-.ui.ui.selectable.inverted.table tbody tr:hover,
+.ui.ui.selectable.inverted.table > tbody > tr:hover,
 .ui.inverted.table tbody tr td.selectable:hover {
   background: @selectableInvertedBackground;
   color: @selectableInvertedTextColor;
@@ -587,13 +628,13 @@
 
 /* Table Striping */
 .ui.striped.table > tr:nth-child(2n),
-.ui.striped.table tbody tr:nth-child(2n) {
+.ui.striped.table > tbody > tr:nth-child(2n) {
   background-color: @stripedBackground;
 }
 
 /* Stripes */
 .ui.inverted.striped.table > tr:nth-child(2n),
-.ui.inverted.striped.table tbody tr:nth-child(2n) {
+.ui.inverted.striped.table > tbody > tr:nth-child(2n) {
   background-color: @invertedStripedBackground;
 }
 
@@ -792,13 +833,13 @@ each(@colors, {
     Sortable
 ---------------*/
 
-.ui.sortable.table thead th {
+.ui.sortable.table > thead > tr > th {
   cursor: pointer;
   white-space: nowrap;
   border-left: @sortableBorder;
   color: @sortableColor;
 }
-.ui.sortable.table thead th:first-child {
+.ui.sortable.table > thead > tr > th:first-child {
   border-left: none;
 }
 .ui.sortable.table thead th.sorted,
@@ -806,7 +847,7 @@ each(@colors, {
   user-select: none;
 }
 
-.ui.sortable.table thead th:after {
+.ui.sortable.table > thead > th:after {
   display: none;
   font-style: normal;
   font-weight: @normal;
@@ -830,7 +871,7 @@ each(@colors, {
   cursor: auto;
   color: @sortableDisabledColor;
 }
-.ui.sortable.table thead th:hover {
+.ui.sortable.table > thead >tr > th:hover {
   background: @sortableHoverBackground;
   color: @sortableHoverColor;
 }
@@ -855,11 +896,11 @@ each(@colors, {
   background: @sortableInvertedActiveBackground;
   color: @sortableInvertedActiveColor;
 }
-.ui.inverted.sortable.table thead th:hover {
+.ui.inverted.sortable.table > thead > tr > th:hover {
   background: @sortableInvertedHoverBackground;
   color: @sortableInvertedHoverColor;
 }
-.ui.inverted.sortable.table thead th {
+.ui.inverted.sortable.table > thead > tr > th {
   border-left-color: @sortableInvertedBorderColor;
   border-right-color: @sortableInvertedBorderColor;
 }
@@ -875,12 +916,16 @@ each(@colors, {
   color: @invertedCellColor;
   border: @invertedBorder;
 }
-.ui.ui.inverted.table th {
+.ui.ui.inverted.table > thead > tr > th,
+.ui.ui.inverted.table > tbody > tr > th,
+.ui.ui.inverted.table > tfoot > tr > th,
+.ui.ui.inverted.table > tr > th {
   background-color: @invertedHeaderBackground;
   border-color: @invertedHeaderBorderColor;
   color: @invertedHeaderColor;
 }
-.ui.inverted.table tr td {
+.ui.inverted.table > tbody > tr > td,
+.ui.inverted.table > tr > td {
   border-color: @invertedCellBorderColor;
 }
 
@@ -924,21 +969,25 @@ each(@colors, {
   border: @basicTableBorder;
   box-shadow: @basicBoxShadow;
 }
-.ui.basic.table thead,
-.ui.basic.table tfoot {
+.ui.basic.table > thead,
+.ui.basic.table > tfoot {
   box-shadow: none;
 }
-.ui.basic.table th {
+.ui.basic.table > thead > tr > th,
+.ui.basic.table > tbody > tr > th,
+.ui.basic.table > tfoot > tr > th,
+.ui.basic.table > tr > th {
   background: @basicTableHeaderBackground;
   border-left: @basicTableHeaderDivider;
 }
-.ui.basic.table tbody tr {
+.ui.basic.table > tbody > tr {
   border-bottom: @basicTableCellBorder;
 }
-.ui.basic.table td {
+.ui.basic.table > tbody > tr > td,
+.ui.basic.table > tr > td {
   background: @basicTableCellBackground;
 }
-.ui.basic.striped.table tbody tr:nth-child(2n) {
+.ui.basic.striped.table > tbody > tr:nth-child(2n) {
   background-color: @basicTableStripedBackground;
 }
 
@@ -946,19 +995,31 @@ each(@colors, {
 .ui[class*="very basic"].table {
   border: none;
 }
-.ui[class*="very basic"].table:not(.sortable):not(.striped) th,
-.ui[class*="very basic"].table:not(.sortable):not(.striped) td {
+.ui[class*="very basic"].table:not(.sortable):not(.striped) > tr > th,
+.ui[class*="very basic"].table:not(.sortable):not(.striped) > thead > tr > th,
+.ui[class*="very basic"].table:not(.sortable):not(.striped) > tbody > tr > th,
+.ui[class*="very basic"].table:not(.sortable):not(.striped) > tfoot > tr > th,
+.ui[class*="very basic"].table:not(.sortable):not(.striped) > tr > td,
+.ui[class*="very basic"].table:not(.sortable):not(.striped) > tbody > tr > td {
   padding: @basicTableCellPadding;
 }
-.ui[class*="very basic"].table:not(.sortable):not(.striped) th:first-child,
-.ui[class*="very basic"].table:not(.sortable):not(.striped) td:first-child {
+.ui[class*="very basic"].table:not(.sortable):not(.striped) > tr > th:first-child,
+.ui[class*="very basic"].table:not(.sortable):not(.striped) > thead > tr > th:first-child,
+.ui[class*="very basic"].table:not(.sortable):not(.striped) > tbody > tr > th:first-child,
+.ui[class*="very basic"].table:not(.sortable):not(.striped) > tfoot > tr > th:first-child,
+.ui[class*="very basic"].table:not(.sortable):not(.striped) > tr > td:first-child,
+.ui[class*="very basic"].table:not(.sortable):not(.striped) > tbody > tr > td:first-child {
   padding-left: 0;
 }
-.ui[class*="very basic"].table:not(.sortable):not(.striped) th:last-child,
-.ui[class*="very basic"].table:not(.sortable):not(.striped) td:last-child {
+.ui[class*="very basic"].table:not(.sortable):not(.striped) > tr > th:last-child,
+.ui[class*="very basic"].table:not(.sortable):not(.striped) > thead > tr > th:last-child,
+.ui[class*="very basic"].table:not(.sortable):not(.striped) > tbody > tr > th:last-child,
+.ui[class*="very basic"].table:not(.sortable):not(.striped) > tfoot > tr > th:last-child,
+.ui[class*="very basic"].table:not(.sortable):not(.striped) > tr > td:last-child,
+.ui[class*="very basic"].table:not(.sortable):not(.striped) > tbody > tr > td:last-child {
   padding-right: 0;
 }
-.ui[class*="very basic"].table:not(.sortable):not(.striped) thead tr:first-child th {
+.ui[class*="very basic"].table:not(.sortable):not(.striped) > thead > tr:first-child > th {
   padding-top: 0;
 }
 
@@ -966,15 +1027,24 @@ each(@colors, {
      Celled
 ---------------*/
 
-.ui.celled.table tr th,
-.ui.celled.table tr td {
+.ui.celled.table > tr > th,
+.ui.celled.table > thead > tr > th,
+.ui.celled.table > tbody > tr > th,
+.ui.celled.table > tfoot > tr > th,
+.ui.celled.table > tr > td,
+.ui.celled.table > tbody > tr > td {
   border-left: @cellBorder;
 }
-.ui.inverted.celled.table tr td {
+.ui.inverted.celled.table > tbody > tr > td,
+.ui.inverted.celled.table > tr > td {
   border-left: @invertedCellBorder;
 }
-.ui.celled.table tr th:first-child,
-.ui.celled.table tr td:first-child {
+.ui.celled.table > tr > th:first-child,
+.ui.celled.table > thead > tr > th:first-child,
+.ui.celled.table > tbody > tr > th:first-child,
+.ui.celled.table > tfoot > tr > th:first-child,
+.ui.celled.table > tr > td:first-child,
+.ui.celled.table > tbody > tr > td:first-child {
   border-left: none;
 }
 
@@ -982,21 +1052,32 @@ each(@colors, {
      Padded
 ---------------*/
 
-.ui.padded.table th {
+.ui.padded.table > tr > th,
+.ui.padded.table > thead > tr > th,
+.ui.padded.table > tbody > tr > th,
+.ui.padded.table > tfoot > tr > th {
   padding-left: @paddedHorizontalPadding;
   padding-right: @paddedHorizontalPadding;
 }
-.ui.padded.table th,
-.ui.padded.table td {
+.ui.padded.table > tr > th,
+.ui.padded.table > thead > tr > th,
+.ui.padded.table > tbody > tr > th,
+.ui.padded.table > tfoot > tr > th,
+.ui.padded.table > tr > td,
+.ui.padded.table > tbody > tr > td {
   padding: @paddedVerticalPadding @paddedHorizontalPadding;
 }
 
 /* Very */
-.ui[class*="very padded"].table th {
+.ui[class*="very padded"].table > tr > th,
+.ui[class*="very padded"].table > thead > tr > th,
+.ui[class*="very padded"].table > tbody > tr > th,
+.ui[class*="very padded"].table > tfoot > tr > th {
   padding-left: @veryPaddedHorizontalPadding;
   padding-right: @veryPaddedHorizontalPadding;
 }
-.ui[class*="very padded"].table td {
+.ui[class*="very padded"].table > tr > td,
+.ui[class*="very padded"].table > tbody > tr > td {
   padding: @veryPaddedVerticalPadding @veryPaddedHorizontalPadding;
 }
 
@@ -1004,20 +1085,28 @@ each(@colors, {
      Compact
 ---------------*/
 
-.ui.compact.table th {
+.ui.compact.table > tr > th,
+.ui.compact.table > thead > tr > th,
+.ui.compact.table > tbody > tr > th,
+.ui.compact.table > tfoot > tr > th {
   padding-left: @compactHorizontalPadding;
   padding-right: @compactHorizontalPadding;
 }
-.ui.compact.table td {
+.ui.compact.table > tr > td,
+.ui.compact.table > tbody > tr > td {
   padding: @compactVerticalPadding @compactHorizontalPadding;
 }
 
 /* Very */
-.ui[class*="very compact"].table th {
+.ui[class*="very compact"].table > tr > th,
+.ui[class*="very compact"].table > thead > tr > th,
+.ui[class*="very compact"].table > tbody > tr > th,
+.ui[class*="very compact"].table > tfoot > tr > th {
   padding-left: @veryCompactHorizontalPadding;
   padding-right: @veryCompactHorizontalPadding;
 }
-.ui[class*="very compact"].table td {
+.ui[class*="very compact"].table > tr > td,
+.ui[class*="very compact"].table > tbody > tr > td {
   padding: @veryCompactVerticalPadding @veryCompactHorizontalPadding;
 }
 

--- a/src/definitions/collections/table.less
+++ b/src/definitions/collections/table.less
@@ -63,7 +63,7 @@
 .ui.table > thead {
   box-shadow: @headerBoxShadow;
 }
-.ui.table > thead > th {
+.ui.table > thead > tr > th {
   cursor: auto;
   background: @headerBackground;
   text-align: @headerAlign;
@@ -95,7 +95,7 @@
 .ui.table > tfoot {
   box-shadow: @footerBoxShadow;
 }
-.ui.table > tfoot > th {
+.ui.table > tfoot > tr > th {
   cursor: auto;
   border-top: @footerBorder;
   background: @footerBackground;
@@ -208,17 +208,16 @@
     box-shadow: @responsiveCellBoxShadow;
   }
   .ui.table:not(.unstackable) > tr > th:first-child,
-  .ui.table:not(.unstackable) > thead > th:first-child,
-  .ui.table:not(.unstackable) > tbody > th:first-child,
-  .ui.table:not(.unstackable) > tfoot > th:first-child,
-  .ui.table:not(.unstackable) > td:first-child,
+  .ui.table:not(.unstackable) > thead > tr > th:first-child,
+  .ui.table:not(.unstackable) > tbody > tr > th:first-child,
+  .ui.table:not(.unstackable) > tfoot > tr > th:first-child,
   .ui.table:not(.unstackable) > tr > td:first-child,
   .ui.table:not(.unstackable) > tbody > tr > td:first-child {
     font-weight: @responsiveCellHeaderFontWeight;
   }
 
   /* Definition Table */
-  .ui.definition.table:not(.unstackable) > thead > th:first-child {
+  .ui.definition.table:not(.unstackable) > thead > tr > th:first-child {
     box-shadow: none !important;
   }
 }

--- a/src/definitions/collections/table.less
+++ b/src/definitions/collections/table.less
@@ -847,7 +847,7 @@ each(@colors, {
   user-select: none;
 }
 
-.ui.sortable.table > thead > th:after {
+.ui.sortable.table > thead > tr > th:after {
   display: none;
   font-style: normal;
   font-weight: @normal;
@@ -871,7 +871,7 @@ each(@colors, {
   cursor: auto;
   color: @sortableDisabledColor;
 }
-.ui.sortable.table > thead >tr > th:hover {
+.ui.sortable.table > thead > tr > th:hover {
   background: @sortableHoverBackground;
   color: @sortableHoverColor;
 }
@@ -943,11 +943,12 @@ each(@colors, {
   color: @disabledTextColor;
 }
 /* Definition */
-.ui.inverted.definition.table tfoot:not(.full-width) th:first-child,
-.ui.inverted.definition.table thead:not(.full-width) th:first-child {
+.ui.inverted.definition.table > tfoot:not(.full-width) > tr > th:first-child,
+.ui.inverted.definition.table > thead:not(.full-width) > tr > th:first-child {
   background: @definitionPageBackground;
 }
-.ui.inverted.definition.table tr td:first-child {
+.ui.inverted.definition.table > tbody > tr > td:first-child,
+.ui.inverted.definition.table > tr > td:first-child {
   background: @invertedDefinitionColumnBackground;
   color: @invertedDefinitionColumnColor;
 }


### PR DESCRIPTION
## Description
This PR enables support for nesting tables which use either different variants or components inside which themselves also use tables (like `calendar` which is used as the base for the testcase)

As you will see, all table definitions are now defined as direct sibling selectors to accomplish this.
In case the last selector had an additional specific table class set (e.g. `.table td.active`), the direct sibling change was not necessary, because the class clearly defines its usage, so don't get confused when reviewing.

This PR is based on a SUI PR by @Banandrew (again, 2 years ago... 🙄 ). I just had to fix some declarations and adjusted it to the current FUI codebase.

## Testcase
### Broken
https://jsfiddle.net/vd1b2ksf/

### Fixed
https://jsfiddle.net/vd1b2ksf/1/

## Screenshot
Example of a calendar inside a `definition table`
- Content is stacked on mobile
- Header is disabled
Try out the Testcase above for more examples
### Before
![image](https://user-images.githubusercontent.com/18379884/55289063-806e0c00-53c1-11e9-80b8-a344b338fbb6.png)

### After
![image](https://user-images.githubusercontent.com/18379884/55289068-a85d6f80-53c1-11e9-8251-7a468f832658.png)


## Closes
#575 
https://github.com/Semantic-Org/Semantic-UI/issues/5458
https://github.com/Semantic-Org/Semantic-UI/issues/5406
https://github.com/Semantic-Org/Semantic-UI/issues/5779
https://github.com/Semantic-Org/Semantic-UI/pull/5410
