### PR TITLE
[Modal] Don't close dimmer when another modal is still animating

### DIFF
--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -472,7 +472,7 @@ $.fn.modal = function(parameters) {
                   duration    : settings.duration,
                   useFailSafe : true,
                   onStart     : function() {
-                    if(!module.others.active() && !keepDimmed) {
+                    if(!module.others.active() && !module.others.animating() && !keepDimmed) {
                       module.hideDimmer();
                     }
                     if( settings.keyboardShortcuts && !module.others.active() ) {


### PR DESCRIPTION
## Description
When a modal opens another modal just when itself closes and both modals have `allowMultiple` set, the dimmer is hidden too early  making the second modal also close immediatly.

## Testcase
### Broken
https://jsfiddle.net/wrzjh1gy/1/

### Fixed
https://jsfiddle.net/wrzjh1gy

## Screenshot
### Broken
![modalopenonclose_broken](https://user-images.githubusercontent.com/18379884/55353276-31100480-54c3-11e9-873a-a0d4024f129c.gif)

### Fixed
![modalopenonclose_fixed](https://user-images.githubusercontent.com/18379884/55353317-4d13a600-54c3-11e9-8875-e81e07118e8f.gif)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6741
https://github.com/Semantic-Org/Semantic-UI/issues/6786