### PR TITLE
[Calendar] Support Date-Object given for parser.date, initialDate setting is wrongly displayed otherwise

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -1236,6 +1236,9 @@ $.fn.calendar.settings = {
 
   parser: {
     date: function (text, settings) {
+      if (text instanceof Date) {
+        return text;
+      }
       if (!text) {
         return null;
       }


### PR DESCRIPTION
## Description
Since #559 the value of `initialDate` setting is displayed in the input field of the calendar.
Unfortunately the parse.date function did not support raw Date Objects, but always expects text string, resulting in a wrong displayed date around Year 100 🙂 , e.g. when a Date Object is given as initialDate)

## Testcase
### Broken
https://jsfiddle.net/sruafp7k/

### Fixed
https://jsfiddle.net/sruafp7k/1/

Also reproducable on the current 2.7.4 docs page
https://fomantic-ui.com/modules/calendar.html#enable-only-specific-dates

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/55407546-6ddd0980-555e-11e9-8e50-61dcb76cbb02.png)

## Closes
#614 
