### PR TITLE
[Table] selectable rows/cells should have pointing cursor

### DIFF
--- a/src/definitions/collections/table.less
+++ b/src/definitions/collections/table.less
@@ -502,6 +502,12 @@
   color: inherit;
   padding: @cellVerticalPadding @cellHorizontalPadding;
 }
+.ui.table > tr > td.selectable,
+.ui.table > tbody > tr > td.selectable,
+.ui.selectable.table > tbody > tr,
+.ui.selectable.table > tr {
+  cursor:pointer;
+}
 
 /* Other States */
 .ui.ui.selectable.table tr.error:hover,


### PR DESCRIPTION
## Description
A selectable cell in a table already had a pointing cursor, but just because of the full sized a-tag within (browser default). For a `selectable table` instead the cursor still remains as arrow although each row is supposed to be selectable (unless disabled)
This PR now adds the pointing cursor for those rows/cell aswell.

Thanks to @zediogoviana for the basic idea. I simplified the implementation and defined the selectors so they work nicely together with #604 in nested tables

## Testcase
https://jsfiddle.net/zgdjnvb5/1/
Hover over the rows in the first table.
Remove CSS to see the difference

## Closes
https://github.com/Semantic-Org/Semantic-UI/pull/6784
