### PR TITLE
[Dropdown]: image and remove icons used as item icons are misaligned

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -281,7 +281,7 @@
 
 .ui.dropdown > .text > img,
 .ui.dropdown > .text > .image,
-.ui.dropdown .menu > .item > .image,
+.ui.dropdown .menu > .item > .image:not(.icon),
 .ui.dropdown .menu > .item > img {
   display: inline-block;
   vertical-align: top;
@@ -679,7 +679,7 @@ select.ui.dropdown {
 }
 
 /* Clearable Selection */
-.ui.dropdown .remove.icon {
+.ui.dropdown > .remove.icon {
   cursor: pointer;
   font-size: @dropdownIconSize;
   margin: @selectionIconMargin;
@@ -699,7 +699,7 @@ select.ui.dropdown {
 .ui.dropdown select.noselection ~ .remove.icon,
 .ui.dropdown input[value=''] ~ .remove.icon,
 .ui.dropdown input:not([value]) ~ .remove.icon,
-.ui.dropdown.loading .remove.icon {
+.ui.dropdown.loading > .remove.icon {
   display: none;
 }
 

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -280,7 +280,7 @@
 ---------------*/
 
 .ui.dropdown > .text > img,
-.ui.dropdown > .text > .image,
+.ui.dropdown > .text > .image:not(.icon),
 .ui.dropdown .menu > .item > .image:not(.icon),
 .ui.dropdown .menu > .item > img {
   display: inline-block;


### PR DESCRIPTION
## Description
An `image icon` aswell as a `remove icon` used as item icons in dropdown menus conflicted with other css settings which basically took care of "real" images or the clearing icon.

As a clearing icon is always rendered as a direct sibling of dropdown it is save to change the selector to direct sibling which fixes the issue for the remove icon
For image is was the usual problem of having font awesome icons which names conflict with FUI classnames so the fix as always is to remove the .icon class from the selector

## Testcase
http://jsfiddle.net/se7hm0wf/
A bit difficult to reset the current setting to make a proper fiddle, so watch the screenshot 😄 

## Screenshot
![imageremovedropdownitemicons](https://user-images.githubusercontent.com/18379884/55581950-82680000-571e-11e9-99ce-7a2e367b815f.gif)

## Closes
#620 
