### PR TITLE
[Popup] support iOS to recognize popup close on touch

### DIFF
--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -32,6 +32,10 @@ $.fn.popup = function(parameters) {
 
     moduleSelector = $allModules.selector || '',
 
+    clickEvent      = ('ontouchstart' in document.documentElement)
+        ? 'touchstart'
+        : 'click',
+
     time           = new Date().getTime(),
     performance    = [],
 
@@ -981,7 +985,7 @@ $.fn.popup = function(parameters) {
             module.debug('Binding popup events to module');
             if(settings.on == 'click') {
               $module
-                .on('click' + eventNamespace, module.toggle)
+                .on(clickEvent + eventNamespace, module.toggle)
               ;
             }
             if(settings.on == 'hover') {
@@ -1038,7 +1042,7 @@ $.fn.popup = function(parameters) {
           clickaway: function() {
             module.verbose('Binding popup close event to document');
             $document
-              .on('click' + elementNamespace, function(event) {
+              .on(clickEvent + elementNamespace, function(event) {
                 module.verbose('Clicked away from popup');
                 module.event.hideGracefully.call(element, event);
               })


### PR DESCRIPTION
## Description
iOS does not trigger the `click` event when clicked inside whitespace, but only `touchstart`.
Because of this an open popup with setting `on: 'click'` was not closable again by clicking somewhere else
I adopted the same logic as for dimmer to fix this by binding either the `click` or the `touchstart` event depending on existance of `ontouchstart` 

## Testcase
### Not working
http://jsfiddle.net/byre2q7d

### Working
http://jsfiddle.net/byre2q7d/1/

## Screenshot
![ios_popup_close](https://user-images.githubusercontent.com/18379884/55627118-b2aaaf80-57ad-11e9-85a2-b4bf2e977e6a.gif)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5356
