### PR TITLE
[Form] Adds segment corner rounding to form segments loader

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -651,7 +651,7 @@
 }
 
 .ui.loading.form.segments:before {
-  border-radius: @borderRadius;
+  border-radius: @defaultBorderRadius;
 }
 
 .ui.loading.form:after {

--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -649,6 +649,11 @@
   height: 100%;
   z-index: @loaderDimmerZIndex;
 }
+
+.ui.loading.form.segments:before {
+  border-radius: @borderRadius;
+}
+
 .ui.loading.form:after {
   position: absolute;
   content: '';


### PR DESCRIPTION
## Description

The ::before `.loader` pseudo-element did not have segment rounded corners on a `.segments.form`. Added those.

## Testcase
https://jsfiddle.net/douglasg14b/e7cs93zd/4/


## Closes
#628
