### PR TITLE
[Menu]: Fixes right dropdown sub-menu not being vertical

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -483,7 +483,7 @@ Floated Menu / Item
 }
 /* Right Floated */
 .ui.menu:not(.vertical) .right.item,
-.ui.menu:not(.vertical) .right.menu {
+.ui.menu:not(.vertical) :not(.dropdown) > .right.menu {
   display: flex;
   margin-left: auto !important;
 }


### PR DESCRIPTION
This style was already added to the left menu

## Description

Fixes the issue where a right sub-menu dropdown of a menu would open up horizontally instead of vertically. This style was already added for the left menu, but was not for the right menu.

## Testcase
https://jsfiddle.net/986c0o5L/1/

## Closes

#382
