### PR TITLE
[Divider] Horizontal alignment for divider content

### DIFF
--- a/src/definitions/elements/divider.less
+++ b/src/definitions/elements/divider.less
@@ -186,7 +186,7 @@
 /*--------------
      Header
 ---------------*/
-.ui.divider.header[class*="left aligned"] {
+.ui.horizontal.divider[class*="left aligned"] {
   &:before {
     display: none;
   }
@@ -194,7 +194,7 @@
     width: 100%;
   }
 }
-.ui.divider.header[class*="right aligned"] {
+.ui.horizontal.divider[class*="right aligned"] {
   &:before {
     width: 100%;
   }

--- a/src/definitions/elements/divider.less
+++ b/src/definitions/elements/divider.less
@@ -183,6 +183,26 @@
   vertical-align: middle;
 }
 
+/*--------------
+     Header
+---------------*/
+.ui.divider.header[class*="left aligned"] {
+  &:before {
+    display: none;
+  }
+  &:after {
+    width: 100%;
+  }
+}
+.ui.divider.header[class*="right aligned"] {
+  &:before {
+    width: 100%;
+  }
+  &:after {
+    display: none;
+  }
+}
+
 /*******************************
           Variations
 *******************************/


### PR DESCRIPTION
## Description
Add text alignment modifiers for dividers: `left aligned` and `right aligned`
`center aligned` is the default divider alignment

## Testcase
https://jsfiddle.net/9umo0ac8/

## Screenshot (when possible)
![image](https://user-images.githubusercontent.com/5517677/55703664-81fb8d80-59da-11e9-9810-0d5d3ff9d2dd.png)
