### PR TITLE
[Modal] Support fixed menu, toast and sidebar to also not move when a modal is shown

### DIFF
--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -604,8 +604,10 @@ $.fn.modal = function(parameters) {
           bodyMargin: function() {
             initialBodyMargin = $body.css('margin-right');
             var bodyMarginRightPixel = parseInt(initialBodyMargin.replace(/[^\d.]/g, '')),
-                bodyScrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
-            $body.css('margin-right', (bodyMarginRightPixel + bodyScrollbarWidth) + 'px');
+                bodyScrollbarWidth = window.innerWidth - document.documentElement.clientWidth,
+                diffPos = bodyMarginRightPixel + bodyScrollbarWidth;
+            $body.css('margin-right', diffPos + 'px');
+            $body.find(selector.bodyFixed).css('padding-right', diffPos + 'px');
           }
         },
 
@@ -617,6 +619,7 @@ $.fn.modal = function(parameters) {
           },
           bodyMargin: function() {
             $body.css('margin-right', initialBodyMargin);
+            $body.find(selector.bodyFixed).css('padding-right', initialBodyMargin);
           }
         },
 
@@ -1105,7 +1108,8 @@ $.fn.modal.settings = {
     approve  : '.actions .positive, .actions .approve, .actions .ok',
     deny     : '.actions .negative, .actions .deny, .actions .cancel',
     modal    : '.ui.modal',
-    dimmer   : '> .ui.dimmer'
+    dimmer   : '> .ui.dimmer',
+    bodyFixed: '> .ui.fixed.menu, > .ui.right.toast-container, > .ui.right.sidebar'
   },
   error : {
     dimmer    : 'UI Dimmer, a required component is not included in this page',


### PR DESCRIPTION
## Description
In 2.7.3 we fixed the behavior of a modal when opening on large page with a scrollbar to not slide the body to the right for the width of the scrollbar.
Unfortunately a possible existing `fixed menu`, `right sidebar` or `right toast-container` still move 😢 

This PR fixes them as well 🙂 

## Testcase
### Bad
https://jsfiddle.net/snudrg69

### Good
https://jsfiddle.net/snudrg69/1/

## Screenshot
|Bad|Good|
|-|-|
|![modal_fixed_move_bad](https://user-images.githubusercontent.com/18379884/55726799-f2250600-5a10-11e9-8145-fa9032dc8f84.gif)|![modal_fixed_move_good](https://user-images.githubusercontent.com/18379884/55726818-f94c1400-5a10-11e9-95d7-ad4aafdca1da.gif)|



## Closes
#634 
