### PR TITLE
fix(form): Remove unnecessary property '-webkit-appearance: none' with :focus from error field

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -552,7 +552,6 @@
   border-color: @inputErrorFocusBorder;
   color: @inputErrorFocusColor;
 
-  -webkit-appearance: none;
   box-shadow: @inputErrorFocusBoxShadow;
 }
 


### PR DESCRIPTION
## Description
The property `-webkit-appearance: none` causes the select element unstable on focus and unfocus
events. Removing native appearance from select on focus reduces the space between the border
and it's content which causes unexpected bouncing.

This property doesn't give any extra effect to all fields for focus event, but making select
element inconsistency alone. So, better to remove this property to make the select element stable
along with the other fields when it's focused or unfocused.

## Testcase
<!-- Fork https://jsfiddle.net/31d6y7mn -->

## Screenshot
Before | After
--------- | ---------
![before](https://user-images.githubusercontent.com/930315/55760007-effa9000-5a80-11e9-8e38-a6928f096f42.gif) | ![after](https://user-images.githubusercontent.com/930315/55760040-01dc3300-5a81-11e9-9be1-0acd2cc4a728.gif)

## Closes
#576 
