### PR TITLE
[Dropdown] Hide a possible open menu on destroy for correct reset state

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -140,6 +140,8 @@ $.fn.dropdown = function(parameters) {
         destroy: function() {
           module.verbose('Destroying previous dropdown', $module);
           module.remove.tabbable();
+          module.remove.active();
+          $menu.removeClass(className.visible).addClass(className.hidden);
           $module
             .off(eventNamespace)
             .removeData(moduleNamespace)

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -141,6 +141,7 @@ $.fn.dropdown = function(parameters) {
           module.verbose('Destroying previous dropdown', $module);
           module.remove.tabbable();
           module.remove.active();
+          $menu.transition('stop all');
           $menu.removeClass(className.visible).addClass(className.hidden);
           $module
             .off(eventNamespace)


### PR DESCRIPTION
## Description
In case a dropdown is recreated and a menu was open, the re-instantiated dropdown still had this menu open, although the initial state of a dropdown is a hidden menu. The dropdown is not active, thus click events outside of the dropdown did not close the menu.
Also takes care, that any running animations are stopped

## Testcase
#### #653
https://jsfiddle.net/gad2791y/  

#### #654
https://jsfiddle.net/c62bagsn/

## Closes
#653
#654 
