### PR TITLE
fix(dropdown): margin missing when the position of floating menu of dropdown is upward

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -1302,10 +1302,10 @@ select.ui.dropdown {
   border-radius: @floatingMenuBorderRadius !important;
 }
 .ui:not(.upward).floating.dropdown > .menu {
-  margin-top: @floatingMenuDistance !important;
+  margin-top: @floatingMenuDistance;
 }
 .ui.upward.floating.dropdown > .menu {
-  margin-bottom: @floatingMenuDistance !important;
+  margin-bottom: @floatingMenuDistance;
 }
 
 /*--------------

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -1299,8 +1299,13 @@ select.ui.dropdown {
   border-radius: @floatingMenuBorderRadius !important;
 }
 .ui.floating.dropdown > .menu {
-  margin-top: @floatingMenuDistance !important;
   border-radius: @floatingMenuBorderRadius !important;
+}
+.ui:not(.upward).floating.dropdown > .menu {
+  margin-top: @floatingMenuDistance !important;
+}
+.ui.upward.floating.dropdown > .menu {
+  margin-bottom: @floatingMenuDistance !important;
 }
 
 /*--------------


### PR DESCRIPTION
## Description

When the position of floating menu of dropdown is upward, the margin is missing

## Screenshot (when possible)
**Before**
![dropdown](https://user-images.githubusercontent.com/1622751/55909118-7dea8e00-5bdb-11e9-82dd-e5d8df8ba105.gif)

**after**
![dropdown](https://user-images.githubusercontent.com/1622751/55911564-37982d80-5be1-11e9-9dfe-784afd3a5965.gif)


