### PR TITLE
[Card] Force horizontal cards meta, extra content and actions to align properly

### DIFF
--- a/src/definitions/views/card.less
+++ b/src/definitions/views/card.less
@@ -430,6 +430,7 @@
 .ui.horizontal.cards > .card,
 .ui.card.horizontal {
   flex-direction: row;
+  flex-wrap: wrap;
   min-width: @horizontalMinWidth;
   width: @horizontalWidth;
   max-width: 100%;
@@ -456,6 +457,12 @@
   width: 100%;
   height: 100%;
   border-radius: @defaultBorderRadius 0 0 @defaultBorderRadius;
+}
+.ui.horizontal.cards > .card > .content, .ui.horizontal.card > .content {
+  flex-basis: 1px;
+}
+.ui.horizontal.cards > .card > .extra, .ui.horizontal.card > .extra {
+  flex-basis: 100%;
 }
 
 /*-------------------


### PR DESCRIPTION
## Description
As reported in #159, the meta data, actions and extra content are forced to display in one row in horizontal cards. It's because of `flex-direction: row` setting `flex-wrap: wrap`, and the flex item for meta data has no initial size. So, it forces the other flex items to wrap in available spaces next to it which leads them displaying in the same row.

Since, the extra content and buttons are always supposed to appear on the next line and should take 100% width of the card. The meta data should have initial size with minimum value which will make sure the meta data to wrap in the available space on the current row and the extra content and buttons to appear in the next row respectively.

## Testcase
**Before:** https://jsfiddle.net/kv2sj3hq/
**After:** https://jsfiddle.net/axc9hmqy/

## Screenshot
Before | After
--------- | --------
![Before-1](https://user-images.githubusercontent.com/930315/55915353-8b217000-5c0f-11e9-8609-504b19dd14a4.png) | ![After-1](https://user-images.githubusercontent.com/930315/55915360-91175100-5c0f-11e9-8626-e6343deb5e40.png) |
----------------- | -----------------
![Before-2](https://user-images.githubusercontent.com/930315/55915380-a3918a80-5c0f-11e9-8e04-0ba8fa8e055f.png) | ![After-2](https://user-images.githubusercontent.com/930315/55915395-a7bda800-5c0f-11e9-864b-5e7bd05546cf.png)
----------------- | ----------------- 
![Before-3](https://user-images.githubusercontent.com/930315/55915443-c4f27680-5c0f-11e9-87fb-e9e364955bd0.png) | ![After-3](https://user-images.githubusercontent.com/930315/55915454-c9b72a80-5c0f-11e9-895b-f54ebffe7818.png)

Works on Firefox, Google Chrome, Opera, Microsoft Edge on Windows 10. And Firefox and Chromium on Ubuntu.

## Closes
I hope this PR fixes the issue #159.