### PR TITLE
[Formvalidation] Make sure match/difference rules are selecting within the same form

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1160,7 +1160,7 @@ $.fn.form = function(parameters) {
                     ? ''
                     : (settings.shouldTrim) ? $.trim(value + '') : String(value + '')
                 ;
-                return ruleFunction.call(field, value, ancillary);
+                return ruleFunction.call(field, value, ancillary, $module);
               }
             ;
             if( !$.isFunction(ruleFunction) ) {
@@ -1670,21 +1670,22 @@ $.fn.form.settings = {
     },
 
     // matches another field
-    match: function(value, identifier) {
+    match: function(value, identifier, $module) {
       var
-        matchingValue
+        matchingValue,
+        matchingElement
       ;
-      if( $('[data-validate="'+ identifier +'"]').length > 0 ) {
-        matchingValue = $('[data-validate="'+ identifier +'"]').val();
+      if((matchingElement = $module.find('[data-validate="'+ identifier +'"]')).length > 0 ) {
+        matchingValue = matchingElement.val();
       }
-      else if($('#' + identifier).length > 0) {
-        matchingValue = $('#' + identifier).val();
+      else if((matchingElement = $module.find('#' + identifier)).length > 0) {
+        matchingValue = matchingElement.val();
       }
-      else if($('[name="' + identifier +'"]').length > 0) {
-        matchingValue = $('[name="' + identifier + '"]').val();
+      else if((matchingElement = $module.find('[name="' + identifier +'"]')).length > 0) {
+        matchingValue = matchingElement.val();
       }
-      else if( $('[name="' + identifier +'[]"]').length > 0 ) {
-        matchingValue = $('[name="' + identifier +'[]"]');
+      else if((matchingElement = $module.find('[name="' + identifier +'[]"]')).length > 0 ) {
+        matchingValue = matchingElement;
       }
       return (matchingValue !== undefined)
         ? ( value.toString() == matchingValue.toString() )
@@ -1693,22 +1694,23 @@ $.fn.form.settings = {
     },
 
     // different than another field
-    different: function(value, identifier) {
+    different: function(value, identifier, $module) {
       // use either id or name of field
       var
-        matchingValue
+        matchingValue,
+        matchingElement
       ;
-      if( $('[data-validate="'+ identifier +'"]').length > 0 ) {
-        matchingValue = $('[data-validate="'+ identifier +'"]').val();
+      if((matchingElement = $module.find('[data-validate="'+ identifier +'"]')).length > 0 ) {
+        matchingValue = matchingElement.val();
       }
-      else if($('#' + identifier).length > 0) {
-        matchingValue = $('#' + identifier).val();
+      else if((matchingElement = $module.find('#' + identifier)).length > 0) {
+        matchingValue = matchingElement.val();
       }
-      else if($('[name="' + identifier +'"]').length > 0) {
-        matchingValue = $('[name="' + identifier + '"]').val();
+      else if((matchingElement = $module.find('[name="' + identifier +'"]')).length > 0) {
+        matchingValue = matchingElement.val();
       }
-      else if( $('[name="' + identifier +'[]"]').length > 0 ) {
-        matchingValue = $('[name="' + identifier +'[]"]');
+      else if((matchingElement = $module.find('[name="' + identifier +'[]"]')).length > 0 ) {
+        matchingValue = matchingElement;
       }
       return (matchingValue !== undefined)
         ? ( value.toString() !== matchingValue.toString() )


### PR DESCRIPTION
## Description
When there are multiple forms on a page and the form fields also have identical names, the `match` and `difference` rule functions possibly select the wrong field from a different form.
This PR makes sure the field selection takes place within the form

## Testcase
- Enter something in the "Username" field of the **second** form
- Enter the same value in the "Retype username" field of the **first** form
- See that...

### Broken
- ... the rule validates
https://jsfiddle.net/v0hm1r8f

### Fixed
- ... the rule does not validate
https://jsfiddle.net/v0hm1r8f/1

## Screenshot
### Broken
![form_match_bad](https://user-images.githubusercontent.com/18379884/55979340-396df980-5c92-11e9-807a-d18247419432.gif)

### Fixed
![form_match_good](https://user-images.githubusercontent.com/18379884/55979353-412d9e00-5c92-11e9-8288-80bfe9929c5a.gif)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5190
