### PR TITLE
[Menu] Leave floating labels in secondary pointing menus as they are

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -941,7 +941,7 @@ Floated Menu / Item
   border-bottom-width: 0;
 }
 
-.ui.secondary.pointing.menu .item > .label {
+.ui.secondary.pointing.menu .item > .label:not(.floating) {
   margin-top: -@labelVerticalPadding;
   margin-bottom: -@labelVerticalPadding;
 }


### PR DESCRIPTION
## Description
Labels in `secondary pointing menu` were adjusted, but did not respect `floating` labels, which have a different positioning. Thus those were misaligned.

## Testcase
https://jsfiddle.net/gv2br0zu/
Remove CSS to see issue

## Screenshot
### Before
![image](https://user-images.githubusercontent.com/18379884/56125106-724eec80-5f78-11e9-984b-709e76644ed1.png)

### After
![image](https://user-images.githubusercontent.com/18379884/56125028-46336b80-5f78-11e9-96a1-fed886f3b198.png)

## Closes
#668 
