### PR TITLE
[Menu] Additional specificity for secondary inverted menu not necessary anymore

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -912,7 +912,7 @@ Floated Menu / Item
 }
 
 /* Inverted */
-.ui.secondary.inverted.menu.menu {
+.ui.secondary.inverted.menu {
   background-color: transparent;
 }
 


### PR DESCRIPTION
## Description
The additional specificity for `secondary inverted menu` was necessary (when 2.7.0 was released) to override a background color setting when `secondary` was still supported as a background color for menus. We removed this in #366 , so the additional specificity is not needed anymore

## Testcase
https://fomantic-ui.com/
- The top menu bar was the reason for the previous added `.menu` specificity. Removing it does not disturb it anymore,

## Screenshot
![secondaryinvertedmenu](https://user-images.githubusercontent.com/18379884/56202340-1bfab000-6043-11e9-8918-8bbeea4575ce.gif)

## Closes
#672 
