### PR TITLE
fix(tab): position issue with fixed item size

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -1523,7 +1523,7 @@ each(@colors, {
   text-align: center;
   justify-content: center;
 }
-.ui.attached.item.menu {
+.ui.attached.item.menu:not(.tabular) {
   margin: 0 @attachedHorizontalOffset !important;
 }
 


### PR DESCRIPTION
## Description
For Semantic-Org/Semantic-UI#4248 a horizontal margin of -1px is introduced, this is not needed for tabular menus.

## Screenshot (when possible)
![image](https://user-images.githubusercontent.com/5517677/56266160-dba33c80-60eb-11e9-8d24-6f1646185c09.png)

## Closes
#671
