### PR TITLE
feat(calendar): add eventDates support and onSelect handler

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -858,9 +858,9 @@ $.fn.calendar = function(parameters) {
               for (; i < il; i++) {
                 d = dates[i];
                 if (d instanceof Date && module.helper.dateEqual(date, d, mode)) {
-                  return {
-                    date: d
-                  };
+                  var dateObject = {};
+                  dateObject[metadata.date] = d;
+                  return dateObject;
                 }
                 else if (d !== null && typeof d === 'object' && d[metadata.date] && module.helper.dateEqual(date, d[metadata.date], mode)  ) {
                   return d;

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -492,17 +492,15 @@ $.fn.calendar = function(parameters) {
             var date = target.data(metadata.date);
             var focusDate = target.data(metadata.focusDate);
             var mode = target.data(metadata.mode);
-            if(settings.onSelect.call(element, date, mode) !== false) {
-              if (date) {
-                var forceSet = target.hasClass(className.today);
-                module.selectDate(date, forceSet);
-              }
-              else if (focusDate) {
-                module.set.focusDate(focusDate);
-              }
-              else if (mode) {
-                module.set.mode(mode);
-              }
+            if (date && settings.onSelect.call(element, date, module.get.mode()) !== false) {
+              var forceSet = target.hasClass(className.today);
+              module.selectDate(date, forceSet);
+            }
+            else if (focusDate) {
+              module.set.focusDate(focusDate);
+            }
+            else if (mode) {
+              module.set.mode(mode);
             }
           },
           keydown: function (event) {

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -492,15 +492,17 @@ $.fn.calendar = function(parameters) {
             var date = target.data(metadata.date);
             var focusDate = target.data(metadata.focusDate);
             var mode = target.data(metadata.mode);
-            if (date) {
-              var forceSet = target.hasClass(className.today);
-              module.selectDate(date, forceSet);
-            }
-            else if (focusDate) {
-              module.set.focusDate(focusDate);
-            }
-            else if (mode) {
-              module.set.mode(mode);
+            if(settings.onSelect.call(element, date, mode) !== false) {
+              if (date) {
+                var forceSet = target.hasClass(className.today);
+                module.selectDate(date, forceSet);
+              }
+              else if (focusDate) {
+                module.set.focusDate(focusDate);
+              }
+              else if (mode) {
+                module.set.mode(mode);
+              }
             }
           },
           keydown: function (event) {
@@ -1473,6 +1475,10 @@ $.fn.calendar.settings = {
 
   // callback after hide animation
   onHidden: function () {
+  },
+
+  // callback before item is selected, return false to prevent selection
+  onSelect: function (date, mode) {
   },
 
   // is the given date disabled?


### PR DESCRIPTION
## Description
This PR adds support for `eventDates` and a new event handler `onSelect` to provide individual functionality whenever a cell-item was clicked.
This works similar as `disabledDates` by providing the option to set a tooltip given a message to a date cell.In addition a given `class` can be added to the cell. Otherwise a default `eventClass` (default `blue`) will be added to every event-cell.

### Example using individual className for eventDate cells
```javascript
$('.ui.calendar').calendar({
eventDates: [
    {
      date: new Date(2019,3,21),
      message: 'Show me in light purple',
      class: 'inverted purple'
    },{
      date: new Date(2019,3,22),
      message: 'Show me in green',
      class: 'green'
    }
]
});
```
### Example using default className for each event
```javascript
$('.ui.calendar').calendar({
eventClass: 'inverted red',
eventDates: [
    new Date(2019,3,20), //no message tooltip
    {
      date: new Date(2019,3,21),
      message: 'I got the default color (light red)'
    },{
      date: new Date(2019,3,22),
      message: 'Me too'
    }
]
});
```
### Example using onSelect event handler
```javascript
$('.ui.calendar').calendar({
onSelect: function(date,mode) {
  console.log('You have chosen',date,'in mode',mode);
  if(mode!=='day') {
    console.log('You cannot select anything else than a day!');
    return false;
  }
}
});
```

## Testcase
#### eventDates
http://jsfiddle.net/nc0yutq2/

#### onSelect
http://jsfiddle.net/c7kLvef4/

## Screenshot
![eventdates](https://user-images.githubusercontent.com/18379884/56299611-a707a300-6134-11e9-9345-1aed48b79294.gif)

## Closes
#674 
