### PR TITLE
feat(form): add calendar input field

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1544,11 +1544,7 @@ $.fn.form.settings = {
     date: function(date) {
       var date = new Date(date);
 
-      return Intl.DateTimeFormat('en-GB', {
-        year: "numeric",
-        month: "2-digit",
-        day: "2-digit"
-      }).format(date);
+      return Intl.DateTimeFormat('en-GB').format(date);
     },
     datetime: function(date) {
       return Intl.DateTimeFormat('en-GB', {

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -661,13 +661,13 @@ $.fn.form = function(parameters) {
             $fields.each(function(index, field) {
               var
                 $field       = $(field),
+                $calendar    = $field.closest(selector.uiCalendar),
                 name         = $field.prop('name'),
                 value        = $field.val(),
                 isCheckbox   = $field.is(selector.checkbox),
                 isRadio      = $field.is(selector.radio),
                 isMultiple   = (name.indexOf('[]') !== -1),
-                $calendar    = $field.closest(selector.uiCalendar),
-                isCalendar   = ($calendar.length>0),
+                isCalendar   = ($calendar.length > 0),
                 isChecked    = (isCheckbox)
                   ? $field.is(':checked')
                   : false
@@ -716,7 +716,7 @@ $.fn.form = function(parameters) {
                       } else if(settings.dateHandling == 'input') {
                         values[name] = $calendar.calendar('get input date')
                       } else if (settings.dateHandling == 'formatter') {
-                        var type = $calendar.calendar('get mode');
+                        var type = $calendar.calendar('setting', 'type');
 
                         switch(type) {
                           case 'date':

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1542,8 +1542,6 @@ $.fn.form.settings = {
 
   formatter: {
     date: function(date) {
-      var date = new Date(date);
-
       return Intl.DateTimeFormat('en-GB').format(date);
     },
     datetime: function(date) {

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -661,14 +661,13 @@ $.fn.form = function(parameters) {
             $fields.each(function(index, field) {
               var
                 $field       = $(field),
-                $parent      = $field.parent(),
-                $grandParent = $parent.parent(),
                 name         = $field.prop('name'),
                 value        = $field.val(),
                 isCheckbox   = $field.is(selector.checkbox),
                 isRadio      = $field.is(selector.radio),
                 isMultiple   = (name.indexOf('[]') !== -1),
-                isCalendar   = ($parent.is(selector.uiCalendar) || $grandParent.is(selector.uiCalendar)),
+                $calendar    = $field.closest(selector.uiCalendar),
+                isCalendar   = ($calendar.length>0),
                 isChecked    = (isCheckbox)
                   ? $field.is(':checked')
                   : false
@@ -709,56 +708,43 @@ $.fn.form = function(parameters) {
                     }
                   }
                   else if(isCalendar) {
-                    // We must determine which item is the calendar module
-                    var $calendar = $parent.is(selector.uiCalendar)
-                      ? $parent
-                      : $grandParent.is(selector.uiCalendar)
-                        ? $grandParent
-                        : false
-                    ;
+                    var date = $calendar.calendar('get date');
 
-                    if ($calendar) {
-                      var date = $calendar.calendar('get date');
+                    if (date !== null) {
+                      if (settings.dateHandling == 'date') {
+                        values[name] = date;
+                      } else if(settings.dateHandling == 'input') {
+                        values[name] = $calendar.calendar('get input date')
+                      } else if (settings.dateHandling == 'formatter') {
+                        var type = $calendar.calendar('get mode');
 
-                      if (date !== null) {
-                        if (settings.dateHandling == 'date') {
-                          values[name] = date;
-                        } else if(settings.dateHandling == 'input') {
-                          values[name] = $calendar.calendar('get input date')
-                        } else if (settings.dateHandling == 'formatter') {
-                          var type = $calendar.calendar('get mode');
-
-                          switch(type) {
-                            case 'date':
-                            values[name] = settings.formatter.date(date);
-                            break;
-                            
-                            case 'datetime':
-                            values[name] = settings.formatter.datetime(date);
-                            break;
-                            
-                            case 'time':
-                            values[name] = settings.formatter.time(date);
-                            break;
-                            
-                            case 'month':
-                            values[name] = settings.formatter.month(date);
-                            break;
-                            
-                            case 'year':
-                            values[name] = settings.formatter.year(date);
-                            break;
-    
-                            default:
-                            module.debug('Wrong calendar mode', $calendar, type);
-                            values[name] = '';
-                          }
+                        switch(type) {
+                          case 'date':
+                          values[name] = settings.formatter.date(date);
+                          break;
+                          
+                          case 'datetime':
+                          values[name] = settings.formatter.datetime(date);
+                          break;
+                          
+                          case 'time':
+                          values[name] = settings.formatter.time(date);
+                          break;
+                          
+                          case 'month':
+                          values[name] = settings.formatter.month(date);
+                          break;
+                          
+                          case 'year':
+                          values[name] = settings.formatter.year(date);
+                          break;
+  
+                          default:
+                          module.debug('Wrong calendar mode', $calendar, type);
+                          values[name] = '';
                         }
-                      } else {
-                        values[name] = '';
                       }
                     } else {
-                      module.debug('Unable to find calendar module', $field);
                       values[name] = '';
                     }
                   } else {

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -189,9 +189,11 @@ $.fn.form = function(parameters) {
               $element     = $field.parent(),
               $fieldGroup  = $field.closest($group),
               $prompt      = $fieldGroup.find(selector.prompt),
+              $calendar    = $field.closest(selector.uiCalendar),
               defaultValue = $field.data(metadata.defaultValue) || '',
               isCheckbox   = $element.is(selector.uiCheckbox),
               isDropdown   = $element.is(selector.uiDropdown),
+              isCalendar   = ($calendar.length > 0),
               isErrored    = $fieldGroup.hasClass(className.error)
             ;
             if(isErrored) {
@@ -206,6 +208,9 @@ $.fn.form = function(parameters) {
             else if(isCheckbox) {
               $field.prop('checked', false);
             }
+            else if (isCalendar) {
+              $calendar.calendar('clear');
+            }
             else {
               module.verbose('Resetting field value', $field, defaultValue);
               $field.val('');
@@ -219,10 +224,12 @@ $.fn.form = function(parameters) {
               $field       = $(el),
               $element     = $field.parent(),
               $fieldGroup  = $field.closest($group),
+              $calendar    = $field.closest(selector.uiCalendar),
               $prompt      = $fieldGroup.find(selector.prompt),
               defaultValue = $field.data(metadata.defaultValue),
               isCheckbox   = $element.is(selector.uiCheckbox),
               isDropdown   = $element.is(selector.uiDropdown),
+              isCalendar   = ($calendar.length > 0),
               isErrored    = $fieldGroup.hasClass(className.error)
             ;
             if(defaultValue === undefined) {
@@ -240,6 +247,9 @@ $.fn.form = function(parameters) {
             else if(isCheckbox) {
               module.verbose('Resetting checkbox value', $element, defaultValue);
               $field.prop('checked', defaultValue);
+            }
+            else if (isCalendar) {
+              $calendar.calendar('set date', defaultValue);
             }
             else {
               module.verbose('Resetting field value', $field, defaultValue);

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -577,6 +577,9 @@ $.fn.calendar = function(parameters) {
           date: function () {
             return module.helper.sanitiseDate($module.data(metadata.date)) || null;
           },
+          inputDate: function() {
+            return $input.val();
+          },
           focusDate: function () {
             return $module.data(metadata.focusDate) || null;
           },


### PR DESCRIPTION
This PR add calendar as a form field, plus it implement its validation and allow to grab underlying value while validating in three different formats.

To do so, a new parameter has been added to the settings: `dateHandling`. It can contain one of these three string:
- `date` (default): field value will be the selected date as a string.
- `input`: field value will be the underlying input value of the calendar.
- `formatter` will let you customize the format of the selected date (or datetime, time, month and year).

Default formatter settings is:
```js
formatter: {
    date: function(date) {
      var date = new Date(date);

      return Intl.DateTimeFormat('en-GB', {
        year: "numeric",
        month: "2-digit",
        day: "2-digit"
      }).format(date);
    },
    datetime: function(date) {
      return Intl.DateTimeFormat('en-GB', {
        year: "numeric",
        month: "2-digit",
        day: "2-digit",
        hour: '2-digit',
        minute: '2-digit',
        second: '2-digit'
      }).format(date);
    },
    time: function(date) {
      return Intl.DateTimeFormat('en-GB', {
        hour: '2-digit',
        minute: '2-digit',
        second: '2-digit'
      }).format(date);
    },
    month: function(date) {
      return Intl.DateTimeFormat('en-GB', {
        month: '2-digit',
        year: 'numeric'
      }).format(date);
    },
    year: function(date) {
      return Intl.DateTimeFormat('en-GB', {
        year: 'numeric'
      }).format(date);
    }
  }
```

As you can see the default format is the english format, since its [the most used in the world](https://en.wikipedia.org/wiki/Date_format_by_country), but exposing this formatter allow editing it.

Also, the calendar module got a new behavior that return the input text, `get input date`.