### PR TITLE
fix(*): breakpoints ignoring next breakpoint in some cases

### DIFF
--- a/src/themes/default/globals/site.variables
+++ b/src/themes/default/globals/site.variables
@@ -780,10 +780,10 @@
 
 
 /* Responsive */
-@largestMobileScreen : (@tabletBreakpoint - 0.01px);
-@largestTabletScreen : (@computerBreakpoint - 0.01px);
-@largestSmallMonitor : (@largeMonitorBreakpoint - 0.01px);
-@largestLargeMonitor : (@widescreenMonitorBreakpoint - 0.01px);
+@largestMobileScreen : (@tabletBreakpoint - 0.02px);
+@largestTabletScreen : (@computerBreakpoint - 0.02px);
+@largestSmallMonitor : (@largeMonitorBreakpoint - 0.02px);
+@largestLargeMonitor : (@widescreenMonitorBreakpoint - 0.02px);
 
 
 /*-------------------


### PR DESCRIPTION
## Description
Especially recognized in `table` or `grid` elements a breakpoint wasn't correctly fetched by the browsers, because the floating max value covers a 0.99 of the "before pixel" (was implemented by #567)
While mathematically correct, it was not working on the browser to correctly recognize the next full pixel again. (768 pixel were still recognized as something below)
I found out that it was working again when we'll use 0.98 of the breakpoint pixel (instead of 0.99.
This way the dpi fix of #567 still works but also fixes #681 now.
While i was testing with different dpi settings and windows resizings, i never came across a value of xxxx.99, so xxxx.98 as a breakpoint should fix both issues now.

## Testcase
https://fomantic-ui.com/collections/table.html
See gif-video:
- Open the mentioned website in chrome
- In developer tools toggle device toolbar and change to "iPad"
- change the breakpoint from 767.99 to 767.98 and the 768px width is now correctly recognized.

## Screenshot
![breakpoint](https://user-images.githubusercontent.com/18379884/56587220-71096980-65e1-11e9-9753-0db09d476727.gif)

## Closes
#681 
