### PR TITLE
fix(calendar): string selectors for start/endCalendar did not work

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -643,7 +643,7 @@ $.fn.calendar = function(parameters) {
               return null;
             }
             if (!(selector instanceof $)) {
-              selector = $module.parent().children(selector).first();
+              selector = $(selector).first();
             }
             //assume range related calendars are using the same namespace
             return selector.data(moduleNamespace);


### PR DESCRIPTION
## Description
In case the startCalendar/endCalendar settings were given as string (which basically was supported) the current code assumes the selector would have the same parent as the opposite calendar, which is not even true in the docs-example (where each calendar is inside a form div)
This PR now corrects this, so it is using the given string selector as expected searching in the whole document

## Testcase
- Select an end-Date in the right calendar
- Open the left calendar to select a start Date
- The calendar should recognize the range given the end date from the other calendar value

#### Not working
https://jsfiddle.net/ue9hy7vL/

#### Working
https://jsfiddle.net/c83kypx1/

## Closes
#685 
