### PR TITLE
feat(segment): add fitted variant

### DIFF
--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -685,6 +685,19 @@ each(@colors,{
   margin-bottom: @verticalMargin;
 }
 
+/*--------------
+     Fitted
+---------------*/
+
+.ui.fitted.segment:not(.horizontally) {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+.ui.fitted.segment:not(.vertically) {
+  padding-left: 0;
+  padding-right: 0;
+}
+
 /*-------------------
         Size
 --------------------*/


### PR DESCRIPTION
## Description
This PR adds the variants `fitted`, `horizontally fitted` and `vertically fitted` to the segment element, as is it already availble for `menu`

## Testcase
https://jsfiddle.net/g7ha28wk/4/

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6117
#701 (when the mentioned workaround is used)
