### PR TITLE
fix(card): word-wrap overflowing with long strings

### DIFF
--- a/src/definitions/views/card.less
+++ b/src/definitions/views/card.less
@@ -42,6 +42,7 @@
   box-shadow: @boxShadow;
   transition: @transition;
   z-index: @zIndex;
+  word-wrap: break-word;
 }
 .ui.card {
   margin: @margin;


### PR DESCRIPTION
## Description
Whenever a card has a long string inside, it overflows the card container.
Although @hammy2899 mentioned [here](https://github.com/Semantic-Org/Semantic-UI/issues/6186#issuecomment-367317097) that this is a rare case to fix, i thought about links in cards, which probably are not so much rarely used.

... so i adopted the fix by @w96k.

## Testcase
https://jsfiddle.net/9wz01hek/
Remove the CSS to see the issue

## Screenshot
|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/56897369-ace37980-6a8e-11e9-8029-c7d847b32b60.png)|![image](https://user-images.githubusercontent.com/18379884/56897356-9fc68a80-6a8e-11e9-9e28-1473dca164d9.png)|

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6186
https://github.com/Semantic-Org/Semantic-UI/issues/5608