### PR TITLE
fix(modal): `autofocus` shouldn’t focus disabled inputs

### DIFF
--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -742,7 +742,9 @@ $.fn.modal = function(parameters) {
         set: {
           autofocus: function() {
             var
-              $inputs    = $module.find('[tabindex], :input').filter(':visible'),
+              $inputs    = $module.find('[tabindex], :input').filter(':visible').filter(function() {
+                return $(this).closest('.disabled').length === 0;
+              }),
               $autofocus = $inputs.filter('[autofocus]'),
               $input     = ($autofocus.length > 0)
                 ? $autofocus.first()


### PR DESCRIPTION
## Description
If the first input (or its field) (in a modal) has the disabled class, autofocus will still give it focus, which makes it fully editable until it loses focus.
This PR now additionally filters all possible input fields accordingly.

## Testcase
Open the modal. It has a textarea inside and its `field` has the `disabled` class

#### Broken
https://jsfiddle.net/tb4qwhdr
-  The textarea is focused although disabled. You can type anything inside until blurring

#### Fixed
https://jsfiddle.net/tb4qwhdr/1/
- Textarea is not focused as expected

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5794
