### PR TITLE
fix(form validation): error when calling "validate form" with API attached

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1114,7 +1114,7 @@ $.fn.form = function(parameters) {
                 module.add.errors(formErrors);
               }
               // prevent ajax submit
-              if($module.data('moduleApi') !== undefined) {
+              if(event && $module.data('moduleApi') !== undefined) {
                 event.stopImmediatePropagation();
               }
               if(ignoreCallbacks !== true) {


### PR DESCRIPTION
## Description
When a form has an api attached (for form submissions via ajax) and that form is validated manually by behavior `validate form` a console error
 `Uncaught TypeError: Cannot read property 'stopImmediatePropagation' of undefined` 
raises, because the event is not given

## Testcase
### Broken
https://jsfiddle.net/x40jsLhr/

### Fixed
https://jsfiddle.net/x40jsLhr/1/

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5537
