### PR TITLE
fix(progess): all percents are shown while animation

### DIFF
--- a/src/definitions/modules/progress.js
+++ b/src/definitions/modules/progress.js
@@ -314,22 +314,20 @@ $.fn.progress = function(parameters) {
           },
 
           // gets current displayed percentage (if animating values this is the intermediary value)
-          displayPercent: function() {
-            return $bars.map(function(index, element) {
-              var
-                $bar           = $(element),
-                barWidth       = $bar.width(),
-                totalWidth     = $module.width(),
-                minDisplay     = parseInt($bar.css('min-width'), 10),
-                displayPercent = (barWidth > minDisplay)
-                  ? (barWidth / totalWidth * 100)
-                  : module.percent
+          displayPercent: function(index) {
+            var
+              $bar           = $($bars[index]),
+              barWidth       = $bar.width(),
+              totalWidth     = $module.width(),
+              minDisplay     = parseInt($bar.css('min-width'), 10),
+              displayPercent = (barWidth > minDisplay)
+                ? (barWidth / totalWidth * 100)
+                : module.percent
+            ;
+            return (settings.precision > 0)
+              ? Math.round(displayPercent * (10 * settings.precision)) / (10 * settings.precision)
+              : Math.round(displayPercent)
               ;
-              return (settings.precision > 0)
-                ? Math.round(displayPercent * (10 * settings.precision)) / (10 * settings.precision)
-                : Math.round(displayPercent)
-                ;
-            }).toArray();
           },
 
           percent: function(index) {


### PR DESCRIPTION
## Description

## Testcase
### Before
https://jsfiddle.net/syvph8jg/
![befire](https://user-images.githubusercontent.com/127635/56941559-2abb8980-6b50-11e9-975b-1c66dbeb55d0.gif)

### After
https://jsfiddle.net/9axt3n0b/
![multi-progress-pecent-fix](https://user-images.githubusercontent.com/127635/56957019-d381dd00-6b80-11e9-8944-b3b22800d142.gif)

## Screenshot (when possible)

## Closes
#707
