### PR TITLE
fix(search): undefined internal variable

### DIFF
--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -555,7 +555,7 @@ $.fn.search = function(parameters) {
         search: {
           local: function(searchTerm) {
             var
-              results = module.search.object(searchTerm, settings.content),
+              results = module.search.object(searchTerm, settings.source),
               searchHTML
             ;
             module.set.loading();


### PR DESCRIPTION
## Description
This PR fixes a typo, because `settings.content` does not exist and is never specified or documented or used.
That value is always replaced by `setting.source` within the function `module.search.object` instead, so codewise it works identical without the fix, but it's "cleaner" this way.

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5313
