### PR TITLE
fix(list): align text in lists with icons

### DIFF
--- a/src/definitions/elements/list.less
+++ b/src/definitions/elements/list.less
@@ -107,6 +107,7 @@ ol.ui.list ol li,
 .ui.list .list > .item > i.icon,
 .ui.list > .item > i.icon {
   display: table-cell;
+  min-width: 1.55em;
   margin: 0;
   padding-top: @iconOffset;
   transition: @iconTransition;
@@ -118,6 +119,7 @@ ol.ui.list ol li,
 .ui.list .list > .item > i.icon:only-child,
 .ui.list > .item > i.icon:only-child {
   display: inline-block;
+  min-width: auto;
   vertical-align: @iconVerticalAlign;
 }
 


### PR DESCRIPTION
Define min-width for icon in lists, so text is aligned.

Closes #597

<!--
  Please read the contibuting guide before you submit a pull request
  https://github.com/fomantic/Fomantic-UI/blob/master/CONTRIBUTING.md
-->

## Description

## Testcase
https://jsfiddle.net/vk2enzd5/

## Screenshot (when possible)
![image](https://user-images.githubusercontent.com/891192/56999313-9d2c7800-6be9-11e9-9eb8-95cc3e705dd6.png)