### PR TITLE
fix(label): adjust basic ribbon label size and position

### DIFF
--- a/src/definitions/elements/label.less
+++ b/src/definitions/elements/label.less
@@ -255,7 +255,7 @@ a.ui.label {
   border-color: inherit;
   border-width: @basicBorderWidth 0 0 @basicBorderWidth;
   border-style: inherit;
-  right: e(%("calc(100%% + %d)", @basicBorderWidth));
+  right: @basicBorderFullWidthOffset;
 }
 .ui.basic.tag.labels .label:after,
 .ui.basic.tag.label:after {
@@ -384,6 +384,27 @@ a.ui.label {
   left: @rightRibbonOffset;
   padding-left: @ribbonTriangleSize;
   padding-right: @ribbonDistance;
+}
+.ui.basic.ribbon.label {
+  padding-top: @basicRibbonOffset;
+  padding-bottom: @basicRibbonOffset;
+}
+.ui.basic.ribbon.label:not([class*="right ribbon"]) {
+  padding-left: @basicRibbonTriangleSizeOffset;
+  padding-right: @basicRibbonTriangleSize;
+}
+.ui.basic[class*="right ribbon"].label {
+  padding-left: @basicRibbonTriangleSize;
+  padding-right: @basicRibbonTriangleSizeOffset;
+}
+.ui.basic.ribbon.label::after {
+  top: @basicBorderFullWidthOffset;
+}
+.ui.basic.ribbon.label:not([class*="right ribbon"])::after {
+  left: @basicBorderWidthOffset;
+}
+.ui.basic[class*="right ribbon"].label::after {
+  right: @basicBorderWidthOffset;
 }
 
 /* Right Ribbon */

--- a/src/themes/default/elements/label.variables
+++ b/src/themes/default/elements/label.variables
@@ -105,6 +105,8 @@
 /* Basic */
 @basicBackground: none @white;
 @basicBorderWidth: 1px;
+@basicBorderWidthOffset: -@basicBorderWidth;
+@basicBorderFullWidthOffset: e(%("calc(100%% + %d)", @basicBorderWidth));
 @basicBorder: @basicBorderWidth solid @borderColor;
 @basicColor: @textColor;
 @basicBoxShadow: none;
@@ -128,10 +130,13 @@
 
 /* Ribbon */
 @ribbonTriangleSize: 1.2em;
+@basicRibbonTriangleSize: e(%("calc(%d - %d)", @ribbonTriangleSize, @basicBorderWidth));
+@basicRibbonTriangleSizeOffset: e(%("calc(1rem + %d - %d)", @ribbonTriangleSize, @basicBorderWidth));
 @ribbonShadowColor: rgba(0, 0, 0, 0.15);
 
 @ribbonMargin: 1rem;
 @ribbonOffset: e(%("calc(%d - %d)", -@ribbonMargin, @ribbonTriangleSize));
+@basicRibbonOffset: e(%("calc(%d - %d)", @verticalPadding, @basicBorderWidth));
 @ribbonDistance: e(%("calc(%d + %d)", @ribbonMargin, @ribbonTriangleSize));
 @rightRibbonOffset: e(%("calc(100%% + %d + %d)", @ribbonMargin, @ribbonTriangleSize));
 


### PR DESCRIPTION
"ui basic ribbon" has a 1px border, but "ui ribbon" does not, so "ui basic ribbon" is 1 pixel wider than "ui ribbon" in all directions:
- subtract 1px from padding on all sides of "ui ribbon basic", so it is same size as "ui ribbon"
- adjust position of "ui.basic.ribbon.label:after"

"ui ribbon"
![default](https://user-images.githubusercontent.com/891192/57006315-a1bd5480-6c1a-11e9-9318-fa9713a46eb2.png)

"ui basic ribbon" before:
![basic](https://user-images.githubusercontent.com/891192/57006313-9bc77380-6c1a-11e9-9841-c8f5c5130784.png)

"ui basic ribbon" after:
![Screen Shot 2019-05-01 at 14 14 39](https://user-images.githubusercontent.com/891192/57006429-b3ebc280-6c1b-11e9-8abf-e0d6ea6f615e.png)

Closes #708

<!--
  Please read the contibuting guide before you submit a pull request
  https://github.com/fomantic/Fomantic-UI/blob/master/CONTRIBUTING.md
-->

## Description

## Testcase
https://jsfiddle.net/eruc460w/

## Screenshot (when possible)
left:
![left](https://user-images.githubusercontent.com/891192/57006375-3b850180-6c1b-11e9-83cd-e0650d9d32eb.png)

right:
![right](https://user-images.githubusercontent.com/891192/57006377-3f188880-6c1b-11e9-9f8f-4765b81f6562.png)