### PR TITLE
feat(dropdown): add scrolling support for simple variant

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -1274,6 +1274,13 @@ select.ui.dropdown {
   display: block;
 }
 
+/* Scrolling */
+.ui.simple.scrolling.active.dropdown > .menu,
+.ui.simple.scrolling.dropdown:hover > .menu {
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
 /*--------------
       Fluid
 ---------------*/


### PR DESCRIPTION
## Description
This PR adds support for `scrolling` to `simple dropdown`

## Testcase
https://jsfiddle.net/mu7e1xsk/

## Screenshot
![simple_scrolling_dropdown](https://user-images.githubusercontent.com/18379884/57137674-d6fbab00-6db0-11e9-84af-803e57709f5b.gif)


## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/4219
