### PR TITLE
fix(breadcrumb): increase line height for readability on wrapped content

### DIFF
--- a/src/definitions/collections/breadcrumb.less
+++ b/src/definitions/collections/breadcrumb.less
@@ -23,7 +23,7 @@
 *******************************/
 
 .ui.breadcrumb {
-  line-height: 1.5;
+  line-height: @lineHeight;
   display: @display;
   margin: @verticalMargin 0;
   vertical-align: @verticalAlign;

--- a/src/definitions/collections/breadcrumb.less
+++ b/src/definitions/collections/breadcrumb.less
@@ -23,7 +23,7 @@
 *******************************/
 
 .ui.breadcrumb {
-  line-height: 1;
+  line-height: 1.5;
   display: @display;
   margin: @verticalMargin 0;
   vertical-align: @verticalAlign;

--- a/src/themes/default/collections/breadcrumb.variables
+++ b/src/themes/default/collections/breadcrumb.variables
@@ -9,6 +9,7 @@
 @verticalMargin: 0;
 @display: inline-block;
 @verticalAlign: middle;
+@lineHeight: 1.5;
 
 @dividerSpacing: @3px;
 @dividerOpacity: 0.7;

--- a/src/themes/default/collections/breadcrumb.variables
+++ b/src/themes/default/collections/breadcrumb.variables
@@ -9,7 +9,6 @@
 @verticalMargin: 0;
 @display: inline-block;
 @verticalAlign: middle;
-@lineHeight: 1.5;
 
 @dividerSpacing: @3px;
 @dividerOpacity: 0.7;


### PR DESCRIPTION
## Description
When browser screen is narrowed and the breadcrumb gets in two lines there is no enough vertical space between them.

## Testcase
https://jsfiddle.net/1s9xgcvh/2/

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/57176681-1088f080-6e5b-11e9-9f23-760d809da72c.png)


## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/4671
