### PR TITLE
[Loader] Add dots style variant

### DIFF
--- a/src/definitions/elements/loader.less
+++ b/src/definitions/elements/loader.less
@@ -373,6 +373,8 @@ each(@colors, {
   .ui.inverted.@{color}.loading.loading.loading.loading:not(.usual):after,
   .ui.inverted.@{color}.loading.loading.loading.loading .input > i.icon:after,
   .ui.inverted.@{color}.loading.loading.loading.loading > i.icon:after,
+  .ui.inverted.@{color}.dots.dots.dots.loader,
+  .ui.inverted.@{color}.dots.dots.dots.loader:before,
   .ui.inverted.@{color}.loader.loader.loader:after {
     color: @l;
   }

--- a/src/definitions/elements/loader.less
+++ b/src/definitions/elements/loader.less
@@ -175,6 +175,68 @@
   font-style: normal;
 }
 
+/*-------------------
+        Dots
+--------------------*/
+.ui.dots.dots.dots.loader,
+.ui.dots.dots.dots.loader::after,
+.ui.dots.dots.dots.loader::before {
+  border-width: 0;
+  width: @dotsDiameter;
+  height: @dotsDiameter;
+  border-radius: @dotsRadius;
+  animation-name: defaulDotsLoader;
+  animation-iteration-count: infinite;
+  animation-timing-function: linear;
+}
+@keyframes defaulDotsLoader {
+  0%   { background-color: @textColor; }
+  100% { background-color: transparent; }
+}
+.ui.dots.inline.loader {
+  margin-left: @dotsDiameter * 1.5;
+}
+.ui.dots.loader::after,
+.ui.dots.loader::before {
+  margin: 0;
+  content: "";
+  position: absolute;
+}
+.ui.dots.loader::before {
+  animation-delay: @loaderSpeed * @dotsDelayRatio;
+  left: @dotsDiameter * 1.25;
+}
+.ui.dots.loader::after {
+  animation-delay: @loaderSpeed * -@dotsDelayRatio;
+  left: @dotsDiameter * -1.25;
+}
+.ui.slow.dots.loader::before {
+  animation-delay: @loaderSpeedSlow * @dotsDelayRatio;
+}
+.ui.fast.dots.loader::before {
+  animation-delay: @loaderSpeedFast * @dotsDelayRatio;
+}
+.ui.slow.dots.loader::after {
+  animation-delay: @loaderSpeedSlow * -@dotsDelayRatio;
+}
+.ui..fast.dots.loader::after {
+  animation-delay: @loaderSpeedFast * -@dotsDelayRatio;
+}
+.ui.dots.loader,
+.ui.dots.loader::after,
+.ui.dots.loader::before {
+  animation-duration: @loaderSpeed * @dotsDelayRatio * 3;
+}
+.ui.slow.dots.loader,
+.ui.slow.dots.loader::after,
+.ui.slow.dots.loader::before {
+  animation-duration: @loaderSpeedSlow * @dotsDelayRatio * 3;
+}
+.ui.fast.dots.loader,
+.ui.fast.dots.loader::after,
+.ui.fast.dots.loader::before {
+  animation-duration: @loaderSpeedFast * @dotsDelayRatio * 3;
+}
 
 /*******************************
             States
@@ -280,6 +342,47 @@
   padding-top: (@massive + @textDistance);
 }
 
+/* Dots */
+.ui.mini.dots.loader {
+  width: @mini;
+  height: @mini;
+  font-size: @miniFontSize;
+}
+.ui.tiny.loader {
+  width: @tiny;
+  height: @tiny;
+  font-size: @tinyFontSize;
+}
+.ui.small.loader {
+  width: @small;
+  height: @small;
+  font-size: @smallFontSize;
+}
+.ui.loader {
+  width: @medium;
+  height: @medium;
+  font-size: @mediumFontSize;
+}
+.ui.large.loader {
+  width: @large;
+  height: @large;
+  font-size: @largeFontSize;
+}
+.ui.big.loader {
+  width: @big;
+  height: @big;
+  font-size: @bigFontSize;
+}
+.ui.huge.loader {
+  width: @huge;
+  height: @huge;
+  font-size: @hugeFontSize;
+}
+.ui.massive.loader {
+  width: @massive;
+  height: @massive;
+  font-size: @massiveFontSize;
+}
 
 /*-------------------
        Colors
@@ -289,6 +392,7 @@ each(@colors, {
   @color: replace(@key, '@', '');
   @c: @colors[@@color][color];
   @l: @colors[@@color][light];
+  @dotsLoader: '@{color}DotsLoader';
 
   .ui.@{color}.elastic.loader.loader:before,
   .ui.@{color}.basic.elastic.loading.button:before,
@@ -311,6 +415,16 @@ each(@colors, {
   .ui.inverted.@{color}.loading.loading.loading.loading > i.icon:after,
   .ui.inverted.@{color}.loader.loader.loader:after {
     color: @l;
+  }
+
+  .ui.@{color}.dots.dots.dots.loader,
+  .ui.@{color}.dots.dots.dots.loader::before,
+  .ui.@{color}.dots.dots.dots.loader::after {
+    animation-name: @dotsLoader;
+  }
+  @keyframes @dotsLoader {
+    0%   { background-color: @c; }
+    100% { background-color: transparent; }
   }
 })
 

--- a/src/definitions/elements/loader.less
+++ b/src/definitions/elements/loader.less
@@ -186,11 +186,11 @@
   border-radius: @dotsRadius;
   border-color: currentColor;
   border-width: 0;
-  animation-name: defaulDotsLoader;
+  animation-name: defaultDotsLoader;
   animation-iteration-count: infinite;
   animation-timing-function: linear;
 }
-@keyframes defaulDotsLoader {
+@keyframes defaultDotsLoader {
   0%   { background-color: currentColor; }
   100% { background-color: transparent; }
 }
@@ -220,7 +220,7 @@
 .ui.slow.dots.loader::after {
   animation-delay: @loaderSpeedSlow * -@dotsDelayRatio;
 }
-.ui..fast.dots.loader::after {
+.ui.fast.dots.loader::after {
   animation-delay: @loaderSpeedFast * -@dotsDelayRatio;
 }
 .ui.dots.loader,

--- a/src/definitions/elements/loader.less
+++ b/src/definitions/elements/loader.less
@@ -181,16 +181,17 @@
 .ui.dots.dots.dots.loader,
 .ui.dots.dots.dots.loader::after,
 .ui.dots.dots.dots.loader::before {
-  border-width: 0;
   width: @dotsDiameter;
   height: @dotsDiameter;
   border-radius: @dotsRadius;
+  border-color: currentColor;
+  border-width: 0;
   animation-name: defaulDotsLoader;
   animation-iteration-count: infinite;
   animation-timing-function: linear;
 }
 @keyframes defaulDotsLoader {
-  0%   { background-color: @textColor; }
+  0%   { background-color: currentColor; }
   100% { background-color: transparent; }
 }
 .ui.dots.inline.loader {
@@ -342,48 +343,6 @@
   padding-top: (@massive + @textDistance);
 }
 
-/* Dots */
-.ui.mini.dots.loader {
-  width: @mini;
-  height: @mini;
-  font-size: @miniFontSize;
-}
-.ui.tiny.loader {
-  width: @tiny;
-  height: @tiny;
-  font-size: @tinyFontSize;
-}
-.ui.small.loader {
-  width: @small;
-  height: @small;
-  font-size: @smallFontSize;
-}
-.ui.loader {
-  width: @medium;
-  height: @medium;
-  font-size: @mediumFontSize;
-}
-.ui.large.loader {
-  width: @large;
-  height: @large;
-  font-size: @largeFontSize;
-}
-.ui.big.loader {
-  width: @big;
-  height: @big;
-  font-size: @bigFontSize;
-}
-.ui.huge.loader {
-  width: @huge;
-  height: @huge;
-  font-size: @hugeFontSize;
-}
-.ui.massive.loader {
-  width: @massive;
-  height: @massive;
-  font-size: @massiveFontSize;
-}
-
 /*-------------------
        Colors
 --------------------*/
@@ -392,7 +351,6 @@ each(@colors, {
   @color: replace(@key, '@', '');
   @c: @colors[@@color][color];
   @l: @colors[@@color][light];
-  @dotsLoader: '@{color}DotsLoader';
 
   .ui.@{color}.elastic.loader.loader:before,
   .ui.@{color}.basic.elastic.loading.button:before,
@@ -403,6 +361,8 @@ each(@colors, {
   .ui.@{color}.loading.loading.loading.loading:not(.usual):not(.button):after,
   .ui.@{color}.loading.loading.loading.loading .input > i.icon:after,
   .ui.@{color}.loading.loading.loading.loading > i.icon:after,
+  .ui.@{color}.dots.loader.loader.loader:before,
+  .ui.@{color}.dots.loader.loader.loader,
   .ui.@{color}.loader.loader.loader:after {
     color: @c;
   }
@@ -415,16 +375,6 @@ each(@colors, {
   .ui.inverted.@{color}.loading.loading.loading.loading > i.icon:after,
   .ui.inverted.@{color}.loader.loader.loader:after {
     color: @l;
-  }
-
-  .ui.@{color}.dots.dots.dots.loader,
-  .ui.@{color}.dots.dots.dots.loader::before,
-  .ui.@{color}.dots.dots.dots.loader::after {
-    animation-name: @dotsLoader;
-  }
-  @keyframes @dotsLoader {
-    0%   { background-color: @c; }
-    100% { background-color: transparent; }
   }
 })
 

--- a/src/themes/default/elements/loader.variables
+++ b/src/themes/default/elements/loader.variables
@@ -30,6 +30,11 @@
 @invertedLoaderTextColor: @invertedTextColor;
 
 
+/* Dots */
+@dotsRadius: 0.2em;
+@dotsDiameter: @dotsRadius * 2;
+@dotsDelayRatio: 0.5;
+
 /*-------------------
         States
 --------------------*/


### PR DESCRIPTION
## Description

Add `dots loader` variant in which 3 dots are flashing left to right.

I am not sure when to use dots/spinner differently, so I am seeking feedbacks !!
For what usecase do we add this kind of variants?

Or wonfix to avoid tech debt? (Current implementation does not support `dots` loader containing text inside) 

## Screenshot (when possible)
![dots-loader](https://user-images.githubusercontent.com/127635/57188311-6b901580-6f37-11e9-90b7-b8d0a77fe6b2.gif)


## Closes
#694