### PR TITLE
Fix default theme icon overrides

### DIFF
--- a/src/themes/default/elements/icon.overrides
+++ b/src/themes/default/elements/icon.overrides
@@ -14,9 +14,9 @@ i.icon.circle-o => i.icon.circle.outline
 //abbreviation are replaced by full letters:
 i.icon.ellipsis-h => i.icon.ellipsis.horizontal
 i.icon.ellipsis-v => i.icon.ellipsis.vertical
-.alpha => .i.icon.alphabet
-.asc => .i.icon.ascending
-.desc => .i.icon.descending
+.alpha => i.icon.alphabet
+.asc => i.icon.ascending
+.desc => i.icon.descending
 .alt =>.alternate
 
 ASCII order is conserved for easier maintenance.


### PR DESCRIPTION
Fix typos in icon overrides for default theme.

<!--
  Please read the contibuting guide before you submit a pull request
  https://github.com/fomantic/Fomantic-UI/blob/master/CONTRIBUTING.md
-->

## Description

## Testcase
<!-- Fork https://jsfiddle.net/31d6y7mn -->

## Screenshot (when possible)
![]()

## Closes
#222 #333 #444
