### PR TITLE
fix(menu): correct submenu fix which broke right menus

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -477,16 +477,22 @@ Floated Menu / Item
 
 /* Left Floated */
 .ui.menu:not(.vertical) .left.item,
-.ui.menu:not(.vertical) :not(.dropdown) > .left.menu {
+.ui.menu:not(.vertical) .left.menu {
   display: flex;
   margin-right: auto !important;
 }
 /* Right Floated */
 .ui.menu:not(.vertical) .right.item,
-.ui.menu:not(.vertical) :not(.dropdown) > .right.menu {
+.ui.menu:not(.vertical) .right.menu {
   display: flex;
   margin-left: auto !important;
 }
+
+.ui.menu:not(.vertical) :not(.dropdown) > .left.menu,
+.ui.menu:not(.vertical) :not(.dropdown) > .right.menu {
+  display: inherit;
+}
+
 /* Center */
 .ui.menu:not(.vertical) .center.item,
 .ui.menu:not(.vertical) .center.menu {


### PR DESCRIPTION
## Description
The Fix of #632 was correctly implemented by the given jsfiddle. However in the PR itself the change was done differently (similiar to `left menu`...but this was also wrong already).
Unfortunately the change now leads to break normal existing `right menu` elements

This PR reverts the change by #632 but adds the fix out of the jsfiddle which was given by #632 ,so it' still @douglasg14b who found a fix for the main problem 😄 

## Testcase
https://jsfiddle.net/zobwu0q2/

## Screenshot
### Before
![submenu_wrong](https://user-images.githubusercontent.com/18379884/57408257-74a60e80-71e5-11e9-975f-ccb8cc703988.gif)

### After
![submenu_right](https://user-images.githubusercontent.com/18379884/57408263-7a035900-71e5-11e9-8b64-049f697f6ecc.gif)

## Closes
#632 
#382 
