### PR TITLE
build(deps): update jquery

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "web"  : "http://www.jacklukic.com"
   },
   "dependencies": {
-    "jquery"      : "^3.2.1"
+    "jquery"      : "^3.4.0"
   },
   "main": [
     "src/semantic.less",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3606,10 +3606,6 @@
       }
     },
     "jquery": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
-      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
-      
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.0.tgz",
       "integrity": "sha512-ggRCXln9zEqv6OqAGXFEcshF5dSBvCkzj6Gm2gzuR5fWawaX8t7cxKVkkygKODrDAzKdoYw3l/e3pm3vlT4IbQ=="

--- a/package-lock.json
+++ b/package-lock.json
@@ -3609,6 +3609,10 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
       "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
+      
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.0.tgz",
+      "integrity": "sha512-ggRCXln9zEqv6OqAGXFEcshF5dSBvCkzj6Gm2gzuR5fWawaX8t7cxKVkkygKODrDAzKdoYw3l/e3pm3vlT4IbQ=="
     },
     "js-beautify": {
       "version": "1.8.9",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "install": "gulp install"
   },
   "dependencies": {
-    "jquery": "^3.2.1",
+    "jquery": "^3.4.0",
     "@octokit/rest": "^16.16.0",
     "gulp-concat-filenames": "^1.2.0",
     "gulp-debug": "^4.0.0",


### PR DESCRIPTION
## Description
Update jQuery to v3.4.0 to fix security issues surrounding nvd.nist.gov/vuln/detail/CVE-2019-11358

> jQuery before 3.4.0, as used in Drupal, Backdrop CMS, and other products, mishandles jQuery.extend(true, {}, ...) because of Object.prototype pollution. If an unsanitized source object contained an enumerable proto property, it could extend the native Object.prototype.
