### PR TITLE
feat(progress): add indeterminate states

### DIFF
--- a/src/definitions/modules/progress.less
+++ b/src/definitions/modules/progress.less
@@ -487,6 +487,12 @@ each(@colors, {
   transform-origin: center;
   width: 100%;
 }
+.ui.slow.indeterminate.progress .bar::before {
+  animation-duration: @indeterminatePulseDurationSlow;
+}
+.ui.fast.indeterminate.progress .bar::before {
+  animation-duration: @indeterminatePulseDurationFast;
+}
 .ui.swinging.indeterminate.progress .bar::before {
   transform-origin: left;
   animation-name: progress-swinging;

--- a/src/definitions/modules/progress.less
+++ b/src/definitions/modules/progress.less
@@ -57,8 +57,8 @@
   transition: @barTransition;
   overflow: hidden;
 }
-.ui.ui.ui.progress:not([data-percent]) .bar,
-.ui.ui.ui.progress[data-percent="0"] .bar {
+.ui.ui.ui.progress:not([data-percent]):not(.indeterminate) .bar,
+.ui.ui.ui.progress[data-percent="0"]:not(.indeterminate) .bar {
   background:transparent;
 }
 .ui.progress[data-percent="0"] .bar .progress {

--- a/src/definitions/modules/progress.less
+++ b/src/definitions/modules/progress.less
@@ -414,10 +414,12 @@ each(@colors, {
   @c: @colors[@@color][color];
   @l: @colors[@@color][light];
 
+  .ui.indeterminate.@{color}.progress .bar::before,
   .ui.@{color}.progress .bar,
   .ui.progress .@{color}.bar {
     background-color: @c;
   }
+  .ui.inverted.indeterminate.@{color}.progress .bar::before,
   .ui.@{color}.inverted.progress .bar,
   .ui.inverted.progress .@{color}.bar {
     background-color: @l;
@@ -461,6 +463,113 @@ each(@colors, {
 }
 .ui.big.progress .bar {
   height: @bigBarHeight;
+}
+
+/*---------------
+  Indeterminate
+----------------*/
+
+.ui.indeterminate.progress .bar {
+  width: 100%;
+}
+.ui.indeterminate.progress .bar .progress,
+.ui.progress .bar .centered.progress {
+  text-align: center;
+  position: relative;
+}
+.ui.indeterminate.progress .bar::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  border-radius: @barBorderRadius;
+  animation: progress-pulsating @indeterminatePulseDuration @defaultEasing infinite;
+  transform-origin: center;
+  width: 100%;
+}
+.ui.swinging.indeterminate.progress .bar::before {
+  transform-origin: left;
+  animation-name: progress-swinging;
+}
+.ui.sliding.indeterminate.progress .bar::before {
+  transform-origin: left;
+  animation-name: progress-sliding;
+}
+.ui.filling.indeterminate.progress .bar::before {
+  animation-name: progress-filling;
+}
+.ui.indeterminate.progress:not(.sliding):not(.filling):not(.swinging) .bar::before {
+  background: @indeterminatePulseColor;
+}
+.ui.sliding.indeterminate.progress .bar,
+.ui.swinging.indeterminate.progress .bar,
+.ui.filling.indeterminate.progress .bar {
+  background: @background;
+}
+.ui.inverted.sliding.indeterminate.progress .bar,
+.ui.inverted.swinging.indeterminate.progress .bar,
+.ui.inverted.filling.indeterminate.progress .bar {
+  background: @invertedBackground;
+}
+.ui.sliding.indeterminate.progress .bar .progress,
+.ui.swinging.indeterminate.progress .bar .progress {
+  color: @invertedProgressColor;
+}
+.ui.inverted.sliding.indeterminate.progress .bar .progress,
+.ui.inverted.swinging.indeterminate.progress .bar .progress {
+  color: @progressColor;
+}
+
+@keyframes progress-swinging {
+  0%, 100% {
+    width:10%;
+    left:-25%;
+  }
+  25%, 65% {
+    width:70%;
+  }
+  50% {
+    width: 10%;
+    left:100%;
+  }
+}
+
+@keyframes progress-sliding {
+  0% {
+    width:10%;
+    left:-25%;
+  }
+  50% {
+    width:70%;
+  }
+  100% {
+    width:10%;
+    left:100%;
+  }
+}
+
+@keyframes progress-filling {
+  0% {
+    transform: scale(0,1);
+  }
+  80% {
+    transform: scale(1);
+    opacity:1;
+  }
+  100% {
+    opacity:0;
+  }
+}
+
+@keyframes progress-pulsating {
+  0% {
+    transform: scale(0,1);
+    opacity:0.7;
+  }
+  100% {
+    transform: scale(1);
+    opacity:0;
+  }
 }
 
 .loadUIOverrides();

--- a/src/themes/default/modules/progress.variables
+++ b/src/themes/default/modules/progress.variables
@@ -122,3 +122,5 @@
 /* Indeterminate */
 @indeterminatePulseColor: @white;
 @indeterminatePulseDuration: @activePulseDuration;
+@indeterminatePulseDurationSlow: 4s;
+@indeterminatePulseDurationFast: 2s;

--- a/src/themes/default/modules/progress.variables
+++ b/src/themes/default/modules/progress.variables
@@ -123,4 +123,4 @@
 @indeterminatePulseColor: @white;
 @indeterminatePulseDuration: @activePulseDuration;
 @indeterminatePulseDurationSlow: 4s;
-@indeterminatePulseDurationFast: 2s;
+@indeterminatePulseDurationFast: 1s;

--- a/src/themes/default/modules/progress.variables
+++ b/src/themes/default/modules/progress.variables
@@ -118,3 +118,7 @@
 @smallBarHeight: 1em;
 @largeBarHeight: 2.5em;
 @bigBarHeight: 3.5em;
+
+/* Indeterminate */
+@indeterminatePulseColor: @white;
+@indeterminatePulseDuration: @activePulseDuration;


### PR DESCRIPTION
## Description
This PR adds a proposed solution for an `indeterminate` state to the progress module.
It does not even need javascript and works with any existing FUI progress html code by just applying an additional class 😄 
To visually comply with the current FUI style relied on the `active` state animation style.
Every state is fully compatible to any size or color.

In addtion this PR adds an optional `centered` class to the inner progress text, to provide a functionality to show the percentage as static centered text regardless of the bar width.

I added the following `indeterminate` states :

`pulsating` (currently default, thus not explicitely defined as a class)
`filling`
`sliding`
`swinging`

I would be happy to hear feedback 🙂 

## Testcase
https://jsfiddle.net/nekc8v7m/8/

## Screenshot
![indeterminate_progress](https://user-images.githubusercontent.com/18379884/57449974-8925ed80-725d-11e9-9fc8-eca230cac843.gif)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/4840
