### PR TITLE
Added Width per Device for tables

### DIFF
--- a/src/definitions/collections/table.less
+++ b/src/definitions/collections/table.less
@@ -834,6 +834,350 @@ each(@colors, {
   width: @sixteenWide;
 }
 
+/*----------------------
+    Width per Device
+-----------------------*/
+
+/* Mobile Sizing Combinations */
+@media only screen and (min-width: @mobileBreakpoint) and (max-width: @largestMobileScreen) {
+  .ui.table th[class*="one wide mobile"],
+  .ui.table td[class*="one wide mobile"] {
+    width: @oneWide !important;
+  }
+  .ui.table th[class*="two wide mobile"],
+  .ui.table td[class*="two wide mobile"] {
+    width: @twoWide !important;
+  }
+  .ui.table th[class*="three wide mobile"],
+  .ui.table td[class*="three wide mobile"] {
+    width: @threeWide !important;
+  }
+  .ui.table th[class*="four wide mobile"],
+  .ui.table td[class*="four wide mobile"] {
+    width: @fourWide !important;
+  }
+  .ui.table th[class*="five wide mobile"],
+  .ui.table td[class*="five wide mobile"] {
+    width: @fiveWide !important;
+  }
+  .ui.table th[class*="six wide mobile"],
+  .ui.table td[class*="six wide mobile"] {
+    width: @sixWide !important;
+  }
+  .ui.table th[class*="seven wide mobile"],
+  .ui.table td[class*="seven wide mobile"] {
+    width: @sevenWide !important;
+  }
+  .ui.table th[class*="eight wide mobile"],
+  .ui.table td[class*="eight wide mobile"] {
+    width: @eightWide !important;
+  }
+  .ui.table th[class*="nine wide mobile"],
+  .ui.table td[class*="nine wide mobile"] {
+    width: @nineWide !important;
+  }
+  .ui.table th[class*="ten wide mobile"],
+  .ui.table td[class*="ten wide mobile"] {
+    width: @tenWide !important;
+  }
+  .ui.table th[class*="eleven wide mobile"],
+  .ui.table td[class*="eleven wide mobile"] {
+    width: @elevenWide !important;
+  }
+  .ui.table th[class*="twelve wide mobile"],
+  .ui.table td[class*="twelve wide mobile"] {
+    width: @twelveWide !important;
+  }
+  .ui.table th[class*="thirteen wide mobile"],
+  .ui.table td[class*="thirteen wide mobile"] {
+    width: @thirteenWide !important;
+  }
+  .ui.table th[class*="fourteen wide mobile"],
+  .ui.table td[class*="fourteen wide mobile"] {
+    width: @fourteenWide !important;
+  }
+  .ui.table th[class*="fifteen wide mobile"],
+  .ui.table td[class*="fifteen wide mobile"] {
+    width: @fifteenWide !important;
+  }
+  .ui.table th[class*="sixteen wide mobile"],
+  .ui.table td[class*="sixteen wide mobile"] {
+    width: @sixteenWide !important;
+  }
+}
+
+/* Tablet Sizing Combinations */
+@media only screen and (min-width: @tabletBreakpoint) and (max-width: @largestTabletScreen) {
+  .ui.table th[class*="one wide tablet"],
+  .ui.table td[class*="one wide tablet"] {
+    width: @oneWide !important;
+  }
+  .ui.table th[class*="two wide tablet"],
+  .ui.table td[class*="two wide tablet"] {
+    width: @twoWide !important;
+  }
+  .ui.table th[class*="three wide tablet"],
+  .ui.table td[class*="three wide tablet"] {
+    width: @threeWide !important;
+  }
+  .ui.table th[class*="four wide tablet"],
+  .ui.table td[class*="four wide tablet"] {
+    width: @fourWide !important;
+  }
+  .ui.table th[class*="five wide tablet"],
+  .ui.table td[class*="five wide tablet"] {
+    width: @fiveWide !important;
+  }
+  .ui.table th[class*="six wide tablet"],
+  .ui.table td[class*="six wide tablet"] {
+    width: @sixWide !important;
+  }
+  .ui.table th[class*="seven wide tablet"],
+  .ui.table td[class*="seven wide tablet"] {
+    width: @sevenWide !important;
+  }
+  .ui.table th[class*="eight wide tablet"],
+  .ui.table td[class*="eight wide tablet"] {
+    width: @eightWide !important;
+  }
+  .ui.table th[class*="nine wide tablet"],
+  .ui.table td[class*="nine wide tablet"] {
+    width: @nineWide !important;
+  }
+  .ui.table th[class*="ten wide tablet"],
+  .ui.table td[class*="ten wide tablet"] {
+    width: @tenWide !important;
+  }
+  .ui.table th[class*="eleven wide tablet"],
+  .ui.table td[class*="eleven wide tablet"] {
+    width: @elevenWide !important;
+  }
+  .ui.table th[class*="twelve wide tablet"],
+  .ui.table td[class*="twelve wide tablet"] {
+    width: @twelveWide !important;
+  }
+  .ui.table th[class*="thirteen wide tablet"],
+  .ui.table td[class*="thirteen wide tablet"] {
+    width: @thirteenWide !important;
+  }
+  .ui.table th[class*="fourteen wide tablet"],
+  .ui.table td[class*="fourteen wide tablet"] {
+    width: @fourteenWide !important;
+  }
+  .ui.table th[class*="fifteen wide tablet"],
+  .ui.table td[class*="fifteen wide tablet"] {
+    width: @fifteenWide !important;
+  }
+  .ui.table th[class*="sixteen wide tablet"],
+  .ui.table td[class*="sixteen wide tablet"] {
+    width: @sixteenWide !important;
+  }
+}
+
+/* Computer/Desktop Sizing Combinations */
+@media only screen and (min-width: @computerBreakpoint) {
+  .ui.table th[class*="one wide computer"],
+  .ui.table td[class*="one wide computer"] {
+    width: @oneWide !important;
+  }
+  .ui.table th[class*="two wide computer"],
+  .ui.table td[class*="two wide computer"] {
+    width: @twoWide !important;
+  }
+  .ui.table th[class*="three wide computer"],
+  .ui.table td[class*="three wide computer"] {
+    width: @threeWide !important;
+  }
+  .ui.table th[class*="four wide computer"],
+  .ui.table td[class*="four wide computer"] {
+    width: @fourWide !important;
+  }
+  .ui.table th[class*="five wide computer"],
+  .ui.table td[class*="five wide computer"] {
+    width: @fiveWide !important;
+  }
+  .ui.table th[class*="six wide computer"],
+  .ui.table td[class*="six wide computer"] {
+    width: @sixWide !important;
+  }
+  .ui.table th[class*="seven wide computer"],
+  .ui.table td[class*="seven wide computer"] {
+    width: @sevenWide !important;
+  }
+  .ui.table th[class*="eight wide computer"],
+  .ui.table td[class*="eight wide computer"] {
+    width: @eightWide !important;
+  }
+  .ui.table th[class*="nine wide computer"],
+  .ui.table td[class*="nine wide computer"] {
+    width: @nineWide !important;
+  }
+  .ui.table th[class*="ten wide computer"],
+  .ui.table td[class*="ten wide computer"] {
+    width: @tenWide !important;
+  }
+  .ui.table th[class*="eleven wide computer"],
+  .ui.table td[class*="eleven wide computer"] {
+    width: @elevenWide !important;
+  }
+  .ui.table th[class*="twelve wide computer"],
+  .ui.table td[class*="twelve wide computer"] {
+    width: @twelveWide !important;
+  }
+  .ui.table th[class*="thirteen wide computer"],
+  .ui.table td[class*="thirteen wide computer"] {
+    width: @thirteenWide !important;
+  }
+  .ui.table th[class*="fourteen wide computer"],
+  .ui.table td[class*="fourteen wide computer"] {
+    width: @fourteenWide !important;
+  }
+  .ui.table th[class*="fifteen wide computer"],
+  .ui.table td[class*="fifteen wide computer"] {
+    width: @fifteenWide !important;
+  }
+  .ui.table th[class*="sixteen wide computer"],
+  .ui.table td[class*="sixteen wide computer"] {
+    width: @sixteenWide !important;
+  }
+}
+
+/* Large Monitor Sizing Combinations */
+@media only screen and (min-width: @largeMonitorBreakpoint) and (max-width: @largestLargeMonitor){
+  .ui.table th[class*="one wide large screen"],
+  .ui.table td[class*="one wide large screen"] {
+    width: @oneWide !important;
+  }
+  .ui.table th[class*="two wide large screen"],
+  .ui.table td[class*="two wide large screen"] {
+    width: @twoWide !important;
+  }
+  .ui.table th[class*="three wide large screen"],
+  .ui.table td[class*="three wide large screen"] {
+    width: @threeWide !important;
+  }
+  .ui.table th[class*="four wide large screen"],
+  .ui.table td[class*="four wide large screen"] {
+    width: @fourWide !important;
+  }
+  .ui.table th[class*="five wide large screen"],
+  .ui.table td[class*="five wide large screen"] {
+    width: @fiveWide !important;
+  }
+  .ui.table th[class*="six wide large screen"],
+  .ui.table td[class*="six wide large screen"] {
+    width: @sixWide !important;
+  }
+  .ui.table th[class*="seven wide large screen"],
+  .ui.table td[class*="seven wide large screen"] {
+    width: @sevenWide !important;
+  }
+  .ui.table th[class*="eight wide large screen"],
+  .ui.table td[class*="eight wide large screen"] {
+    width: @eightWide !important;
+  }
+  .ui.table th[class*="nine wide large screen"],
+  .ui.table td[class*="nine wide large screen"] {
+    width: @nineWide !important;
+  }
+  .ui.table th[class*="ten wide large screen"],
+  .ui.table td[class*="ten wide large screen"] {
+    width: @tenWide !important;
+  }
+  .ui.table th[class*="eleven wide large screen"],
+  .ui.table td[class*="eleven wide large screen"] {
+    width: @elevenWide !important;
+  }
+  .ui.table th[class*="twelve wide large screen"],
+  .ui.table td[class*="twelve wide large screen"] {
+    width: @twelveWide !important;
+  }
+  .ui.table th[class*="thirteen wide large screen"],
+  .ui.table td[class*="thirteen wide large screen"] {
+    width: @thirteenWide !important;
+  }
+  .ui.table th[class*="fourteen wide large screen"],
+  .ui.table td[class*="fourteen wide large screen"] {
+    width: @fourteenWide !important;
+  }
+  .ui.table th[class*="fifteen wide large screen"],
+  .ui.table td[class*="fifteen wide large screen"] {
+    width: @fifteenWide !important;
+  }
+  .ui.table th[class*="sixteen wide large screen"],
+  .ui.table td[class*="sixteen wide large screen"] {
+    width: @sixteenWide !important;
+  }
+}
+
+/* Widescreen Sizing Combinations */
+@media only screen and (min-width: @widescreenMonitorBreakpoint) {
+  .ui.table th[class*="one wide widescreen"],
+  .ui.table td[class*="one wide widescreen"] {
+    width: @oneWide !important;
+  }
+  .ui.table th[class*="two wide widescreen"],
+  .ui.table td[class*="two wide widescreen"] {
+    width: @twoWide !important;
+  }
+  .ui.table th[class*="three wide widescreen"],
+  .ui.table td[class*="three wide widescreen"] {
+    width: @threeWide !important;
+  }
+  .ui.table th[class*="four wide widescreen"],
+  .ui.table td[class*="four wide widescreen"] {
+    width: @fourWide !important;
+  }
+  .ui.table th[class*="five wide widescreen"],
+  .ui.table td[class*="five wide widescreen"] {
+    width: @fiveWide !important;
+  }
+  .ui.table th[class*="six wide widescreen"],
+  .ui.table td[class*="six wide widescreen"] {
+    width: @sixWide !important;
+  }
+  .ui.table th[class*="seven wide widescreen"],
+  .ui.table td[class*="seven wide widescreen"] {
+    width: @sevenWide !important;
+  }
+  .ui.table th[class*="eight wide widescreen"],
+  .ui.table td[class*="eight wide widescreen"] {
+    width: @eightWide !important;
+  }
+  .ui.table th[class*="nine wide widescreen"],
+  .ui.table td[class*="nine wide widescreen"] {
+    width: @nineWide !important;
+  }
+  .ui.table th[class*="ten wide widescreen"],
+  .ui.table td[class*="ten wide widescreen"] {
+    width: @tenWide !important;
+  }
+  .ui.table th[class*="eleven wide widescreen"],
+  .ui.table td[class*="eleven wide widescreen"] {
+    width: @elevenWide !important;
+  }
+  .ui.table th[class*="twelve wide widescreen"],
+  .ui.table td[class*="twelve wide widescreen"] {
+    width: @twelveWide !important;
+  }
+  .ui.table th[class*="thirteen wide widescreen"],
+  .ui.table td[class*="thirteen wide widescreen"] {
+    width: @thirteenWide !important;
+  }
+  .ui.table th[class*="fourteen wide widescreen"],
+  .ui.table td[class*="fourteen wide widescreen"] {
+    width: @fourteenWide !important;
+  }
+  .ui.table th[class*="fifteen wide widescreen"],
+  .ui.table td[class*="fifteen wide widescreen"] {
+    width: @fifteenWide !important;
+  }
+  .ui.table th[class*="sixteen wide widescreen"],
+  .ui.table td[class*="sixteen wide widescreen"] {
+    width: @sixteenWide !important;
+  }
+}
+
 /*--------------
     Sortable
 ---------------*/


### PR DESCRIPTION
Copy/paste/update from definitions/collections/grids.less

<!--
  Please read the contibuting guide before you submit a pull request
  https://github.com/fomantic/Fomantic-UI/blob/master/CONTRIBUTING.md
-->

## Description
I haven't really looked that hard, so I don't know if there was a reason for omitting width-per-device in table column sizes. This _should_ do that... I haven't tested this at all, I just assumed it would work fine based on grids.less.