### PR TITLE
fix(calendar): support JSON dates

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -860,6 +860,9 @@ $.fn.calendar = function(parameters) {
               var d;
               for (; i < il; i++) {
                 d = dates[i];
+                if(typeof d === 'string') {
+                  d = module.helper.sanitiseDate(d);
+                }
                 if (d instanceof Date && module.helper.dateEqual(date, d, mode)) {
                   var dateObject = {};
                   dateObject[metadata.date] = d;
@@ -1263,6 +1266,10 @@ $.fn.calendar.settings = {
       text = ('' + text).trim().toLowerCase();
       if (text.length === 0) {
         return null;
+      }
+      var textDate = new Date(text);
+      if(!isNaN(textDate.getDate())) {
+        return textDate;
       }
 
       var i, j, k;

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -832,6 +832,9 @@ $.fn.calendar = function(parameters) {
         helper: {
           isDisabled: function(date, mode) {
             return mode === 'day' && ((settings.disabledDaysOfWeek.indexOf(date.getDay()) !== -1) || settings.disabledDates.some(function(d){
+              if(typeof d === 'string') {
+                d = module.helper.sanitiseDate(d);
+              }
               if (d instanceof Date) {
                 return module.helper.dateEqual(date, d, mode);
               }
@@ -842,7 +845,10 @@ $.fn.calendar = function(parameters) {
           },
           isEnabled: function(date, mode) {
             if (mode === 'day') {
-              return settings.enabledDates.length == 0 || settings.enabledDates.some(function(d){
+              return settings.enabledDates.length === 0 || settings.enabledDates.some(function(d){
+                if(typeof d === 'string') {
+                  d = module.helper.sanitiseDate(d);
+                }
                 if (d instanceof Date) {
                   return module.helper.dateEqual(date, d, mode);
                 }

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -838,7 +838,7 @@ $.fn.calendar = function(parameters) {
               if (d instanceof Date) {
                 return module.helper.dateEqual(date, d, mode);
               }
-              if (d !== null && typeof d === 'object') {
+              if (d !== null && typeof d === 'object' && d[metadata.date]) {
                 return module.helper.dateEqual(date, module.helper.sanitiseDate(d[metadata.date]), mode);
               }
             }));
@@ -852,7 +852,7 @@ $.fn.calendar = function(parameters) {
                 if (d instanceof Date) {
                   return module.helper.dateEqual(date, d, mode);
                 }
-                if (d !== null && typeof d === 'object') {
+                if (d !== null && typeof d === 'object' && d[metadata.date]) {
                   return module.helper.dateEqual(date, module.helper.sanitiseDate(d[metadata.date]), mode);
                 }
               });

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -839,7 +839,7 @@ $.fn.calendar = function(parameters) {
                 return module.helper.dateEqual(date, d, mode);
               }
               if (d !== null && typeof d === 'object') {
-                return module.helper.dateEqual(date, d[metadata.date], mode);
+                return module.helper.dateEqual(date, module.helper.sanitiseDate(d[metadata.date]), mode);
               }
             }));
           },
@@ -853,7 +853,7 @@ $.fn.calendar = function(parameters) {
                   return module.helper.dateEqual(date, d, mode);
                 }
                 if (d !== null && typeof d === 'object') {
-                  return module.helper.dateEqual(date, d[metadata.date], mode);
+                  return module.helper.dateEqual(date, module.helper.sanitiseDate(d[metadata.date]), mode);
                 }
               });
             } else {
@@ -874,7 +874,7 @@ $.fn.calendar = function(parameters) {
                   dateObject[metadata.date] = d;
                   return dateObject;
                 }
-                else if (d !== null && typeof d === 'object' && d[metadata.date] && module.helper.dateEqual(date, d[metadata.date], mode)  ) {
+                else if (d !== null && typeof d === 'object' && d[metadata.date] && module.helper.dateEqual(date,module.helper.sanitiseDate(d[metadata.date]), mode)  ) {
                   return d;
                 }
               }


### PR DESCRIPTION
## Description
This PR supports JSON-Dates like `2019-05-14T21:00:00.000Z`  or `2019-05-14T21:00:00.00` given as 
- initialdate
- eventDates
- disabledDates
- enabledDates

## Testcase
https://jsfiddle.net/s0wdh57y/1/

## Closes
#741
