### PR TITLE
fix(transition): not checking for event object lead to TypeError

### DIFF
--- a/src/definitions/modules/transition.js
+++ b/src/definitions/modules/transition.js
@@ -215,7 +215,7 @@ $.fn.transition = function() {
         },
 
         complete: function (event) {
-          if(event.target === element) {
+          if(event && event.target === element) {
               event.stopPropagation();
           }
           module.debug('Animation complete', settings.animation);


### PR DESCRIPTION
## Description
This PR fixes a regression of #698 where it was not covered that the `complete`method could have been called outside of an event, thus the event object was not available and accessing it lead into a TypeError 

## Testcase

- Click on the "One" Button
- Dimmer is shown ... and ...

### Broken
- ... breaks resulting into console TypeError
https://jsfiddle.net/allwe/kucxvf79/4/

### Fixed
- ... dimmer gets hidden as expected, no error
https://jsfiddle.net/Luzdq681/

## Closes
#747 

