### PR TITLE
fix(slider): non reachable max value and rounding issues

### DIFF
--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -519,14 +519,18 @@ $.fn.slider = function(parameters) {
             return settings.min;
           },
           max: function() {
-            return settings.max;
+            var step = module.get.step(),
+                min = module.get.min(),
+                quotient = step === 0 ? 0 : Math.floor((settings.max - min) / step),
+                remainder = step === 0 ? 0 : (settings.max - min) % step;
+            return remainder === 0 ? settings.max : min + quotient * step;
           },
           step: function() {
             return settings.step;
           },
           numLabels: function() {
             var value = Math.round((module.get.max() - module.get.min()) / module.get.step());
-            module.debug('Determined that their should be ' + value + ' labels');
+            module.debug('Determined that there should be ' + value + ' labels');
             return value;
           },
           labelType: function() {
@@ -539,7 +543,7 @@ $.fn.slider = function(parameters) {
 
             switch (settings.labelType) {
               case settings.labelTypes.number:
-                return (value * module.get.step()) + module.get.min();
+                return Math.round(((value * module.get.step()) + module.get.min()) * precision ) / precision;
               case settings.labelTypes.letter:
                 return alphabet[(value) % 26];
               default:


### PR DESCRIPTION
## Description
If a max value is not reachable as a multiplier counting from (min + steps * i) it should be adjusted.

For example if min=1, max=10 but step=2 then the 10 is never reachable. But this is not fetched and instead a higher value (next reachable step) is rendered instead. Even worse: That wrong value (11 in the example) is selectable although it shouldn't because the max value is still 10.

This PR now adjusts a given max value to the last reachable value before the given max value is reached.
Given the above example, it now calculates 9 instead of 10.
That also corrects the step points of the slider (was misaligned in those cases)

While testing i figured out the labels are rendered wrongly when working with float values (the usual JS rounding issue).This is also fixed now.

## Testcase
### Broken
https://jsfiddle.net/1mqo5gju/

### Fixed
https://jsfiddle.net/1mqo5gju/1/

## Screenshot
### Broken
![image](https://user-images.githubusercontent.com/18379884/57949791-b4f04580-78e5-11e9-9d05-466e86a785eb.png)

### Fixed
![image](https://user-images.githubusercontent.com/18379884/57949775-a73ac000-78e5-11e9-9397-6ff90184c6c8.png)

## Closes
#716
