### PR TITLE
fix(calendar): support dynamic way to append popup instead of prepending to the parent

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -133,7 +133,9 @@ $.fn.calendar = function(parameters) {
             if (!$container.length) {
               //prepend the popup element to the activator's parent so that it has less chance of messing with
               //the styling (eg input action button needs to be the last child to have correct border radius)
-              $container = $('<div/>').addClass(className.popup).prependTo($activator.parent());
+              var $activatorParent = $activator.parent(),
+                  domPositionFunction = $activatorParent.closest(selector.append).length !== 0 ? 'appendTo' : 'prependTo';
+              $container = $('<div/>').addClass(className.popup)[domPositionFunction]($activatorParent);
             }
             $container.addClass(className.calendar);
             var onVisible = settings.onVisible;
@@ -1503,7 +1505,8 @@ $.fn.calendar.settings = {
   selector: {
     popup: '.ui.popup',
     input: 'input',
-    activator: 'input'
+    activator: 'input',
+    append: '.inline.field,.inline.fields'
   },
 
   regExp: {


### PR DESCRIPTION
## Description
This PR adds the possibility to append the calendar popup to the parent dom instead of prepending it.
In some cases (especially when used in `inline fields` of forms) prepending the calendar lead into CSS issue where `:first-child` did not work anymore.

I haven't found a way for a CSS only solution. It is not 100% sure, that inline fields will always have a `label` as its first child, so a
```less
.ui.form .inline.fields .field > label:first-of-type,
```
could have been a solution. If anybody else has a better idea to solve this otherwise, i am happy to close this PR without merging.

## Testcase
### Broken inline field margin
https://jsfiddle.net/2e59gpw7/

### Fixed
https://jsfiddle.net/vmethgkq/

## Closes
#699 
