### PR TITLE
[Progress] Fix wrong error on validating sum total on multiple progress 

### DIFF
--- a/src/definitions/modules/progress.js
+++ b/src/definitions/modules/progress.js
@@ -71,7 +71,7 @@ $.fn.progress = function(parameters) {
         helper: {
           sum: function (nums) {
             return Array.isArray(nums) ? nums.reduce(function (left, right) {
-              return left + right;
+              return left + Number(right);
             }, 0) : 0;
           },
           /**

--- a/src/definitions/modules/progress.js
+++ b/src/definitions/modules/progress.js
@@ -83,29 +83,28 @@ $.fn.progress = function(parameters) {
            * - total: 1122
            * - values: [325, 111, 74, 612]
            * - min ratio: 74/1122 = 0.0659...
-           * - required precision:  0.01
+           * - required precision:  100
            *
            * Example2
            * - total: 10541
            * - values: [3235, 1111, 74, 6121]
            * - min ratio: 74/10541 = 0.0070...
-           * - required precision:   0.001
+           * - required precision:   1000
            *
            * @param min A minimum value within multiple values
            * @param total A total amount of multiple values
-           * @returns {number} A precison. Could be 1, 0.1, 0.1, ... 1e-10.
+           * @returns {number} A precison. Could be 1, 10, 100, ... 1e+10.
            */
           derivePrecision: function(min, total) {
             var precisionPower = 0
             var precision = 1;
             var ratio = min / total;
-            while (precisionPower > -10) {
-              ratio = ratio / precision;
+            while (precisionPower < 10) {
+              ratio = ratio * precision;
               if (ratio > 1) {
                 break;
               }
-              precisionPower -= 1;
-              precision = Math.pow(10, precisionPower);
+              precision = Math.pow(10, precisionPower++);
             }
             return precision;
           },

--- a/src/definitions/modules/progress.js
+++ b/src/definitions/modules/progress.js
@@ -589,7 +589,7 @@ $.fn.progress = function(parameters) {
               : module.helper.sum(module.percent)
             ;
             if(percent === 100) {
-              if(settings.autoSuccess && !(module.is.warning() || module.is.error() || module.is.success())) {
+              if(settings.autoSuccess && $bars.length === 1 && !(module.is.warning() || module.is.error() || module.is.success())) {
                 module.set.success();
                 module.debug('Automatically triggering success at 100%');
               }

--- a/src/definitions/modules/progress.js
+++ b/src/definitions/modules/progress.js
@@ -77,7 +77,7 @@ $.fn.progress = function(parameters) {
           /**
            * Derive precision for multiple progress with total and values.
            *
-           * This helper dervices a precision that is sufficiently small to show minimum value of multiple progress.
+           * This helper dervices a precision that is sufficiently large to show minimum value of multiple progress.
            *
            * Example1
            * - total: 1122


### PR DESCRIPTION
## Description

1. Validation on sum of percents now is performed before rounding, as proposed by @ryamaguchi0220  in #759.

2.  Add `module.helper.derivePrecision` that calculates small-enough precision for multiple progress.
This is handy for users since they do not need to take care about precision for most cases.
If `precision` option is explicitly specified, it is used.

## Testcase
https://jsfiddle.net/x1ptzvs7/

## Screenshot (when possible)
Multiple progress bars are shown for the data in #757
![image](https://user-images.githubusercontent.com/127635/58075696-5081fe80-7be3-11e9-8179-90b9a21b8332.png)


## Closes
#757
