### PR TITLE
fix(form): remove rule function lead to TypeError

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -909,7 +909,7 @@ $.fn.form = function(parameters) {
               return;
             }
             $.each(validation[field].rules, function(index, rule) {
-              if(rules.indexOf(rule.type) !== -1) {
+              if(rule && rules.indexOf(rule.type) !== -1) {
                 module.debug('Removed rule', rule.type);
                 validation[field].rules.splice(index, 1);
               }


### PR DESCRIPTION
## Description
The behavior `remove rule` is self modifying the rules array of a field. Thus, a previous deleted rule reduces the length of the rule array which the current loop is still running on. 
When the loop now reaches the last array index which does not link to an object anymore because of deletion, this was not fetched leading into a typerror.

## Testcase
- Open console to watch ...
### Broken
... typeerror
https://jsfiddle.net/eL0jh56x/

### Fixed
... no error. The rule `notExactly[1]` is successfully removed and you can enter 1 character in the for field and the form gets validated
https://jsfiddle.net/eL0jh56x/1/

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6270
