### PR TITLE
build(composer): fix typo, add web property & changed domain to FUI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   },
   "keywords" : [
     "fomantic",
-    "fomaniic-ui",
+    "fomantic-ui",
     "semantic",
     "ui",
     "css",

--- a/tasks/config/admin/templates/composer.json
+++ b/tasks/config/admin/templates/composer.json
@@ -1,16 +1,18 @@
 {
-  "name"        : "semantic/ui",
-  "description" : "Semantic empowers designers and developers by creating a shared vocabulary for UI.",
-  "homepage"    : "http://www.semantic-ui.com",
+  "name"        : "fomantic/ui",
+  "description" : "Fomantic empowers designers and developers by creating a shared vocabulary for UI.",
+  "homepage"    : "https://fomantic-ui.com",
   "authors": [
     {
       "name" : "Jack Lukic",
       "email": "jacklukic@gmail.com",
-      "web"  : "http://www.jacklukic.com",
+      "homepage"  : "http://www.jacklukic.com",
       "role" : "Creator"
     }
   ],
   "keywords": [
+    "fomantic",
+    "fomantic-ui",
     "semantic",
     "ui",
     "css",


### PR DESCRIPTION
## Description
This PR corrects the composer.json files for correct schema usage and fomantic-domain as well as a typo 

## Closes
https://github.com/Semantic-Org/Semantic-UI/pull/6815