### PR TITLE
fix(icon): don't import default theme overrides

### DIFF
--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -370,4 +370,4 @@ i.icons .inverted.corner.icon {
   text-shadow: @cornerIconInvertedShadow;
 }
 
-.loadUIOverrides();
+.loadUIOverrides(false);

--- a/src/theme.less
+++ b/src/theme.less
@@ -66,8 +66,10 @@
      Overrides
 -------------------*/
 
-.loadUIOverrides() {
-  @import (optional) "@{themesFolder}/default/@{type}s/@{element}.overrides";
+.loadUIOverrides(@importDefault: true) {
+  & when (@importDefault = true) {
+    @import (optional) "@{themesFolder}/default/@{type}s/@{element}.overrides";
+  }
   @import (optional) "@{themesFolder}/@{theme}/@{type}s/@{element}.overrides";
   @import (optional) "@{siteFolder}/@{type}s/@{element}.overrides";
 }


### PR DESCRIPTION
## Description
Don't automatically import the default theme overrides file for icons.

## Closes
#763
