### PR TITLE
fix(form): stop propagation only when dirty event was triggered and prevent default action

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -298,9 +298,10 @@ $.fn.form = function(parameters) {
             } else {
               module.set.clean();
             }
-                  
-            if (e) {
+
+            if (e && e.namespace === 'dirty') {
               e.stopImmediatePropagation();
+              e.preventDefault();
             }
           }
         },


### PR DESCRIPTION
## Description
The `isDirty` method was immediatly stopping any other bubbling events, preventing other events to the same object to not work anymore.
But the method was also not preventing the default browser action, resulting in opening for example a file dialogue twice when manually triggered.

## Testcase
Try to select a file by clicking either into the FUI Input field or on the button of the lower native file input

### Broken
- The FUI Field does not open the file dialogue at all.
- The native field opens twice
https://jsfiddle.net/y0dsjotp/1/

## Fixed
- Both ways will show the upload dialogue once as expected.
https://jsfiddle.net/y0dsjotp/2/

## Closes
#746
#770
#786
https://github.com/atk4/ui/issues/718