### PR TITLE
[Button] Center button text in fluid & vertically aligned button group

### DIFF
--- a/src/definitions/elements/button.less
+++ b/src/definitions/elements/button.less
@@ -1335,6 +1335,7 @@
 .ui.fluid.vertical.buttons > .button {
   display: flex;
   width: auto;
+  justify-content: center;
 }
 
 .ui.two.vertical.buttons > .button {


### PR DESCRIPTION
## Description
While `fluid button` has centered text, `fluid vertical buttons` group do not, because of the flex display setting difference.
This PR corrects it now, so the text is also centered in those button groups.

Thanks to @tcmal for the [original SUI PR](https://github.com/Semantic-Org/Semantic-UI/pull/6335). I just left out the `width` setting change, because it's not necessary.

## Testcase
Remove CSS to see the issue
https://jsfiddle.net/0x3jntob/

## Screenshot

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/58367585-4f9de500-7ee1-11e9-8b86-e764763565b4.png)|![image](https://user-images.githubusercontent.com/18379884/58367590-60e6f180-7ee1-11e9-8f20-c54ca866936b.png)|


## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6065
