### PR TITLE
docs(security): add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,8 +7,11 @@
 | Version   | Supported          |
 | --------- | ------------------ |
 | 2.7.x     | :white_check_mark: |
-| > 2.x.x     | :lock:             |
+| > 2.x.x   | :lock:             |
 | 1.x.x     | :x:                |
+
+> All security fixes will be added the next release. Unless the threat is major the fix will be released with in the normal release
+> schedule.
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Supported Versions
+
+:white_check_mark: = Supported   :lock: = Security updates   :x: = Not supported
+
+| Version   | Supported          |
+| --------- | ------------------ |
+| 2.7.x     | :white_check_mark: |
+| > 2.x.x     | :lock:             |
+| 1.x.x     | :x:                |
+
+## Reporting a Vulnerability
+
+We take security very seriously with thousands of users using our library we need the communities help to spot security
+vulnerabilities.
+
+If you think you have found a vulnerability or have any concerns about our security please feel free to reach out to us using
+the details below.
+
+ - Email: security@fomantic-ui.com or contact@fomantic-ui.com
+ - Twitter: [@fomanticui](https://twitter.com/fomanticui)
+ - Discord: [https://discord.gg/YChxjJ3](https://discord.gg/YChxjJ3)


### PR DESCRIPTION
## Description

Added a security policy showing which versions we support and how people can get in touch with us to report vulnerabilities or their concerns.


(merging into master so people can see it before release)