### PR TITLE
build(theme.less): adjust line numbers for error messages

### DIFF
--- a/tasks/config/tasks.js
+++ b/tasks/config/tasks.js
@@ -94,14 +94,14 @@ module.exports = {
             element
           ;
           if(error.filename.match(/theme.less/)) {
-            if(error.line == 5) {
+            if(error.line == 9) {
               element  = regExp.variable.exec(error.message)[1];
               if(element) {
                 console.error('Missing theme.config value for ', element);
               }
               console.error('Most likely new UI was added in an update. You will need to add missing elements from theme.config.example');
             }
-            if(error.line == 46) {
+            if(error.line == 73) {
               element = regExp.element.exec(error.message)[1];
               theme   = regExp.theme.exec(error.message)[1];
               console.error(theme + ' is not an available theme for ' + element);


### PR DESCRIPTION
## Description
The tasks already fetches an error in `theme.less`. But it differed between a missing element or missing theme. To figure it out it relied on line numbers.
As theme.less had changed a lot over time since 2015 the line numbers were not correct anymore, leading into never informing the user what probably went wrong.
This PR adjusts the line numbers to their respective new positions of the relevant codelines.

