### PR TITLE
fix(dropdown): check for existing observer before accessing it

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -181,7 +181,7 @@ $.fn.dropdown = function(parameters) {
         },
         observe: {
           select: function() {
-            if(module.has.input()) {
+            if(module.has.input() && selectObserver) {
               selectObserver.observe($module[0], {
                 childList : true,
                 subtree   : true
@@ -189,7 +189,7 @@ $.fn.dropdown = function(parameters) {
             }
           },
           menu: function() {
-            if(module.has.menu()) {
+            if(module.has.menu() && menuObserver) {
               menuObserver.observe($menu[0], {
                 childList : true,
                 subtree   : true


### PR DESCRIPTION
## Description
When a search dropdown is initialized out of a `select` tag with given option values and one of those is set as `allowAddition:true` is set, it will trigger a observer at initialization time, but the observer is not yet initialized. This leads into a TypeError.
This PR adds a check for existing observer object before trying to access it (as it is implemented everywhere else in the code)

## Testcase
### Broken 
https://jsfiddle.net/6t70ce54/

### Fixed
https://jsfiddle.net/7rsge546/

## Closes
#784
