### PR TITLE
fix(table): table header on mobile

### DIFF
--- a/src/definitions/collections/table.less
+++ b/src/definitions/collections/table.less
@@ -168,6 +168,10 @@
     width: 100%;
     padding: 0;
   }
+  .ui.table:not(.unstackable) > thead,
+  .ui.table:not(.unstackable) > thead > tr,
+  .ui.table:not(.unstackable) > tfoot,
+  .ui.table:not(.unstackable) > tfoot > tr,
   .ui.table:not(.unstackable) > tbody,
   .ui.table:not(.unstackable) > tr,
   .ui.table:not(.unstackable) > tbody > tr,
@@ -196,10 +200,10 @@
     box-shadow: @responsiveRowBoxShadow;
   }
 
-  .ui.table:not(.unstackable) > tr > th,
-  .ui.table:not(.unstackable) > thead > tr > th,
-  .ui.table:not(.unstackable) > tbody > tr > th,
-  .ui.table:not(.unstackable) > tfoot > tr > th,
+  .ui.ui.ui.ui.table:not(.unstackable) > tr > th,
+  .ui.ui.ui.ui.table:not(.unstackable) > thead > tr > th,
+  .ui.ui.ui.ui.table:not(.unstackable) > tbody > tr > th,
+  .ui.ui.ui.ui.table:not(.unstackable) > tfoot > tr > th,
   .ui.ui.ui.ui.table:not(.unstackable) > tr > td,
   .ui.ui.ui.ui.table:not(.unstackable) > tbody > tr > td {
     background: none;
@@ -411,6 +415,10 @@
 @media only screen and (max-width : @largestTabletScreen) {
 
   .ui[class*="tablet stackable"].table,
+  .ui[class*="tablet stackable"].table > thead,
+  .ui[class*="tablet stackable"].table > thead > tr,
+  .ui[class*="tablet stackable"].table > tfoot,
+  .ui[class*="tablet stackable"].table > tfoot > tr,
   .ui[class*="tablet stackable"].table > tbody,
   .ui[class*="tablet stackable"].table > tbody > tr,
   .ui[class*="tablet stackable"].table > tr,


### PR DESCRIPTION
## Description
On mobile Screens the table header was inheriting a wrong margin, width and border setting since 2.7.5
This has been corrected now

## Testcase
https://jsfiddle.net/4gozw610/
Remove CSS to see the issue

## Screenshot
#### Before
![image](https://user-images.githubusercontent.com/18379884/58873327-694fe100-86c6-11e9-9cd3-39f30f6c960c.png)

#### After
![image](https://user-images.githubusercontent.com/18379884/58873383-8a183680-86c6-11e9-9c46-28380f74ea70.png)

## Closes
#787 
