### PR TITLE
Removing traling white spaces

### DIFF
--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -484,7 +484,7 @@ $.fn.modal = function(parameters) {
                     if ( settings.allowMultiple ) {
                       $previousModal.addClass(className.front);
                       $module.removeClass(className.front);
-      
+
                       if ( hideOthersToo ) {
                         $allModals.find(selector.dimmer).removeClass('active');
                       }


### PR DESCRIPTION
I don't know if the project coding style guide recommends to remove trailing white spaces, but I get the feeling it does considering the other empty lines in `modal.js`

So just a little PR to avoid my editor editing this line when I hack Fomantic ;-)