### PR TITLE
fix(form): transparent input padding and texarea support

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -130,6 +130,7 @@
 }
 
 /* Text Area */
+.ui.input textarea,
 .ui.form textarea {
   margin: 0;
   -webkit-appearance: none;
@@ -186,12 +187,13 @@
       Transparent
 ---------------------*/
 
-.ui.form .field .transparent.input input,
+.ui.form .field .transparent.input:not(.icon) input,
 .ui.form .field input.transparent,
 .ui.form .field textarea.transparent {
-  padding: @transparentPadding !important;
+  padding: @transparentPadding;
 }
 
+.ui.form .field input.transparent,
 .ui.form .field textarea.transparent {
   border-color: transparent !important;
   background-color: transparent !important;
@@ -199,6 +201,7 @@
 }
 
 .ui.form .field.error .transparent.input input,
+.ui.form .field.error .transparent.input textarea,
 .ui.form .field.error input.transparent,
 .ui.form .field.error textarea.transparent {
   background-color: @transparentFormErrorBackground !important;

--- a/src/definitions/elements/input.less
+++ b/src/definitions/elements/input.less
@@ -211,22 +211,25 @@
 .ui.transparent.input > input {
   border-color: transparent !important;
   background-color: transparent !important;
-  padding: 0 !important;
+  padding: 0;
   box-shadow: none !important;
   border-radius: 0 !important;
 }
+.field .ui.transparent.input > textarea {
+  padding: @padding;
+}
 
 /* Transparent Icon */
-.ui.transparent.icon.input > i.icon {
+:not(.field) > .ui.transparent.icon.input > i.icon {
   width: @transparentIconWidth;
 }
-.ui.transparent.icon.input > input {
-  padding-left: 0 !important;
-  padding-right: @transparentIconMargin !important;
+:not(.field) > .ui.transparent.icon.input > input {
+  padding-left: 0;
+  padding-right: @transparentIconMargin;
 }
-.ui.transparent[class*="left icon"].input > input {
-  padding-left: @transparentIconMargin !important;
-  padding-right: 0 !important;
+:not(.field) > .ui.transparent[class*="left icon"].input > input {
+  padding-left: @transparentIconMargin;
+  padding-right: 0;
 }
 
 /* Transparent Inverted */
@@ -271,9 +274,9 @@
 .ui.icon.input > i.icon:not(.link) {
   pointer-events: none;
 }
-.ui.icon.input > textarea,
-.ui.icon.input > input {
-  padding-right: @iconMargin !important;
+.ui.ui.icon.input > textarea,
+.ui.ui.icon.input > input {
+  padding-right: @iconMargin;
 }
 
 .ui.icon.input > i.icon:before,
@@ -303,10 +306,10 @@
   right: auto;
   left: @circularIconHorizontalOffset;
 }
-.ui[class*="left icon"].input > textarea,
-.ui[class*="left icon"].input > input {
-  padding-left: @iconMargin !important;
-  padding-right: @horizontalPadding !important;
+.ui.ui[class*="left icon"].input > textarea,
+.ui.ui[class*="left icon"].input > input {
+  padding-left: @iconMargin;
+  padding-right: @horizontalPadding;
 }
 
 /* Focus */
@@ -394,6 +397,9 @@
 }
 .ui.icon.input > textarea ~ .icon {
   height: @textareaIconHeight;
+}
+:not(.field) > .ui.transparent.icon.input > textarea ~ .icon {
+  height: @transparentTextareaIconHeight;
 }
 
 /* Corner Label Position  */

--- a/src/themes/default/elements/input.variables
+++ b/src/themes/default/elements/input.variables
@@ -45,6 +45,7 @@
 @transparentIconMargin: 2em;
 
 @textareaIconHeight: 3em;
+@transparentTextareaIconHeight: 1.3em;
 
 /* Circular Icon Input */
 @circularIconVerticalOffset: 0.35em;


### PR DESCRIPTION
## Description
A lot of padding and support of textarea were misaligned, wrong or not supported at all:

- icons in `transparent input` were misaligned when inside a form
- `textarea` had no style at all when outside of a form
- `field error` on a `transparent input` still had a border
- `field error` on `transparent input icon` for `textarea` had no error background

## Testcase
### Broken
https://jsfiddle.net/bq9kv4a8/

### Fixed
https://jsfiddle.net/bq9kv4a8/1
As i removed many `!important` the fixed fiddle contains a whole adjusted dist css file

## Screenshot
|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/59143385-e3d07780-89ca-11e9-8f36-2a8de36180b3.png)|![image](https://user-images.githubusercontent.com/18379884/59143389-f2b72a00-89ca-11e9-8a1a-41aa38754810.png)|
|![image](https://user-images.githubusercontent.com/18379884/59143349-93591a00-89ca-11e9-89a2-0e5ab6f268a5.png)|![image](https://user-images.githubusercontent.com/18379884/59143367-ab309e00-89ca-11e9-9c95-3c2f3a4b4b12.png)|
|![image](https://user-images.githubusercontent.com/18379884/59143402-0cf10800-89cb-11e9-99ca-11acd50f6057.png)|![image](https://user-images.githubusercontent.com/18379884/59143418-39a51f80-89cb-11e9-9a24-338c1b915857.png)|

## Closes
#798
