### PR TITLE
Replaced 'browsers' with 'overrideBrowserslist' to remove warning

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: [hammy2899]

--- a/tasks/config/tasks.js
+++ b/tasks/config/tasks.js
@@ -117,7 +117,7 @@ module.exports = {
 
     /* What Browsers to Prefix */
     prefix: {
-      browsers: [
+      overrideBrowserslist: [
         'last 2 versions',
         '> 1%',
         'opera 12.1',


### PR DESCRIPTION
## Description

The latest version of "autoprefixer": "^9.6.0" produces the following warning when running 'gulp build'

>   Replace Autoprefixer browsers option to Browserslist config.
>   Use browserslist key in package.json or .browserslistrc file.
> 
>   Using browsers option cause some error. Browserslist config 
>   can be used for Babel, Autoprefixer, postcss-normalize and other tools.
> 
>   If you really need to use option, rename it to overrideBrowserslist.

This change removes the warning

## Testcase
N/A

## Screenshot (when possible)
N/A

## Closes
N/A
