### PR TITLE
fix(menu): hover & active state colors on inverted secondary pointing

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -1044,9 +1044,10 @@ Floated Menu / Item
 
 
 /* Active */
-.ui.secondary.inverted.pointing.menu .active.item {
+.ui.ui.secondary.inverted.pointing.menu .active.item {
   border-color: @secondaryPointingInvertedActiveBorderColor;
   color: @secondaryPointingInvertedActiveColor;
+  background-color: transparent;
 }
 
 /*--------------
@@ -1305,8 +1306,11 @@ each(@colors, {
 
   & when not (@color=secondary) {
     .ui.ui.menu .@{color}.active.item,
+    .ui.ui.@{color}.menu .active.item:hover,
     .ui.ui.@{color}.menu .active.item {
-      border-color: @c;
+      & when not (@secondaryPointingActiveBorderColor = currentColor) {
+        border-color: @c;
+      }
       color: @c;
     }
   }
@@ -1430,6 +1434,7 @@ each(@colors, {
 each(@colors, {
   @color: replace(@key, '@', '');
   @c: @colors[@@color][color];
+  @h: @colors[@@color][hover];
 
   & when not (@color=secondary) {
     .ui.ui.inverted.menu .@{color}.active.item,
@@ -1441,6 +1446,10 @@ each(@colors, {
     }
     .ui.ui.inverted.@{color}.menu .active.item {
       background-color: @invertedColoredActiveBackground;
+    }
+    .ui.inverted.pointing.@{color}.menu .active.item:after,
+    .ui.inverted.pointing.@{color}.menu .active.item {
+      background-color: @h;
     }
   }
 })

--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -1447,13 +1447,15 @@ each(@colors, {
     .ui.ui.inverted.@{color}.menu .active.item {
       background-color: @invertedColoredActiveBackground;
     }
-    .ui.inverted.pointing.@{color}.menu .active.item:after,
     .ui.inverted.pointing.@{color}.menu .active.item {
       background-color: @h;
     }
   }
 })
 
+.ui.ui.ui.inverted.pointing.menu .active.item:after{
+  background-color: inherit;
+}
 
 /*--------------
      Fitted

--- a/src/themes/default/collections/menu.variables
+++ b/src/themes/default/collections/menu.variables
@@ -407,7 +407,7 @@
 @invertedMenuPressedColor: @invertedSelectedTextColor;
 
 /* Inverted Active */
-@invertedActiveBackground: @strongTransparentWhite;
+@invertedActiveBackground: @invertedArrowActiveColor;
 @invertedActiveColor: @invertedSelectedTextColor;
 @invertedArrowActiveColor: #3D3E3F;
 

--- a/src/themes/default/collections/menu.variables
+++ b/src/themes/default/collections/menu.variables
@@ -257,7 +257,7 @@
 
 @secondaryPointingHoverTextColor: @textColor;
 
-@secondaryPointingActiveBorderColor: @black;
+@secondaryPointingActiveBorderColor: currentColor;
 @secondaryPointingActiveTextColor: @selectedTextColor;
 @secondaryPointingActiveFontWeight: @bold;
 
@@ -283,7 +283,7 @@
 @secondaryPointingInvertedBorderColor: @whiteBorderColor;
 @secondaryPointingInvertedItemTextColor: @invertedTextColor;
 @secondaryPointingInvertedItemHeaderColor: @white;
-@secondaryPointingInvertedItemHoverTextColor: @selectedTextColor;
+@secondaryPointingInvertedItemHoverTextColor: @invertedSelectedTextColor;
 @secondaryPointingInvertedActiveBorderColor: @white;
 @secondaryPointingInvertedActiveColor: @invertedSelectedTextColor;
 


### PR DESCRIPTION
## Description
This PR corrects some color settings for `inverted/secondary/pointing` menus:

- `secondary pointing menu`: A colored active item went to black on hover
- `inverted secondary pointing menu`: non-active items went to black on hover
- Colored `inverted pointing menu` had black or half transparent pointer
- Active item on `inverted secondary pointing menu` had a background color

## Testcase
#### Broken
https://jsfiddle.net/b6z45ru3
https://jsfiddle.net/tqn4yub6/1/ (all colors example)

#### Fixed
https://jsfiddle.net/b6z45ru3/1/
https://jsfiddle.net/tqn4yub6/2/ (all colors example using a precompiled dist-css)

## Screenshot
|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/59159482-7a379280-8aca-11e9-9344-8ffe9f907269.png)|![image](https://user-images.githubusercontent.com/18379884/59159490-950a0700-8aca-11e9-8008-68c9fa37060f.png)|
|![menuactiveitemhover_bad](https://user-images.githubusercontent.com/18379884/59159512-e87c5500-8aca-11e9-96a1-abb4a6860623.gif)|![menuactiveitemhover_good](https://user-images.githubusercontent.com/18379884/59159514-efa36300-8aca-11e9-98e6-bc9f718be993.gif)|

## Closes
#777
