### PR TITLE
[Image] Hidden images were still visible when used in image groups

### DIFF
--- a/src/definitions/elements/image.less
+++ b/src/definitions/elements/image.less
@@ -48,7 +48,7 @@ img.ui.image {
 *******************************/
 
 .ui.hidden.images,
-.ui.hidden.image {
+.ui.ui.hidden.image {
   display: none;
 }
 .ui.hidden.transition.images,


### PR DESCRIPTION
## Description
A `hidden image` inside a `ui images` group hasn't got enough specificity to be hidden when not also used together with a `transition`.

## Testcase
You should not see any image
https://jsfiddle.net/2fy3gLaw/1/
Remove the CSS and one image , which is inside the group, will be shown

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6827
