### PR TITLE
fix(form): inline field label doesn't respect error styles

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -490,10 +490,10 @@
 }
 
 /* On Field(s) */
-.ui.form .fields.error .field label,
-.ui.form .field.error label,
-.ui.form .fields.error .field .input,
-.ui.form .field.error .input {
+.ui.ui.form .fields.error .field label,
+.ui.ui.form .field.error label,
+.ui.ui.form .fields.error .field .input,
+.ui.ui.form .field.error .input {
   color: @formErrorColor;
 }
 


### PR DESCRIPTION
## Description
Labels of `inline` fields within a form kept their black label color even when the field is marked as `error`
I also tested against other used labels like `checkbox` or `corner` but those specificity is not affected

## Testcase
https://jsfiddle.net/q2bowsne/1/
Remove the CSS to see the issue

## Screenshot
#### Before
![image](https://user-images.githubusercontent.com/14183168/59718071-a0230c80-9219-11e9-9b8c-dcc5881d08d0.png)

#### After
![image](https://user-images.githubusercontent.com/14183168/59718194-e7a99880-9219-11e9-9fe4-4016b6a93ce6.png)

## Closes
#818 
