### PR TITLE
feat(checkbox): add toggle on ENTER-key option

### DIFF
--- a/src/definitions/modules/checkbox.js
+++ b/src/definitions/modules/checkbox.js
@@ -244,7 +244,7 @@ $.fn.checkbox = function(parameters) {
               $input.blur();
               shortcutPressed = true;
             }
-            else if(!event.ctrlKey && ( key == keyCode.space || key == keyCode.enter) ) {
+            else if(!event.ctrlKey && ( key == keyCode.space || (key == keyCode.enter && settings.enableEnterKey)) ) {
               module.verbose('Enter/space key pressed, toggling checkbox');
               module.toggle();
               shortcutPressed = true;
@@ -829,6 +829,7 @@ $.fn.checkbox.settings = {
   // delegated event context
   uncheckable         : 'auto',
   fireOnInit          : false,
+  enableEnterKey      : true,
 
   onChange            : function(){},
 


### PR DESCRIPTION
## Description
The usual behavior of a standard (non FUI / html default) checkbox is to also get toggled by the SPACE key, but not by the ENTER key, when the checkbox is focused. 
But if a checkbox is initialized via the checkbox module of FUI it also allows to be toggled via the ENTER key by default.
This could lead into unwanted form submissions.
This PR adds a new setting `enableEnterKey` (default `true` to stay backward compatible), so one can make the FUI behavior match to the html default behavior of a checkbox

## Testcase
https://jsfiddle.net/6o8pvfe4/

## Closes
#819 
