### PR TITLE
fix(step): step visualization also on non active

### DIFF
--- a/src/definitions/elements/step.less
+++ b/src/definitions/elements/step.less
@@ -337,6 +337,9 @@
 }
 
 /* Active Arrow */
+.ui.steps .step:after {
+  display: @arrowDisplay;
+}
 .ui.steps .active.step:after {
   display: @activeArrowDisplay;
 }


### PR DESCRIPTION
## Description
This PR reverts a small change from #216 (commit https://github.com/fomantic/Fomantic-UI/pull/216/commits/32c932b607d990f68fa51b58b3172d56a867f031), which was (by accident) also removing the pointer step on (horizontal and non active) steps .

## Testcase
https://jsfiddle.net/f10pvax3/
Remove CSS to see the issue

## Screenshots
#### Before
![image](https://user-images.githubusercontent.com/18379884/59981052-adb40a00-95fe-11e9-962c-adfb04ce8899.png)

#### After (matches SUI again)
![image](https://user-images.githubusercontent.com/18379884/59981039-983ee000-95fe-11e9-9d13-6c9bed52ddc7.png)


## Closes
#830
