### PR TITLE
fix(dropdown): correct clear icon alignment

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -84,7 +84,7 @@
  Dropdown Icon
 ---------------*/
 
-.ui.dropdown > .dropdown.icon {
+.ui.dropdown > .dropdown.icon.icon {
   position: relative;
   width: auto;
   font-size: @dropdownIconSize;


### PR DESCRIPTION
This PR fixes the bad icon alignment in sized form's dropdowns. Icon `font-size` was overwritten by a rule in form.less, so I just increased the `.icon` weight in `dropdown.less` (hope this sentence is understandable...).

## Before
[![85b12e6759daf68101a38f093dcc80d7.md.png](http://tof.cx/images/2019/06/28/85b12e6759daf68101a38f093dcc80d7.md.png)](http://tof.cx/image/Yw4j9)

## After
[![779d8d11540e33ad377f6c3fc1326eca.md.png](http://tof.cx/images/2019/06/28/779d8d11540e33ad377f6c3fc1326eca.md.png)](http://tof.cx/image/YwpSv)

## Close
#837 