### PR TITLE
Tell RTLCSS to ignore flag icon background-positions. Fix #859

### DIFF
--- a/src/themes/default/elements/flag.overrides
+++ b/src/themes/default/elements/flag.overrides
@@ -3,6 +3,7 @@
 /*******************************
          Theme Overrides
 *******************************/
+/*rtl:begin:ignore*/
 
 i.flag.ad:before,
 i.flag.andorra:before {
@@ -989,3 +990,5 @@ i.flag.zw:before,
 i.flag.zimbabwe:before {
   background-position: -108px -390px;
 }
+
+/*rtl:end:ignore*/


### PR DESCRIPTION
RTLCSS which creates the Right-To-Left language support versions (semantic.rtl.css) incorrectly converts background-position: 0 ... to background-position: 100% .... Which breaks the flags.

This is expected behaviour in RTLCSS, see:

MohammadYounes/rtlcss#109

And the correct solution is to tell RTLCSS to ignore that section.

## Description
Adds in rtl:ignore directives see: https://rtlcss.com/learn/usage-guide/control-directives/

## Testcase
https://jsfiddle.net/1f4qbLa7/

## Closes
#859
