### PR TITLE
fix(form): prompt template function

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -733,23 +733,23 @@ $.fn.form = function(parameters) {
                           case 'date':
                           values[name] = settings.formatter.date(date);
                           break;
-                          
+
                           case 'datetime':
                           values[name] = settings.formatter.datetime(date);
                           break;
-                          
+
                           case 'time':
                           values[name] = settings.formatter.time(date);
                           break;
-                          
+
                           case 'month':
                           values[name] = settings.formatter.month(date);
                           break;
-                          
+
                           case 'year':
                           values[name] = settings.formatter.year(date);
                           break;
-  
+
                           default:
                           module.debug('Wrong calendar mode', $calendar, type);
                           values[name] = '';

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -860,7 +860,7 @@ $.fn.form = function(parameters) {
             }
             if(settings.inline) {
               if(!promptExists) {
-                $prompt = settings.templates.prompt(errors);
+                $prompt = settings.templates.prompt(errors, className.label);
                 $prompt
                   .appendTo($fieldGroup)
                 ;
@@ -1533,9 +1533,9 @@ $.fn.form.settings = {
     },
 
     // template that produces label
-    prompt: function(errors) {
+    prompt: function(errors, labelClasses) {
       return $('<div/>')
-        .addClass($.fn.form.settings.className.label)
+        .addClass(labelClasses)
         .html(errors[0])
       ;
     }

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1535,7 +1535,7 @@ $.fn.form.settings = {
     // template that produces label
     prompt: function(errors) {
       return $('<div/>')
-        .addClass(settings.className.label)
+        .addClass($.fn.form.settings.className.label)
         .html(errors[0])
       ;
     }

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1506,7 +1506,7 @@ $.fn.form.settings = {
 
   className : {
     error   : 'error',
-    label   : 'ui prompt label',
+    label   : 'ui basic red pointing prompt label',
     pressed : 'down',
     success : 'success'
   },
@@ -1535,7 +1535,7 @@ $.fn.form.settings = {
     // template that produces label
     prompt: function(errors) {
       return $('<div/>')
-        .addClass('ui basic red pointing prompt label')
+        .addClass(settings.className.label)
         .html(errors[0])
       ;
     }


### PR DESCRIPTION
## Description
The form template function used to create error labels was using a string literal instead of the `className.label` setting.

## Testcase
Before: https://jsfiddle.net/snkr9d4p/
After: https://jsfiddle.net/cyxb2v3z/

## Screenshot (when possible)
Before:
![image](https://user-images.githubusercontent.com/11588822/60993854-2af1b580-a347-11e9-94e2-5ae0b9dd8349.png)

After:
![image](https://user-images.githubusercontent.com/11588822/60993862-2fb66980-a347-11e9-867c-ac029b6b943e.png)
