### PR TITLE
[Dropdown] Support icon and or image settings as json properties

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -4028,6 +4028,9 @@ $.fn.dropdown.settings = {
 
 /* Templates */
 $.fn.dropdown.settings.templates = {
+  deQuote: function(string) {
+      return String(string).replace(/"/g,"");
+  },
   escape: function(string, preserveHTML) {
     if (preserveHTML){
       return string;
@@ -4058,7 +4061,8 @@ $.fn.dropdown.settings.templates = {
       placeholder = select.placeholder || false,
       values      = select.values || [],
       html        = '',
-      escape = $.fn.dropdown.settings.templates.escape
+      escape = $.fn.dropdown.settings.templates.escape,
+      deQuote = $.fn.dropdown.settings.templates.deQuote
     ;
     html +=  '<i class="dropdown icon"></i>';
     if(placeholder) {
@@ -4069,7 +4073,7 @@ $.fn.dropdown.settings.templates = {
     }
     html += '<div class="'+className.menu+'">';
     $.each(values, function(index, option) {
-      html += '<div class="'+(option.disabled ? className.disabled+' ':'')+className.item+'" data-value="' + String(option.value).replace(/"/g,"") + '">' + escape(option.name,preserveHTML) + '</div>';
+      html += '<div class="'+(option.disabled ? className.disabled+' ':'')+className.item+'" data-value="' + deQuote(option.value) + '">' + escape(option.name,preserveHTML) + '</div>';
     });
     html += '</div>';
     return html;
@@ -4080,7 +4084,8 @@ $.fn.dropdown.settings.templates = {
     var
       values = response[fields.values] || [],
       html   = '',
-      escape = $.fn.dropdown.settings.templates.escape
+      escape = $.fn.dropdown.settings.templates.escape,
+      deQuote = $.fn.dropdown.settings.templates.deQuote
     ;
     $.each(values, function(index, option) {
       var
@@ -4092,18 +4097,18 @@ $.fn.dropdown.settings.templates = {
       if( itemType === 'item' ) {
         var
           maybeText = (option[fields.text])
-            ? ' data-text="' + String(option[fields.text]).replace(/"/g,"") + '"'
+            ? ' data-text="' + deQuote(option[fields.text]) + '"'
             : '',
           maybeDisabled = (option[fields.disabled])
             ? className.disabled+' '
             : ''
         ;
-        html += '<div class="'+ maybeDisabled + className.item+'" data-value="' + String(option[fields.value]).replace(/"/g,"") + '"' + maybeText + '>';
+        html += '<div class="'+ maybeDisabled + className.item+'" data-value="' + deQuote(option[fields.value]) + '"' + maybeText + '>';
         if(option[fields.image]) {
-          html += '<img class="'+(option[fields.imageClass] ? String(option[fields.imageClass]).replace(/"/g,"") : className.image)+'" src="' + String(option[fields.image]).replace(/"/g,"") + '">';
+          html += '<img class="'+(option[fields.imageClass] ? deQuote(option[fields.imageClass]) : className.image)+'" src="' + deQuote(option[fields.image]) + '">';
         }
         if(option[fields.icon]) {
-          html += '<i class="'+option[fields.icon].replace(/"/g,"")+' '+(option[fields.iconClass] ? String(option[fields.iconClass]).replace(/"/g,"") : className.icon)+'"></i>';
+          html += '<i class="'+deQuote(option[fields.icon])+' '+(option[fields.iconClass] ? deQuote(option[fields.iconClass]) : className.icon)+'"></i>';
         }
         html +=   escape(option[fields.name],preserveHTML);
         html += '</div>';

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -3952,7 +3952,11 @@ $.fn.dropdown.settings = {
     name         : 'name',     // displayed dropdown text
     value        : 'value',    // actual dropdown value
     text         : 'text',     // displayed text when selected
-    type         : 'type'      // type of dropdown element
+    type         : 'type',     // type of dropdown element
+    image        : 'image',    // optional image path
+    imageClass   : 'imageClass', // optional individual class for image
+    icon        : 'icon',     // optional icon name
+    iconClass   : 'iconClass'  // optional individual class for icon (for example to use flag instead)
   },
 
   keys : {
@@ -3999,6 +4003,8 @@ $.fn.dropdown.settings = {
     dropdown    : 'ui dropdown',
     filtered    : 'filtered',
     hidden      : 'hidden transition',
+    icon        : 'icon',
+    image       : 'image',
     item        : 'item',
     label       : 'ui label',
     loading     : 'loading',
@@ -4093,6 +4099,12 @@ $.fn.dropdown.settings.templates = {
             : ''
         ;
         html += '<div class="'+ maybeDisabled + className.item+'" data-value="' + String(option[fields.value]).replace(/"/g,"") + '"' + maybeText + '>';
+        if(option[fields.image]) {
+          html += '<img class="'+(option[fields.imageClass] ? String(option[fields.imageClass]).replace(/"/g,"") : className.image)+'" src="' + String(option[fields.image]).replace(/"/g,"") + '">';
+        }
+        if(option[fields.icon]) {
+          html += '<i class="'+option[fields.icon].replace(/"/g,"")+' '+(option[fields.iconClass] ? String(option[fields.iconClass]).replace(/"/g,"") : className.icon)+'"></i>';
+        }
         html +=   escape(option[fields.name],preserveHTML);
         html += '</div>';
       } else if (itemType === 'header') {

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -751,6 +751,16 @@ select.ui.dropdown {
 .ui.multiple.dropdown > .label ~ .text {
   display: none;
 }
+.ui.multiple.dropdown > .label:not(.image) > img:not(.centered) {
+  margin-right: @itemElementDistance;
+}
+.ui.multiple.dropdown > .label:not(.image) > img.ui:not(.avatar) {
+  margin-bottom: @itemElementBottomDistance;
+}
+.ui.multiple.dropdown > .image.label img {
+  margin: @imageLabelImageMargin;
+  height: @imageLabelHeight;
+}
 
 /*-----------------
   Multiple Search

--- a/src/themes/default/modules/dropdown.variables
+++ b/src/themes/default/modules/dropdown.variables
@@ -99,6 +99,7 @@
 /* Item Sub-Element */
 @itemElementFloat: none;
 @itemElementDistance: @mini;
+@itemElementBottomDistance: @itemElementDistance / 2;
 
 /* Sub-Menu Dropdown Icon */
 @itemDropdownIconDistance: 1em;
@@ -273,6 +274,9 @@
 @labelVerticalPadding: @relative5px;
 @labelHorizontalPadding: @relativeMini;
 @labelPadding: @labelVerticalPadding @labelHorizontalPadding;
+
+@imageLabelHeight: (1em + @labelVerticalPadding * 2);  /* Logic adopted from label.less */
+@imageLabelImageMargin: -@labelVerticalPadding @labelHorizontalPadding -@labelVerticalPadding -@labelHorizontalPadding;
 
 /*-------------------
        States


### PR DESCRIPTION
## Description
This PR adds support for image or icon properties to be used in json values for item data (either by `values` or most important by any API response)

This is done if the following optional key-properties for an item value are given

|Property|Content|
|-|-|
|image|url to the image to be displayed. If omitted, image code rendering is skipped|
|imageClass|individual className for the image (for example `ui avatar image`). Default is `image`|
|icon|name of the icon/flag to be displayed. If omitted, icon code rendering is skipped|
|iconClass|could be changed to `flag` here. Default is `icon`|

### Example JSON
```json
{
	"name": "Avatar",
	"value": "jenny",
	"image": "https://fomantic-ui.com/images/avatar/small/jenny.jpg",
	"imageClass": "ui avatar image"
},
{
	"name": "Image",
	"value": "elliot",
	"image": "https://fomantic-ui.com/images/avatar/small/elliot.jpg"
},
{
	"name": "Flag",
	"value": "uk",
	"icon": "uk",
	"iconClass": "flag"
},
{
	"name": "Icon",
	"value": "female",
	"icon": "female"
},
{
	"name": "Colored Icon",
	"value": "coloredfemale",
	"icon": "pink female"
}
```

This way it's also possible to use both, image and icon, in one item entry.

To avoid adding  the classNames to every item entry (for example if you want to display a list of avatars), you could override the default setting for className.image or className.icon when initializing the dropdown
```javascript
$('.ui.dropdown').dropdown({
	className: {
		image: 'ui avatar image'
	}
});
```

### Support of `image label` for multiple selection labels
In addition this PR now supports/corrects usage of `image label` when `multiple selection` is used

```javascript
$('.ui.dropdown').dropdown({
	className: {
		label: 'ui image label'
	}
});
```
|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/61156420-9e382a80-a4f3-11e9-8183-761e4a6a7e81.png)|![image](https://user-images.githubusercontent.com/18379884/61156378-895b9700-a4f3-11e9-857a-da0ebc0af86c.png)|

## Testcase
https://jsfiddle.net/en6dwvqc/

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/61156655-359d7d80-a4f4-11e9-82a2-d52f425fb223.png)


## Closes
#872 
