### PR TITLE
[Popup] Optional setting "forcePosition" to disable calculation, even if popup will not fit

### DIFF
--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -1376,7 +1376,7 @@ $.fn.popup.settings = {
   // default position relative to element
   position       : 'top left',
 
-  // default position relative to element
+  // if given position should be used regardless if popup fits
   forcePosition  : false,
 
   // name of variation to use

--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -905,7 +905,7 @@ $.fn.popup = function(parameters) {
             // see if any boundaries are surpassed with this tentative position
             distanceFromBoundary = module.get.distanceFromBoundary(popupOffset, calculations);
 
-            if( module.is.offstage(distanceFromBoundary, position) ) {
+            if(!settings.forcePosition && module.is.offstage(distanceFromBoundary, position) ) {
               module.debug('Position is outside viewport', position);
               if(searchDepth < settings.maxSearchDepth) {
                 searchDepth++;
@@ -1375,6 +1375,9 @@ $.fn.popup.settings = {
 
   // default position relative to element
   position       : 'top left',
+
+  // default position relative to element
+  forcePosition  : false,
 
   // name of variation to use
   variation      : '',


### PR DESCRIPTION
## Description
This PR adds a new optional setting `forcePosition` (default `false` to stay backward compatible) to the popup module.
Before this PR the popup module always tries to recalculate a given `position` setting, in case the popup wouldn't be completely visible. if now `forcePosition: true` is used, the `position` setting will definately be used, regardless if it's completely shown or cropped. This could help in situations for the calendar module because the (non-inline) calendar is a popup itself and disturbs wanted UI behavior.

## Testcase
 Reduce output viewport, so calendar would fit to the right, but not to the bottom (see screenshots)
https://jsfiddle.net/0cxn2gy3/

## Screenshot
Given:  `position: 'bottom left' `
### Before or `forcePosition:false`
- Position is ignored, because the calendar does not fit to viewport on bottom left
![image](https://user-images.githubusercontent.com/18379884/61302594-5a407080-a7e6-11e9-872d-ea91be0d1497.png)

### After or `forcePosition:true`
- Displayed at bottom left as defined, although the calendar does not fit to viewport and gets cropped
![image](https://user-images.githubusercontent.com/18379884/61302574-4c8aeb00-a7e6-11e9-8c0e-29814ac57c4e.png)

## Closes
#684 
