### PR TITLE
[Table] Colored definition table shows overlapping border in top left cell

### DIFF
--- a/src/definitions/collections/table.less
+++ b/src/definitions/collections/table.less
@@ -283,7 +283,7 @@
   background: @definitionHeaderBackground;
   font-weight: @definitionHeaderFontWeight;
   color: @definitionHeaderColor;
-  box-shadow: -@borderWidth -@borderWidth 0 @borderWidth @definitionPageBackground;
+  box-shadow: -@coloredBorderSizeCover -@coloredBorderSize 0 @coloredBorderSizeCover @definitionPageBackground;
 }
 
 .ui.definition.table > tfoot:not(.full-width) > tr > th:first-child {
@@ -291,7 +291,7 @@
   background: @definitionFooterBackground;
   font-weight: @definitionFooterFontWeight;
   color: @definitionFooterColor;
-  box-shadow: -@borderWidth @borderWidth 0 @borderWidth @definitionPageBackground;
+  box-shadow: -@coloredBorderSizeCover @coloredBorderSize 0 @coloredBorderSizeCover @definitionPageBackground;
 }
 
 /* Remove Border */

--- a/src/definitions/collections/table.less
+++ b/src/definitions/collections/table.less
@@ -294,14 +294,6 @@
   box-shadow: -@coloredBorderSizeCover @coloredBorderSize 0 @coloredBorderSizeCover @definitionPageBackground;
 }
 
-/* Remove Border */
-.ui.celled.definition.table > thead:not(.full-width) > tr > th:first-child {
-  box-shadow: 0 -@borderWidth 0 @borderWidth @definitionPageBackground;
-}
-.ui.celled.definition.table > tfoot:not(.full-width) > tr > th:first-child {
-  box-shadow: 0 @borderWidth 0 @borderWidth @definitionPageBackground;
-}
-
 /* Highlight Defining Column */
 .ui.definition.table > tr > td:first-child:not(.ignored),
 .ui.definition.table > tbody > tr > td:first-child:not(.ignored),

--- a/src/definitions/collections/table.less
+++ b/src/definitions/collections/table.less
@@ -284,6 +284,7 @@
   font-weight: @definitionHeaderFontWeight;
   color: @definitionHeaderColor;
   box-shadow: -@coloredBorderSizeCover -@coloredBorderSize 0 @coloredBorderSizeCover @definitionPageBackground;
+  -moz-transform: scale(1);
 }
 
 .ui.definition.table > tfoot:not(.full-width) > tr > th:first-child {
@@ -292,6 +293,7 @@
   font-weight: @definitionFooterFontWeight;
   color: @definitionFooterColor;
   box-shadow: -@coloredBorderSizeCover @coloredBorderSize 0 @coloredBorderSizeCover @definitionPageBackground;
+  -moz-transform: scale(1);
 }
 
 /* Highlight Defining Column */
@@ -320,21 +322,6 @@
 .ui.definition.table > tr > td:nth-child(2),
 .ui.definition.table > tbody > tr > td:nth-child(2) {
   border-left: @borderWidth solid @borderColor;
-}
-
-/* Legacy */
-.ui.legacy.definition.table {
-  border-collapse: collapse;
-}
-.ui.legacy.definition.table > thead:not(.full-width) > tr > th:first-child,
-.ui.legacy.definition.table > tfoot:not(.full-width) > tr > th:first-child {
-  border-left: @borderWidth solid @definitionPageBackground;
-}
-.ui.legacy.definition.table > thead:not(.full-width) > tr > th:first-child {
-  border-top: @coloredBorderSize solid @definitionPageBackground;
-}
-.ui.legacy.definition.table > tfoot:not(.full-width) > tr > th:first-child {
-  border-bottom: @coloredBorderSize solid @definitionPageBackground;
 }
 
 /*******************************

--- a/src/definitions/collections/table.less
+++ b/src/definitions/collections/table.less
@@ -322,6 +322,20 @@
   border-left: @borderWidth solid @borderColor;
 }
 
+/* Legacy */
+.ui.legacy.definition.table {
+  border-collapse: collapse;
+}
+.ui.legacy.definition.table > thead:not(.full-width) > tr > th:first-child,
+.ui.legacy.definition.table > tfoot:not(.full-width) > tr > th:first-child {
+  border-left: @borderWidth solid @definitionPageBackground;
+}
+.ui.legacy.definition.table > thead:not(.full-width) > tr > th:first-child {
+  border-top: @coloredBorderSize solid @definitionPageBackground;
+}
+.ui.legacy.definition.table > tfoot:not(.full-width) > tr > th:first-child {
+  border-bottom: @coloredBorderSize solid @definitionPageBackground;
+}
 
 /*******************************
              States

--- a/src/themes/default/collections/table.variables
+++ b/src/themes/default/collections/table.variables
@@ -83,7 +83,7 @@
 /* Definition */
 @definitionPageBackground: @white;
 
-@definitionHeaderBackground: transparent;
+@definitionHeaderBackground: @white;
 @definitionHeaderColor: @unselectedTextColor;
 @definitionHeaderFontWeight: @normal;
 
@@ -202,6 +202,7 @@
 /* Colors */
 @coloredBorderSize: 0.2em;
 @coloredBorderRadius: 0 0 @borderRadius @borderRadius;
+@coloredBorderSizeCover: @coloredBorderSize / 2;
 
 /* Inverted */
 @invertedBackground: #333333;


### PR DESCRIPTION
##  Description
A colored `definition table` was still showing the table color border on the top left cell (which is not used on definition tables by design)
I first thought it was enough to change the background, but IE/Edge still showed the border on zooming, thats why i still had to use and adjust the box-shadow

## Testcase
https://jsfiddle.net/gc15zfku/

## Screenshots
### Before
![883_evil](https://user-images.githubusercontent.com/18379884/61477775-4fc1da80-a990-11e9-9a62-b90f37810b2e.gif)

### Using only background (FYI)
![883_bad](https://user-images.githubusercontent.com/18379884/61477795-610ae700-a990-11e9-9bc6-549bcad0b57c.gif)

### Final Fix
![883_good](https://user-images.githubusercontent.com/18379884/61477811-6700c800-a990-11e9-83e6-06ea91a2fcea.gif)

## Closes
#883 
https://github.com/Semantic-Org/Semantic-UI-React/issues/3710