### PR TITLE
[Dropdown] Corrected initial clearable icon when <select> was used for conversion

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -2172,7 +2172,8 @@ $.fn.dropdown = function(parameters) {
             else {
               module.set.selected();
             }
-            if(module.get.value()!=='') {
+            var value = module.get.value();
+            if(value && value !== '') {
               $input.removeClass(className.noselection);
             } else {
               $input.addClass(className.noselection);

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -2024,11 +2024,11 @@ $.fn.dropdown = function(parameters) {
                 ? module.get.values()
                 : module.get.text()
             ;
+            isMultiple = (module.is.multiple() && Array.isArray(value));
             shouldSearch = (isMultiple)
               ? (value.length > 0)
               : (value !== undefined && value !== null)
             ;
-            isMultiple = (module.is.multiple() && Array.isArray(value));
             strict     = (value === '' || value === false  || value === true)
               ? true
               : strict || false
@@ -2172,7 +2172,7 @@ $.fn.dropdown = function(parameters) {
             else {
               module.set.selected();
             }
-            if(module.get.item()) {
+            if(module.get.value()!=='') {
               $input.removeClass(className.noselection);
             } else {
               $input.addClass(className.noselection);

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -2173,7 +2173,7 @@ $.fn.dropdown = function(parameters) {
               module.set.selected();
             }
             var value = module.get.value();
-            if(value && value !== '') {
+            if(value && value !== '' && !(Array.isArray(value) && value.length === 0)) {
               $input.removeClass(className.noselection);
             } else {
               $input.addClass(className.noselection);


### PR DESCRIPTION
## Description
When a dropdown was setup out of a `select` tag and had empty <option> values set but used something different than `placeholder: 'auto'`, the initial clearable icon was shown, although the initial value was "" (= no selection)

## Testcase
### Fixed
https://jsfiddle.net/dfp09hLz/

### Broken
https://jsfiddle.net/pn12f3Lr/2/

## Screenshot
#### Before
![image](https://user-images.githubusercontent.com/18379884/61666344-83c23600-acd7-11e9-8c8d-de1025db8734.png)

### After
![image](https://user-images.githubusercontent.com/18379884/61666313-70af6600-acd7-11e9-854b-d6dedcff3dd9.png)

## Closes
#839 
