### PR TITLE
[Dropdown] Only preventdefault on hide for associating labels

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1200,7 +1200,9 @@ $.fn.dropdown = function(parameters) {
             },
             hide: function(event) {
               if(module.determine.eventInModule(event, module.hide)){
+                if(element.id && $(event.target).attr('for') === element.id){
                   event.preventDefault();
+                }
               }
             }
           },


### PR DESCRIPTION
## Description
This PR adjusts the fix implemented by #188 
The implemented `preventDefault` avoided a dropdown by reopening when clicking on the associated label instead of the dropdown itself.
Unfortunately this also stops other events in some situations which do not belong to the dropdown itself.
This PR now only prevents the event when the special case of the associated label was the target.

## Testcase
This example is taken from the related issue #861 
- Choose something from the dropdown
- It is going to replace the whole dropdown adding an additional form (which is not related DOM-wise to the dropdown)
- Clicking on the form submit button ...

### Broken
... does not trigger the event (see console, it should read "event")
https://jsfiddle.net/fpr4joez/4/
### Fixed
.. triggers the event as expected
https://jsfiddle.net/m51q6oje/

To make sure the original fix #188 is still fixed see this jsfiddle 
- clicking on the label does work as expected as before
https://jsfiddle.net/3yLmuezc/

## Closes
#861
Semantic-Org/Semantic-UI#6638
