### PR TITLE
[Accordion] Remove transition class after animation to make conten loader work again

### DIFF
--- a/src/definitions/modules/accordion.js
+++ b/src/definitions/modules/accordion.js
@@ -189,7 +189,10 @@ $.fn.accordion = function(parameters) {
                     debug            : settings.debug,
                     verbose          : settings.verbose,
                     duration         : settings.duration,
-                    skipInlineHidden : true
+                    skipInlineHidden : true,
+                    onComplete: function() {
+                      $activeContent.children().removeClass(className.transition);
+                    }
                   })
               ;
             }
@@ -591,7 +594,8 @@ $.fn.accordion.settings = {
 
   className   : {
     active    : 'active',
-    animating : 'animating'
+    animating : 'animating',
+    transition: 'transition'
   },
 
   selector    : {


### PR DESCRIPTION
## Description
A `loading transition` moves into invisible area, which is correct behavior.
However when some content, like a form or segment, got the `transition` class after getting animated and you try to add the `loading` class onto it (for example to show a loading form or segment), the loader and whole content vanishes, because the transition class is still set and prevents the loading display.
Exactly that happens in the accordion module when child elements are getting animated. They keep the `transition` class.
This PR now removes the `transition` class after show-animation finishes (only there! hidden transition must be kept!) to prepare the element for usage of a `loading` class again. This is a safe action, because any additional animation (opening/closing accordion) will always re-add the `transition` class again because of the usage of the transition module and on initialization the opened accordion does not have any `transition` class at all (thats why it always works the first time)

## Testcase
- Click on the blue "Guardar" Button, it will show the loading spinner as expected
- Close the accordion by clicking on the top "Optional Data" header
- Reopen the accordion by clicking again
- Now click on the blue button again and see...

### Broken
... no loading spinner anymore
https://jsfiddle.net/dfgrwyqs/

### Fixed
... same behavior as before: loading spinner is shown
https://jsfiddle.net/mL6po4dh/

## Screenshot
### Broken
![865_bad](https://user-images.githubusercontent.com/18379884/61729708-1c0ff780-ad78-11e9-9568-aabbfe7fe9d3.gif)

### Fixed
![865_good](https://user-images.githubusercontent.com/18379884/61729714-203c1500-ad78-11e9-9098-2987ba9e6876.gif)

## Closes
#865 
https://github.com/Semantic-Org/Semantic-UI/issues/6840
