### PR TITLE
[Search] Behavior 'get result:' Support numerical fields and make use of user defined searchFields

### DIFF
--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -436,7 +436,6 @@ $.fn.search = function(parameters) {
           },
           result: function(value, results) {
             var
-              lookupFields = ['title', 'id'],
               result       = false
             ;
             value = (value !== undefined)
@@ -451,7 +450,7 @@ $.fn.search = function(parameters) {
               module.debug('Finding result that matches', value);
               $.each(results, function(index, category) {
                 if(Array.isArray(category.results)) {
-                  result = module.search.object(value, category.results, lookupFields)[0];
+                  result = module.search.object(value, category.results)[0];
                   // don't continue searching if a result is found
                   if(result) {
                     return false;
@@ -461,7 +460,7 @@ $.fn.search = function(parameters) {
             }
             else {
               module.debug('Finding result in results object', value);
-              result = module.search.object(value, results, lookupFields)[0];
+              result = module.search.object(value, results)[0];
             }
             return result || false;
           },

--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -632,10 +632,15 @@ $.fn.search = function(parameters) {
             $.each(searchFields, function(index, field) {
               $.each(source, function(label, content) {
                 var
-                  fieldExists = (typeof content[field] == 'string')
+                  fieldExists = (typeof content[field] == 'string') || (typeof content[field] == 'number')
                 ;
                 if(fieldExists) {
-                  var text = module.remove.diacritics(content[field]);
+                  var text;
+                  if (typeof content[field] === 'string'){  
+                      text = module.remove.diacritics(content[field]);
+                  } else {
+                      text = content[field].toString(); 
+                  }
                   if( text.search(matchRegExp) !== -1) {
                     // content starts with value (first in results)
                     addResult(results, content);
@@ -1246,6 +1251,7 @@ $.fn.search.settings = {
 
   // fields to search
   searchFields   : [
+    'id',
     'title',
     'description'
   ],


### PR DESCRIPTION
## Description
When defining custom searchFields the $('.ui.search').search('get result', value)  do not use the user defined values, it uses the default ones.

This is because the default array is passed and the user setting are not used in line 616

``            searchFields = (searchFields !== undefined)
              ? searchFields
              : settings.searchFields
            ;
``
## Testcase
### Numerical values
#### Broken
https://jsfiddle.net/venturaEesc/q3p1b52t/13/

#### Fixed
https://jsfiddle.net/2db9gf7u/

### Not using custom searchFields
#### Broken
https://jsfiddle.net/venturaEesc/q3p1b52t/4/

#### Fixed
https://jsfiddle.net/2jx6bhd8/
## Closes
#897 
https://github.com/Semantic-Org/Semantic-UI/pull/6023