### PR TITLE
[Dropdown] Don't toggle on "set selected" when no labels are used

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1311,9 +1311,7 @@ $.fn.dropdown = function(parameters) {
                   module.remove.filteredItem();
                   module.set.scrollPosition($choice);
                 }
-                selectActionActive = true;
                 module.determine.selectAction.call(this, text, value);
-                selectActionActive = false;
               }
             }
           },
@@ -1641,6 +1639,7 @@ $.fn.dropdown = function(parameters) {
 
         determine: {
           selectAction: function(text, value) {
+            selectActionActive = true;
             module.verbose('Determining action', settings.action);
             if( $.isFunction( module.action[settings.action] ) ) {
               module.verbose('Triggering preset action', settings.action, text, value);
@@ -1653,6 +1652,7 @@ $.fn.dropdown = function(parameters) {
             else {
               module.error(error.action, settings.action);
             }
+            selectActionActive = false;
           },
           eventInModule: function(event, callback) {
             var

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -2671,7 +2671,7 @@ $.fn.dropdown = function(parameters) {
                       module.set.activeItem($selected);
                     }
                   }
-                  else if(!isFiltered) {
+                  else if(!isFiltered && settings.useLabels) {
                     module.debug('Selected active value, removing label');
                     module.remove.selected(selectedValue);
                   }

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -85,6 +85,7 @@ $.fn.dropdown = function(parameters) {
         element         = this,
         instance        = $module.data(moduleNamespace),
 
+        selectActionActive,
         initialLoad,
         pageLostFocus,
         willRefocus,
@@ -1310,7 +1311,9 @@ $.fn.dropdown = function(parameters) {
                   module.remove.filteredItem();
                   module.set.scrollPosition($choice);
                 }
+                selectActionActive = true;
                 module.determine.selectAction.call(this, text, value);
+                selectActionActive = false;
               }
             }
           },
@@ -2671,7 +2674,7 @@ $.fn.dropdown = function(parameters) {
                       module.set.activeItem($selected);
                     }
                   }
-                  else if(!isFiltered && settings.useLabels) {
+                  else if(!isFiltered && (settings.useLabels || selectActionActive)) {
                     module.debug('Selected active value, removing label');
                     module.remove.selected(selectedValue);
                   }


### PR DESCRIPTION
## Description
`set selected` toggles rather than adds values on multiple value dropdown that has `useLabels: false` setting.

## Testcase
Click on the blue button to trigger a `set selected` 

### Broken
- The values toggle between selected and unselected
https://jsfiddle.net/a5j7u231/

### Fixed
- values are selected / kept being selected all the time
https://jsfiddle.net/k8oqpjgx/1/

## Screenshot
![670_bad](https://user-images.githubusercontent.com/18379884/61809690-1a106c00-ae3e-11e9-880c-efdb15959466.gif)

## Closes
#670 
