### PR TITLE
[Container] Respect fluid container on mobile screen and remove !important

### DIFF
--- a/src/definitions/elements/container.less
+++ b/src/definitions/elements/container.less
@@ -24,78 +24,78 @@
 /* All Sizes */
 .ui.container {
   display: block;
-  max-width: @maxWidth !important;
+  max-width: @maxWidth;
 }
 
 /* Mobile */
 @media only screen and (max-width: @largestMobileScreen) {
-  .ui.container {
-    width: @mobileWidth !important;
-    margin-left: @mobileGutter !important;
-    margin-right: @mobileGutter !important;
+  .ui.container:not(.fluid) {
+    width: @mobileWidth;
+    margin-left: @mobileGutter;
+    margin-right: @mobileGutter;
   }
   .ui.grid.container {
-    width: @mobileGridWidth !important;
+    width: @mobileGridWidth;
   }
   .ui.relaxed.grid.container {
-    width: @mobileRelaxedGridWidth !important;
+    width: @mobileRelaxedGridWidth;
   }
   .ui.very.relaxed.grid.container {
-    width: @mobileVeryRelaxedGridWidth !important;
+    width: @mobileVeryRelaxedGridWidth;
   }
 }
 
 /* Tablet */
 @media only screen and (min-width: @tabletBreakpoint) and (max-width: @largestTabletScreen) {
-  .ui.container {
+  .ui.container:not(.fluid) {
     width: @tabletWidth;
-    margin-left: @tabletGutter !important;
-    margin-right: @tabletGutter !important;
+    margin-left: @tabletGutter;
+    margin-right: @tabletGutter;
   }
   .ui.grid.container {
-    width: @tabletGridWidth !important;
+    width: @tabletGridWidth;
   }
   .ui.relaxed.grid.container {
-    width: @tabletRelaxedGridWidth !important;
+    width: @tabletRelaxedGridWidth;
   }
   .ui.very.relaxed.grid.container {
-    width: @tabletVeryRelaxedGridWidth !important;
+    width: @tabletVeryRelaxedGridWidth;
   }
 }
 
 /* Small Monitor */
 @media only screen and (min-width: @computerBreakpoint) and (max-width: @largestSmallMonitor) {
-  .ui.container {
+  .ui.container:not(.fluid) {
     width: @computerWidth;
-    margin-left: @computerGutter !important;
-    margin-right: @computerGutter !important;
+    margin-left: @computerGutter;
+    margin-right: @computerGutter;
   }
   .ui.grid.container {
-    width: @computerGridWidth !important;
+    width: @computerGridWidth;
   }
   .ui.relaxed.grid.container {
-    width: @computerRelaxedGridWidth !important;
+    width: @computerRelaxedGridWidth;
   }
   .ui.very.relaxed.grid.container {
-    width: @computerVeryRelaxedGridWidth !important;
+    width: @computerVeryRelaxedGridWidth;
   }
 }
 
 /* Large Monitor */
 @media only screen and (min-width: @largeMonitorBreakpoint) {
-  .ui.container {
+  .ui.container:not(.fluid) {
     width: @largeMonitorWidth;
-    margin-left: @largeMonitorGutter !important;
-    margin-right: @largeMonitorGutter !important;
+    margin-left: @largeMonitorGutter;
+    margin-right: @largeMonitorGutter;
   }
   .ui.grid.container {
-    width: @largeMonitorGridWidth !important;
+    width: @largeMonitorGridWidth;
   }
   .ui.relaxed.grid.container {
-    width: @largeMonitorRelaxedGridWidth !important;
+    width: @largeMonitorRelaxedGridWidth;
   }
   .ui.very.relaxed.grid.container {
-    width: @largeMonitorVeryRelaxedGridWidth !important;
+    width: @largeMonitorVeryRelaxedGridWidth;
   }
 }
 
@@ -107,7 +107,7 @@
 /* Text Container */
 .ui.text.container {
   font-family: @textFontFamily;
-  max-width: @textWidth !important;
+  max-width: @textWidth;
   line-height: @textLineHeight;
   font-size: @textSize;
 }

--- a/src/definitions/elements/container.less
+++ b/src/definitions/elements/container.less
@@ -29,72 +29,72 @@
 
 /* Mobile */
 @media only screen and (max-width: @largestMobileScreen) {
-  .ui.ui.container:not(.fluid) {
+  .ui.ui.ui.container:not(.fluid) {
     width: @mobileWidth;
     margin-left: @mobileGutter;
     margin-right: @mobileGutter;
   }
-  .ui.grid.container {
+  .ui.ui.grid.container {
     width: @mobileGridWidth;
   }
-  .ui.relaxed.grid.container {
+  .ui.ui.relaxed.grid.container {
     width: @mobileRelaxedGridWidth;
   }
-  .ui.very.relaxed.grid.container {
+  .ui.ui.very.relaxed.grid.container {
     width: @mobileVeryRelaxedGridWidth;
   }
 }
 
 /* Tablet */
 @media only screen and (min-width: @tabletBreakpoint) and (max-width: @largestTabletScreen) {
-  .ui.ui.container:not(.fluid) {
+  .ui.ui.ui.container:not(.fluid) {
     width: @tabletWidth;
     margin-left: @tabletGutter;
     margin-right: @tabletGutter;
   }
-  .ui.grid.container {
+  .ui.ui.grid.container {
     width: @tabletGridWidth;
   }
-  .ui.relaxed.grid.container {
+  .ui.ui.relaxed.grid.container {
     width: @tabletRelaxedGridWidth;
   }
-  .ui.very.relaxed.grid.container {
+  .ui.ui.very.relaxed.grid.container {
     width: @tabletVeryRelaxedGridWidth;
   }
 }
 
 /* Small Monitor */
 @media only screen and (min-width: @computerBreakpoint) and (max-width: @largestSmallMonitor) {
-  .ui.ui.container:not(.fluid) {
+  .ui.ui.ui.container:not(.fluid) {
     width: @computerWidth;
     margin-left: @computerGutter;
     margin-right: @computerGutter;
   }
-  .ui.grid.container {
+  .ui.ui.grid.container {
     width: @computerGridWidth;
   }
-  .ui.relaxed.grid.container {
+  .ui.ui.relaxed.grid.container {
     width: @computerRelaxedGridWidth;
   }
-  .ui.very.relaxed.grid.container {
+  .ui.ui.very.relaxed.grid.container {
     width: @computerVeryRelaxedGridWidth;
   }
 }
 
 /* Large Monitor */
 @media only screen and (min-width: @largeMonitorBreakpoint) {
-  .ui.ui.container:not(.fluid) {
+  .ui.ui.ui.container:not(.fluid) {
     width: @largeMonitorWidth;
     margin-left: @largeMonitorGutter;
     margin-right: @largeMonitorGutter;
   }
-  .ui.grid.container {
+  .ui.ui.grid.container {
     width: @largeMonitorGridWidth;
   }
-  .ui.relaxed.grid.container {
+  .ui.ui.relaxed.grid.container {
     width: @largeMonitorRelaxedGridWidth;
   }
-  .ui.very.relaxed.grid.container {
+  .ui.ui.very.relaxed.grid.container {
     width: @largeMonitorVeryRelaxedGridWidth;
   }
 }

--- a/src/definitions/elements/container.less
+++ b/src/definitions/elements/container.less
@@ -29,7 +29,7 @@
 
 /* Mobile */
 @media only screen and (max-width: @largestMobileScreen) {
-  .ui.container:not(.fluid) {
+  .ui.ui.container:not(.fluid) {
     width: @mobileWidth;
     margin-left: @mobileGutter;
     margin-right: @mobileGutter;
@@ -47,7 +47,7 @@
 
 /* Tablet */
 @media only screen and (min-width: @tabletBreakpoint) and (max-width: @largestTabletScreen) {
-  .ui.container:not(.fluid) {
+  .ui.ui.container:not(.fluid) {
     width: @tabletWidth;
     margin-left: @tabletGutter;
     margin-right: @tabletGutter;
@@ -65,7 +65,7 @@
 
 /* Small Monitor */
 @media only screen and (min-width: @computerBreakpoint) and (max-width: @largestSmallMonitor) {
-  .ui.container:not(.fluid) {
+  .ui.ui.container:not(.fluid) {
     width: @computerWidth;
     margin-left: @computerGutter;
     margin-right: @computerGutter;
@@ -83,7 +83,7 @@
 
 /* Large Monitor */
 @media only screen and (min-width: @largeMonitorBreakpoint) {
-  .ui.container:not(.fluid) {
+  .ui.ui.container:not(.fluid) {
     width: @largeMonitorWidth;
     margin-left: @largeMonitorGutter;
     margin-right: @largeMonitorGutter;


### PR DESCRIPTION
## Description
A `fluid container` is supposed to always have 100% width without any margin.
This is so far working until the screen gets < 768px, then a margin appears.

This PR makes sure a `fluid` is always respected.
While we are at it, this PR also removed the `!important` from the container settings and used  class-specificity levels instead where necessary.

## Testcase
Scale your browser window until it gets the size of <768px (or switch to mobile view in dev-tools)
> It also shows all other container combinations to proove the specificity after removing the !important statements, is still working correctly (But please test yourself)

### Broken
... fluid container gets a margin
https://jsfiddle.net/pmbL25r4/5/
https://jsfiddle.net/pmbL25r4/5/show

### Fixed
... fluid container keeps zero margin
https://jsfiddle.net/pmbL25r4/4/
https://jsfiddle.net/pmbL25r4/4/show

## Screenshot
![fluid_container](https://user-images.githubusercontent.com/18379884/61882892-a469d600-aef9-11e9-9add-049125b6a440.gif)

## Releated to
#900 
