### PR TITLE
fix(chore): revert size variable declaration to avoid recursion

### DIFF
--- a/src/themes/default/globals/site.variables
+++ b/src/themes/default/globals/site.variables
@@ -670,14 +670,14 @@
 @relativeMassive : unit( @massiveRaw, em);
 
 /* rem */
-@absoluteMini    : @mini;
-@absoluteTiny    : @tiny;
-@absoluteSmall   : @small;
-@absoluteMedium  : @medium;
-@absoluteLarge   : @large;
-@absoluteBig     : @big;
-@absoluteHuge    : @huge;
-@absoluteMassive : @massive;
+@absoluteMini    : unit( @miniRaw, rem);
+@absoluteTiny    : unit( @tinyRaw, rem);
+@absoluteSmall   : unit( @smallRaw, rem);
+@absoluteMedium  : unit( @mediumRaw, rem);
+@absoluteLarge   : unit( @largeRaw, rem);
+@absoluteBig     : unit( @bigRaw, rem);
+@absoluteHuge    : unit( @hugeRaw, rem);
+@absoluteMassive : unit( @massiveRaw, rem);
 
 /*-------------------
        Icons


### PR DESCRIPTION
## Description
Reverted variable declaration for the `absolute` size variables because recursion occurs if single components (like `label`) refers as  `@big: @absoluteBig` but `@absoluteBig: @big` was set in site.variables

