### PR TITLE
fix(progress): wrong error on validating sum of rounded percents

### DIFF
--- a/src/definitions/modules/progress.js
+++ b/src/definitions/modules/progress.js
@@ -468,7 +468,7 @@ $.fn.progress = function(parameters) {
                   width: value + '%'
                 });
               }
-              return parseInt(value, 10);
+              return parseFloat(value);
             });
             values.forEach(function(_, index) {
               var $bar = $($bars[index]);
@@ -523,15 +523,15 @@ $.fn.progress = function(parameters) {
                   : undefined;
 
               // round display percentage
-              percents = percents.map(function (percent) {
+              var roundedPercents = percents.map(function (percent) {
                 return (autoPrecision > 0)
                   ? Math.round(percent * (10 * autoPrecision)) / (10 * autoPrecision)
                   : Math.round(percent)
                   ;
               });
-              module.percent = percents;
+              module.percent = roundedPercents;
               if (!hasTotal) {
-                module.value = percents.map(function (percent) {
+                module.value = roundedPercents.map(function (percent) {
                   return (autoPrecision > 0)
                     ? Math.round((percent / 100) * module.total * (10 * autoPrecision)) / (10 * autoPrecision)
                     : Math.round((percent / 100) * module.total * 10) / 10


### PR DESCRIPTION
## Description

I propose to store unrounded percents in the `data-percent` attribute instead of rounded percents.

Here is what causes the wrong error.
① Store rounded percents in the `data-percent` attribute [here](https://github.com/fomantic/Fomantic-UI/blob/master/src/definitions/modules/progress.js#L483)
② Get the rounded percents [here](https://github.com/fomantic/Fomantic-UI/blob/master/src/definitions/modules/progress.js#L165)
③ Validate sum of the rounded percents  [here](https://github.com/fomantic/Fomantic-UI/blob/master/src/definitions/modules/progress.js#L513).
    As [this comment](https://github.com/fomantic/Fomantic-UI/blob/master/src/definitions/modules/progress.js#L514) indicates, it is not expected to pass rounded percents to the `percent()`.

## Testcase
https://jsfiddle.net/yxLr6mut/

## Closes
#953
