### PR TITLE
[Dropdown] Keep input field focus if it's an menu item 

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1296,7 +1296,7 @@ $.fn.dropdown = function(parameters) {
                 isBubbledEvent = ($subMenu.find($target).length > 0)
               ;
               // prevents IE11 bug where menu receives focus even though `tabindex=-1`
-              if (!module.has.search() || !document.activeElement.isEqualNode($search[0])) {
+              if (document.activeElement.tagName.toLowerCase() !== 'input') {
                 $(document.activeElement).blur();
               }
               if(!isBubbledEvent && (!hasSubMenu || settings.allowCategorySelection)) {


### PR DESCRIPTION
## Description
This PR fixes to enter something in input fields within dropdowns when it's not the search input

## Testcase
- Open the dropdown and try to click into any of the three entries

### Broken
- First two entries open the calendar but loose focus immediatly so entering dates manually is not possible
- Third entry is just a simple input field which is also not clickable because it looses focus
https://jsfiddle.net/g19fdp7s/2/

### Fixed
- All entries changable as expected
https://jsfiddle.net/g19fdp7s/1/

## Closes
#937 
