### PR TITLE
feat(dropdown): add select optgroup and horizontal divider support

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -3979,7 +3979,6 @@ $.fn.dropdown.settings = {
     icon         : 'icon',     // optional icon name
     iconClass    : 'iconClass', // optional individual class for icon (for example to use flag instead)
     class        : 'class',    // optional individual class for item/header
-    group        : 'group',    // optional group header an option belongs
     divider      : 'divider'   // optional divider append for group headers
   },
 

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -2438,6 +2438,9 @@ $.fn.dropdown = function(parameters) {
               ? forceScroll
               : false
             ;
+            if(module.get.activeItem().length === 0){
+              forceScroll = false;
+            }
             if($item && $menu.length > 0 && hasActive) {
               itemOffset = $item.position().top;
 

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -382,7 +382,7 @@ $.fn.dropdown = function(parameters) {
                 .attr('class', $input.attr('class') )
                 .addClass(className.selection)
                 .addClass(className.dropdown)
-                .html( templates.dropdown(selectValues,settings.preserveHTML, settings.className) )
+                .html( templates.dropdown(selectValues, fields, settings.preserveHTML, settings.className) )
                 .insertBefore($input)
               ;
               if($input.hasClass(className.multiple) && $input.prop('multiple') === false) {
@@ -1942,7 +1942,8 @@ $.fn.dropdown = function(parameters) {
           },
           selectValues: function() {
             var
-              select = {}
+              select = {},
+              oldGroup = []
             ;
             select.values = [];
             $module
@@ -1954,12 +1955,21 @@ $.fn.dropdown = function(parameters) {
                     disabled = $option.attr('disabled'),
                     value    = ( $option.attr('value') !== undefined )
                       ? $option.attr('value')
-                      : name
+                      : name,
+                    group = $option.parent('optgroup')
                   ;
                   if(settings.placeholder === 'auto' && value === '') {
                     select.placeholder = name;
                   }
                   else {
+                    if(group.length !== oldGroup.length || group[0] !== oldGroup[0]) {
+                      select.values.push({
+                        type: 'header',
+                        divider: settings.headerDivider,
+                        name: group.attr('label') || ''
+                      });
+                      oldGroup = group;
+                    }
                     select.values.push({
                       name     : name,
                       value    : value,
@@ -3886,6 +3896,8 @@ $.fn.dropdown.settings = {
 
   glyphWidth             : 1.037,      // widest glyph width in em (W is 1.037 em) used to calculate multiselect input width
 
+  headerDivider          : true,       // whether option headers should have an additional divider line underneath when converted from <select> <optgroup>
+
   // label settings on multi-select
   label: {
     transition : 'scale',
@@ -3961,8 +3973,11 @@ $.fn.dropdown.settings = {
     type         : 'type',     // type of dropdown element
     image        : 'image',    // optional image path
     imageClass   : 'imageClass', // optional individual class for image
-    icon        : 'icon',     // optional icon name
-    iconClass   : 'iconClass'  // optional individual class for icon (for example to use flag instead)
+    icon         : 'icon',     // optional icon name
+    iconClass    : 'iconClass', // optional individual class for icon (for example to use flag instead)
+    class        : 'class',    // optional individual class for item/header
+    group        : 'group',    // optional group header an option belongs
+    divider      : 'divider'   // optional divider append for group headers
   },
 
   keys : {
@@ -4027,7 +4042,10 @@ $.fn.dropdown.settings = {
     visible     : 'visible',
     clearable   : 'clearable',
     noselection : 'noselection',
-    delete      : 'delete'
+    delete      : 'delete',
+    header      : 'header',
+    divider     : 'divider',
+    groupIcon   : ''
   }
 
 };
@@ -4062,13 +4080,11 @@ $.fn.dropdown.settings.templates = {
     return string;
   },
   // generates dropdown from select values
-  dropdown: function(select, preserveHTML, className) {
+  dropdown: function(select, fields, preserveHTML, className) {
     var
       placeholder = select.placeholder || false,
-      values      = select.values || [],
       html        = '',
-      escape = $.fn.dropdown.settings.templates.escape,
-      deQuote = $.fn.dropdown.settings.templates.deQuote
+      escape = $.fn.dropdown.settings.templates.escape
     ;
     html +=  '<i class="dropdown icon"></i>';
     if(placeholder) {
@@ -4078,9 +4094,7 @@ $.fn.dropdown.settings.templates = {
       html += '<div class="text"></div>';
     }
     html += '<div class="'+className.menu+'">';
-    $.each(values, function(index, option) {
-      html += '<div class="'+(option.disabled ? className.disabled+' ':'')+className.item+'" data-value="' + deQuote(option.value) + '">' + escape(option.name,preserveHTML) + '</div>';
-    });
+    html += $.fn.dropdown.settings.templates.menu(select, fields, preserveHTML,className);
     html += '</div>';
     return html;
   },
@@ -4109,7 +4123,7 @@ $.fn.dropdown.settings.templates = {
             ? className.disabled+' '
             : ''
         ;
-        html += '<div class="'+ maybeDisabled + className.item+'" data-value="' + deQuote(option[fields.value]) + '"' + maybeText + '>';
+        html += '<div class="'+ maybeDisabled + (option[fields.class] ? deQuote(option[fields.class]) : className.item)+'" data-value="' + deQuote(option[fields.value]) + '"' + maybeText + '>';
         if(option[fields.image]) {
           html += '<img class="'+(option[fields.imageClass] ? deQuote(option[fields.imageClass]) : className.image)+'" src="' + deQuote(option[fields.image]) + '">';
         }
@@ -4119,9 +4133,20 @@ $.fn.dropdown.settings.templates = {
         html +=   escape(option[fields.name],preserveHTML);
         html += '</div>';
       } else if (itemType === 'header') {
-        html += '<div class="header">';
-        html +=   escape(option[fields.name],preserveHTML);
-        html += '</div>';
+        var groupName = escape(option[fields.name],preserveHTML),
+            groupIcon = option[fields.icon] ? deQuote(option[fields.icon]) : className.groupIcon
+        ;
+        if(groupName !== '' || groupIcon !== '') {
+          html += '<div class="' + (option[fields.class] ? deQuote(option[fields.class]) : className.header) + '">';
+          if (groupIcon !== '') {
+            html += '<i class="' + groupIcon + ' ' + (option[fields.iconClass] ? deQuote(option[fields.iconClass]) : className.icon) + '"></i>';
+          }
+          html += groupName;
+          html += '</div>';
+        }
+        if(option[fields.divider]){
+          html += '<div class="'+className.divider+'"></div>';
+        }
       }
     });
     return html;

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -168,16 +168,20 @@
 .ui.dropdown .menu > .header {
   margin: @menuHeaderMargin;
   padding: @menuHeaderPadding;
-  color: @menuHeaderColor;
-  font-size: @menuHeaderFontSize;
   font-weight: @menuHeaderFontWeight;
   text-transform: @menuHeaderTextTransform;
 }
-
+.ui.dropdown .menu > .header:not(.ui) {
+  color: @menuHeaderColor;
+  font-size: @menuHeaderFontSize;
+}
 .ui.dropdown .menu > .divider {
   border-top: @menuDividerBorder;
   height: 0;
   margin: @menuDividerMargin;
+}
+.ui.dropdown .menu > .horizontal.divider {
+  border-top: none;
 }
 
 .ui.dropdown.dropdown .menu > .input {


### PR DESCRIPTION
## Description
Whenever a dropdown was created out of a `select` tag, any possible existing `optgroup` groups were ignored.
This PR now supports
- option groups of select tags being converted into dropdown group headers
- manual values and API response settings by new optional item attributes `divider`, `class`, `header`, `icon`
- optional usage of `ui horizontal divider` instead of the usual (since then hardcoded) `header`
- optional display a divider line underneath a usual header
- display of a group header icon either by central setting `groupIcon` or individually as item value
- usage of colors or sizes of when `ui header` is used (needs CSS recompilation, that's why the testcase does not show it)
- display of a possible group header at first position when nothing is selected and menu gets opened
- central usage of the menu template

Infact the dropdown menu creation already supported a given header when `header` as `type` was given. The functionality has been enhanced now 🙂 

## Testcase
http://jsfiddle.net/srcn0u6a/2/

## Screenshot
```html
<select>
  <optgroup label="Optgroup 1">
    <option value="option-1">Option 1</option>
    <option value="option-2">Option 2</option>
  </optgroup>
  <optgroup label="Optgroup 2">
    <option value="option-3">Option 3</option>
    <option value="option-4">Option 4</option>
  </optgroup>
</select>
```
![image](https://user-images.githubusercontent.com/18379884/63716418-46a51280-c846-11e9-8055-50cb6d4e89e7.png)
```javascript
 className: {
        header: 'ui horizontal divider'
    },
    headerDivider: false
```
![image](https://user-images.githubusercontent.com/18379884/63716398-3a20ba00-c846-11e9-8c8c-1e51ea5ea1ff.png)

```javascript

values: [{
        name: 'Female Superheroes 1',
        type: 'header',
        icon: 'female' //use female icon only for this header
    }],
groupIcon: 'male'  //use male icon as header default
```
![image](https://user-images.githubusercontent.com/18379884/63717627-fa0f0680-c848-11e9-90e0-ae4eb865f3cd.png)


## Closes
#956 
https://github.com/Semantic-Org/Semantic-UI/issues/1727
https://github.com/Semantic-Org/Semantic-UI/issues/5099
https://github.com/Semantic-Org/Semantic-UI/issues/6755
