### PR TITLE
feat(slider): add auto adjusted label display

### DIFF
--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -23,6 +23,7 @@ $.fn.slider = function(parameters) {
 
   var
     $allModules    = $(this),
+    $window        = $(window),
 
     moduleSelector = $allModules.selector || '',
 
@@ -86,6 +87,7 @@ $.fn.slider = function(parameters) {
         offset,
         precision,
         isTouch,
+        gapRatio = 1,
 
         module
       ;
@@ -210,7 +212,11 @@ $.fn.slider = function(parameters) {
               for(var i = 0, len = module.get.numLabels(); i <= len; i++) {
                 var
                   labelText = module.get.label(i),
-                  $label = (labelText !== "") ? $('<li class="label">' + labelText + '</li>') : null,
+                  $label = (labelText !== "") 
+                    ? !(i % module.get.gapRatio())
+                      ? $('<li class="label">' + labelText + '</li>') 
+                      : $('<li class="halftick label"></li>')
+                    : null,
                   ratio  = i / len
                 ;
                 if($label) {
@@ -229,6 +235,9 @@ $.fn.slider = function(parameters) {
             module.bind.mouseEvents();
             if(module.is.touch()) {
               module.bind.touchEvents();
+            }
+            if (settings.autoAdjustLabels) {
+              module.bind.windowEvents();
             }
           },
           keyboardEvents: function() {
@@ -273,6 +282,9 @@ $.fn.slider = function(parameters) {
               $(document).on('mousemove' + eventNamespace, module.event.move);
               $(document).on('mouseup' + eventNamespace, module.event.up);
             }
+          },
+          windowEvents: function() {
+            $window.on('resize' + eventNamespace, module.event.resize);
           }
         },
 
@@ -374,6 +386,13 @@ $.fn.slider = function(parameters) {
               $module.focus();
             }
           },
+          resize: function(_event) {
+            // To avoid a useless performance cost, we only call the label refresh when its necessary
+            if (gapRatio != module.get.gapRatio()) {
+              module.setup.labels();
+              gapRatio = module.get.gapRatio();
+            }
+          }
         },
 
         resync: function() {
@@ -587,6 +606,29 @@ $.fn.slider = function(parameters) {
               case 'first':
               default:
                 return position;
+            }
+          },
+          gapRatio: function() {
+            var gapRatio = 1;
+            
+            if( settings.autoAdjustLabels ) {
+              var 
+                numLabels = module.get.numLabels(),
+                gapCounter = 1
+              ;
+
+              // While the distance between two labels is too short,
+              // we divide the number of labels at each iteration
+              // and apply only if the modulo of the operation is an odd number.
+              while ((module.get.trackLength() / numLabels) * gapCounter < settings.labelDistance) {
+                if( !(numLabels % gapCounter) ) {
+                  gapRatio = gapCounter;
+                }
+                gapCounter += 1;
+              }
+              return gapRatio;
+            } else {
+              return 1;
             }
           }
         },
@@ -1169,14 +1211,16 @@ $.fn.slider.settings = {
     secondThumbVal  : 'secondThumbVal'
   },
 
-  min            : 0,
-  max            : 20,
-  step           : 1,
-  start          : 0,
-  end            : 20,
-  labelType      : 'number',
-  showLabelTicks : false,
-  smooth         : false,
+  min              : 0,
+  max              : 20,
+  step             : 1,
+  start            : 0,
+  end              : 20,
+  labelType        : 'number',
+  showLabelTicks   : false,
+  smooth           : false,
+  autoAdjustLabels : true,
+  labelDistance    : 100,
 
   //the decimal place to round to if step is undefined
   decimalPlaces  : 2,

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -299,6 +299,7 @@ $.fn.slider = function(parameters) {
             $module.off('keydown' + eventNamespace);
             $module.off('focusout' + eventNamespace);
             $(document).off('keydown' + eventNamespace + documentEventID, module.event.activateFocus);
+            $window.off('resize' + eventNamespace);
           },
           slidingEvents: function() {
             if(module.is.touch()) {

--- a/src/definitions/modules/slider.less
+++ b/src/definitions/modules/slider.less
@@ -195,6 +195,9 @@
   top: 100%;
   left: 50%;
 }
+.ui.labeled.ticked.slider > .labels .halftick.label:after {
+  height: @labelHeight / 2;
+}
 
 /* Vertical Labels */
 
@@ -216,6 +219,10 @@
   height: @labelWidth;
   left: 100%;
   top: 50%;
+}
+.ui.labeled.vertical.slider > .labels .halftick.label:after {
+  width: @labelHeight / 2;
+  height: @labelWidth;
 }
 
 /* Vertical Reversed Labels */
@@ -335,6 +342,9 @@ each(@colors, {
 .ui.small.labeled.slider:not(.vertical) > .labels .label:after {
   height: @smallLabelHeight;
 }
+.ui.small.labeled.slider:not(.vertical) > .labels .halftick.label:after {
+  height: @smallLabelHeight / 2;
+}
 
 /* Small Vertical */
 .ui.slider.small.vertical .inner {
@@ -348,6 +358,9 @@ each(@colors, {
 .ui.small.labeled.vertical.slider> .labels,
 .ui.small.labeled.vertical.slider> .labels .label:after {
   width: @smallLabelHeight;
+}
+.ui.small.labeled.vertical.slider> .labels .halftick.label:after {
+  width: @smallLabelHeight / 2;
 }
 
 /* Large */
@@ -367,6 +380,9 @@ each(@colors, {
 .ui.large.labeled.slider:not(.vertical) > .labels .label:after {
   height: @largeLabelHeight;
 }
+.ui.large.labeled.slider:not(.vertical) > .labels .halftick.label:after {
+  height: @largeLabelHeight / 2;
+}
 
 /* Large Vertical */
 .ui.slider.large.vertical .inner {
@@ -380,6 +396,9 @@ each(@colors, {
 .ui.large.labeled.vertical.slider> .labels,
 .ui.large.labeled.vertical.slider> .labels .label:after {
   width: @largeLabelHeight;
+}
+.ui.large.labeled.vertical.slider> .labels .halftick.label:after {
+  width: @largeLabelHeight / 2;
 }
 
 /* Big */
@@ -399,6 +418,9 @@ each(@colors, {
 .ui.big.labeled.slider:not(.vertical) > .labels .label:after {
   height: @bigLabelHeight;
 }
+.ui.big.labeled.slider:not(.vertical) > .labels .halftick.label:after {
+  height: @bigLabelHeight / 2;
+}
 
 /* Big Vertical */
 .ui.slider.big.vertical .inner {
@@ -412,6 +434,9 @@ each(@colors, {
 .ui.big.labeled.vertical.slider> .labels,
 .ui.big.labeled.vertical.slider> .labels .label:after {
   width: @bigLabelHeight;
+}
+.ui.big.labeled.vertical.slider> .labels .halftick.label:after {
+  width: @bigLabelHeight / 2;
 }
 
 .loadUIOverrides();


### PR DESCRIPTION
## Description
This PR adds dynamically adjusted labels to sliders, which will avoid unreadable labels when there's too many on screen.

It works by calculating the labels which respect a minimal distance between them (adjustable trough the new setting `labelDistance`; default `100`). All intermediate labels still exists, but they don't display a value, and their tick height is half sized.

This new feature can be disabled by setting `autoAdjustLabels` to `false`.

Oh, and the labels are also adjusted on window resizing too.

## Testcase
Before: [JSFiddle](https://jsfiddle.net/Lopwyghd/)
After: [JSFiddle](https://jsfiddle.net/xj827hfw/)

## Screenshot
![Animationfa5992902b2ebe79.gif](https://s3.gifyu.com/images/Animationfa5992902b2ebe79.gif)

## Closes
#913
