### PR TITLE
fix(form): 'set values' behavior had no proper calendar support

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1023,10 +1023,12 @@ $.fn.form = function(parameters) {
               var
                 $field      = module.get.field(key),
                 $element    = $field.parent(),
+                $calendar   = $field.closest(selector.uiCalendar),
                 isMultiple  = Array.isArray(value),
                 isCheckbox  = $element.is(selector.uiCheckbox)  && module.can.useElement('checkbox'),
                 isDropdown  = $element.is(selector.uiDropdown) && module.can.useElement('dropdown'),
                 isRadio     = ($field.is(selector.radio) && isCheckbox),
+                isCalendar  = ($calendar.length > 0  && module.can.useElement('calendar')),
                 fieldExists = ($field.length > 0),
                 $multipleField
               ;
@@ -1061,6 +1063,9 @@ $.fn.form = function(parameters) {
                 else if(isDropdown) {
                   module.verbose('Setting dropdown value', value, $element);
                   $element.dropdown('set selected', value);
+                }
+                else if (isCalendar) {
+                  $calendar.calendar('set date',value);
                 }
                 else {
                   module.verbose('Setting field value', value, $field);


### PR DESCRIPTION
## Description
When a `calendar` was used within a `form` and the forms `set values` behavior was used, the calendar got only the textual representation of the given date without actually using the date itself. Therefore the calendar internally still had the old value.

## Testcase
### Broken
https://jsfiddle.net/dbLr687e/

### Fixed
https://jsfiddle.net/dbLr687e/1/

## Screenshot
|Broken|Fixed|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/64007592-bb14d580-cb14-11e9-85b4-28a15af49869.png)|![image](https://user-images.githubusercontent.com/18379884/64007887-455d3980-cb15-11e9-99d7-0ad1229d7a41.png)|

## Closes
#980 
