### PR TITLE
feat(calendar): add onBeforeChange callback and fix a date value issue

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -674,7 +674,8 @@ $.fn.calendar = function(parameters) {
 
             var mode = module.get.mode();
             var text = formatter.datetime(date, settings);
-            if (fireChange && settings.onChange.call(element, date, text, mode) === false) {
+
+            if (fireChange && settings.onBeforeChange.call(element, date, text, mode) === false) {
               return false;
             }
 
@@ -693,6 +694,10 @@ $.fn.calendar = function(parameters) {
 
             if (updateInput && $input.length) {
               $input.val(text);
+            }
+
+            if (fireChange) {
+              settings.onChange.call(element, date, text, mode);
             }
           },
           startDate: function (date, refreshCalendar) {
@@ -1473,9 +1478,13 @@ $.fn.calendar.settings = {
     }
   },
 
-  // callback when date changes, return false to cancel the change
-  onChange: function (date, text, mode) {
+  // callback before date is changed, return false to cancel the change
+  onBeforeChange: function (date, text, mode) {
     return true;
+  },
+
+  // callback when date changes
+  onChange: function (date, text, mode) {
   },
 
   // callback before show animation, return false to prevent show


### PR DESCRIPTION
## Description
This PR actually provide two things:
- a new callback, called `onBeforeChange`, which allow to cancel a change before it's applied to calendar logic. The old `onChange` callback is now moved further.

- a fix to the `onChange` callback. His position was bad, since the date wasn't really changed internally when it was called, so any call the one of the behaviors or using the input resulted in a bad value.

⚠️ This is a breaking change ! The new `onChange` callback, doesn't allow to cancel change anymore, so we might warn users when we'll publish this update.

## Testcase
Before: [JSFiddle](https://jsfiddle.net/a28ruv0x/1/)
After: [JSFiddle](https://jsfiddle.net/rL6ukpz1/)

## Closes
#417 
https://github.com/mdehoog/Semantic-UI-Calendar/issues/124