### PR TITLE
fix(dropdown): setting value of dropdown did not remove search

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -988,7 +988,6 @@ $.fn.dropdown = function(parameters) {
           else {
             if(settings.allowAdditions) {
               module.set.selected(module.get.query());
-              module.remove.searchTerm();
             }
             else {
               module.remove.searchTerm();
@@ -2708,7 +2707,8 @@ $.fn.dropdown = function(parameters) {
                 }
               })
             ;
-          },
+            module.remove.searchTerm();
+          }
         },
 
         add: {
@@ -2988,9 +2988,11 @@ $.fn.dropdown = function(parameters) {
             $search.css('width', '');
           },
           searchTerm: function() {
-            module.verbose('Cleared search term');
-            $search.val('');
-            module.set.filtered();
+            if(module.has.search()){
+              module.verbose('Cleared search term');
+              $search.val('');
+              module.set.filtered();
+            }
           },
           userAddition: function() {
             $item.filter(selector.addition).remove();

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -2988,11 +2988,9 @@ $.fn.dropdown = function(parameters) {
             $search.css('width', '');
           },
           searchTerm: function() {
-            if(module.has.search()){
-              module.verbose('Cleared search term');
-              $search.val('');
-              module.set.filtered();
-            }
+            module.verbose('Cleared search term');
+            $search.val('');
+            module.set.filtered();
           },
           userAddition: function() {
             $item.filter(selector.addition).remove();


### PR DESCRIPTION
## Description
If you have a dropdown with a search term and `forceSelection:false` and a given search value not matching any dropdown entry, setting the value of the dropdown with "set selected"/"set exactly" afterwards, did not remove the search term making the selected value overlay the search term.

## Testcase
Enter random text into the dropdown (don't select an item from the list)
Click the button "Click Me"

### Broken
https://jsfiddle.net/twe78h0n/
A value is selected (Graphic Design), but the search term does not get removed.

### Fixed
https://jsfiddle.net/twe78h0n/1/
A value gets selected (Graphic Design), and the search term gets removed.

## Screenshot
|Broken|Fixed|
|-|-|
|![dd_remove_term_bad](https://user-images.githubusercontent.com/18379884/64185877-28569c80-ce6e-11e9-8b39-a99759c6cabf.gif)|![dd_remove_term_good](https://user-images.githubusercontent.com/18379884/64185895-30aed780-ce6e-11e9-8050-08c67cd26260.gif)|

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/4904
