### PR TITLE
[Calendar] Fix broken dates when keyboard typed

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -1277,7 +1277,7 @@ $.fn.calendar.settings = {
         return null;
       }
       // Reverse date and month in some cases
-      text = settings.monthFirst ? text : text.replace(/([0-9]+)[\/\-]([0-9]+)/,'$2/$1');
+      text = settings.monthFirst ? text : text.replace(/([0-9]+)[\/\-\.]([0-9]+)/,'$2/$1');
       var textDate = new Date(text);
       if(!isNaN(textDate.getDate())) {
         return textDate;

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -1276,6 +1276,8 @@ $.fn.calendar.settings = {
       if (text.length === 0) {
         return null;
       }
+      // Reverse date and month in some cases
+      text = settings.monthFirst ? text : text.replace(/([0-9]+)[\/\-]([0-9]+)/,'$2/$1');
       var textDate = new Date(text);
       if(!isNaN(textDate.getDate())) {
         return textDate;


### PR DESCRIPTION
# Description
This PR aim to fix (or at least drastically reduce) the broken date format when it's typed through keyboard. It's a bit hacky, since it only reverse supposed days and month when the setting `monthFirst` is defined to `true`, but I think this little piece of code will cover 98% of cases.

## Testcase
Before: [JSFiddle](https://jsfiddle.net/musjvb63/)
After: [JSFiddle](https://jsfiddle.net/z6ghfcv9/)

## Closes
#829 
#986
