### PR TITLE
[List] use hex notation for unicode character

### DIFF
--- a/src/themes/default/elements/list.variables
+++ b/src/themes/default/elements/list.variables
@@ -162,7 +162,7 @@
 @bulletOffset: -@bulletDistance;
 
 @bulletOpacity: 1;
-@bulletCharacter: '•';
+@bulletCharacter: '\2022';
 @bulletColor: inherit;
 @bulletLinkColor: @textColor;
 @bulletVerticalAlign: top;


### PR DESCRIPTION
## Description

> List component bullets appear as â€¢ instead of bullets utf-8 \2022.
> Problem was showing up in Android and iOS after using Cordova to create the app.
> Traced the issue and not a Cordova problem but a CSS issue.
> 

In usual browsers there is no visual difference, but using hex notation is a more clean implementation anyway

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6867
https://github.com/Semantic-Org/Semantic-UI-React/issues/2325
