### PR TITLE
fix(dropdown): remove searchterm if nothing matches & opts are disabled

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1082,6 +1082,8 @@ $.fn.dropdown = function(parameters) {
                 if(!itemActivated && !pageLostFocus) {
                   if(settings.forceSelection) {
                     module.forceSelection();
+                  } else if(!settings.allowAdditions){
+                    module.remove.searchTerm();
                   }
                   module.hide();
                 }


### PR DESCRIPTION
## Description
Whenever a `search dropdown` having `forceSelection:false` gets a value which does not match one of the dropdown menu items, the search term stays visible when blurring the search input field.

I think, this is fine only when such value is supposed to be added and thus used as current value when `allowAddition:true` is set.

To avoid confusion and also because the behavior `get value` won't return the unmatching searchterm anyway when `allowAdditions:false` (which is default), i removed the searchterm in case the search field is blurred then.

## Testcase
Enter anything into the dropdown field which does not match the menu items
http://jsfiddle.net/15py2t7a/

```javascript
// Should keep the searchtearm visible (it's used as current value)
$('.ui.dropdown').dropdown({
  forceSelection : false,
  allowAdditions: true
});

// Should remove the searchtearm if nothing matches
$('.ui.dropdown').dropdown({
  forceSelection : false,
  allowAdditions: false
});
```

## Closes
#992
