### PR TITLE
fix(calendar): cross browser support for dateparsing using dots

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -1277,7 +1277,7 @@ $.fn.calendar.settings = {
         return null;
       }
       // Reverse date and month in some cases
-      text = settings.monthFirst ? text : text.replace(/([0-9]+)[\/\-\.]([0-9]+)/,'$2/$1');
+      text = settings.monthFirst ? text : text.replace(/[\/\-\.]/g,'/').replace(/([0-9]+)\/([0-9]+)/,'$2/$1');
       var textDate = new Date(text);
       if(!isNaN(textDate.getDate())) {
         return textDate;


### PR DESCRIPTION
## Description
This PR makes #995 crossbrowser compatible. The usage of dot was handled differently in javascript engines <> chrome/webkit based.
The replace itself was ok. But the following Date Object creation was handled differently.
To satisfy any browser i now replaced any given `/` or `-` or `.` by an /  so the `Date()` Object creation does never see anything else than a / and works identically everywhere now

## Testcase
https://jsfiddle.net/9caf67pv/

## Closes
#829 
#986 
#995