### PR TITLE
[Rating] Fix unworking `fireOnInit`

### DIFF
--- a/src/definitions/modules/rating.js
+++ b/src/definitions/modules/rating.js
@@ -57,7 +57,6 @@ $.fn.rating = function(parameters) {
         $module         = $(this),
         $icon           = $module.find(selector.icon),
 
-        initialLoad,
         module
       ;
 
@@ -76,9 +75,7 @@ $.fn.rating = function(parameters) {
           else {
             module.disable();
           }
-          module.set.initialLoad();
           module.set.rating( module.get.initialRating() );
-          module.remove.initialLoad();
           module.instantiate();
         },
 
@@ -183,9 +180,6 @@ $.fn.rating = function(parameters) {
             $module
               .off(eventNamespace)
             ;
-          },
-          initialLoad: function() {
-            initialLoad = false;
           }
         },
 
@@ -206,9 +200,6 @@ $.fn.rating = function(parameters) {
         },
 
         is: {
-          initialLoad: function() {
-            return initialLoad;
-          },
           disabled: function() {
             return $module.hasClass(className.disabled);
           }
@@ -268,12 +259,9 @@ $.fn.rating = function(parameters) {
                   .addClass(className.active)
               ;
             }
-            if(!module.is.initialLoad()) {
+            if(settings.fireOnInit) {
               settings.onRate.call(element, rating);
             }
-          },
-          initialLoad: function() {
-            initialLoad = true;
           }
         },
 


### PR DESCRIPTION
# Description
Following @GammaGames's comment on #1000, i found out that `fireOnInit` parameter didn't work (ever ?). So here's a fix.

I could have done it like this :
```js
if(!module.is.initialLoad() || settings.fireOnInit) {
  settings.onRate.call(element, rating);
}
```
But all the `initialLoad` logic is actually useless, so why not clean the code instead !

## Testcase
Before: [JSFiddle](https://jsfiddle.net/s04wc895/)
After: [JSFiddle](https://jsfiddle.net/wmkcarj2/)
