### PR TITLE
fix(modal): vertical alignment on detachable modal was incorrect

### DIFF
--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -806,17 +806,13 @@ $.fn.modal = function(parameters) {
             }
           },
           modalOffset: function() {
-            var
-              width = module.cache.width,
-              height = module.cache.height
-            ;
             $module
               .css({
-                marginTop: (!$module.hasClass('aligned') && module.can.fit())
-                  ? -(height / 2)
-                  : 0,
-                marginLeft: -(width / 2)
-              })
+                top: (!$module.hasClass('aligned') && module.can.fit())
+                  ? parseInt(($(window).height() / 2) + $(document).scrollTop() - ($module.height() - settings.padding))
+                  : $(document).scrollTop() + (settings.padding / 2),
+                marginLeft: -(module.cache.width / 2)
+              }) 
             ;
             module.verbose('Setting modal offset for legacy mode');
           },

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -694,10 +694,7 @@ $.fn.modal = function(parameters) {
 
         can: {
           useFlex: function() {
-            return (settings.useFlex == 'auto')
-              ? settings.detachable && !module.is.ie()
-              : settings.useFlex
-            ;
+            return settings.useFlex && settings.detachable && !module.is.ie();
           },
           fit: function() {
             var
@@ -806,14 +803,25 @@ $.fn.modal = function(parameters) {
             }
           },
           modalOffset: function() {
-            $module
-              .css({
-                top: (!$module.hasClass('aligned') && module.can.fit())
-                  ? parseInt(($(window).height() / 2) + $(document).scrollTop() - ($module.height() - settings.padding))
-                  : $(document).scrollTop() + (settings.padding / 2),
-                marginLeft: -(module.cache.width / 2)
-              }) 
-            ;
+            if (!settings.detachable) {
+              $module
+                .css({
+                  top: (!$module.hasClass('aligned') && module.can.fit())
+                    ? parseInt(($(window).height() / 2) + $(document).scrollTop() - ($module.height() - settings.padding))
+                    : $(document).scrollTop() + (settings.padding / 2),
+                  marginLeft: -(module.cache.width / 2)
+                }) 
+              ;
+            } else {
+              $module
+                .css({
+                  marginTop: (!$module.hasClass('aligned') && module.can.fit())
+                    ? -(module.cache.height / 2)
+                    : 0,
+                  marginLeft: -(module.cache.width / 2)
+                }) 
+              ;
+            }
             module.verbose('Setting modal offset for legacy mode');
           },
           screenHeight: function() {


### PR DESCRIPTION
## Description
First, i'm not sure this is the best solution, but it seems to fix the problem.
Second, this needs to be heavily tested, so don't approve it until you've tested many cases, please.

When modal is not detachable, it use the legacy display system, not flex based. So it calculates the position of the modal based on his window position, then apply a margin to center it. It works, when you don't have scrolled...

For me, the margin trick is not the best solution, so i tried to center the modal by calculating the top property instead (hope what I write is understandable), but with including the scroll position.

This is not a breaking change, but regarding the nature of the bug I think that we need to be careful with this PR.

Et voilà !

## Testcase
Before: [JSFiddle](http://jsfiddle.net/7j38xdbw/1/)
After: [JSFiddle](http://jsfiddle.net/dgzLjxwv/)

## Closes
#1009 
#717
