### PR TITLE
fix(tab): do not auto activate tabs more than once

### DIFF
--- a/src/definitions/modules/tab.js
+++ b/src/definitions/modules/tab.js
@@ -100,7 +100,7 @@ $.fn.tab = function(parameters) {
             initializedHistory = true;
           }
 
-          if(module.determine.activeTab() == null) {
+          if(instance === undefined && module.determine.activeTab() == null) {
             module.debug('No active tab detected, setting first tab active', module.get.initialPath());
             module.changeTab(module.get.initialPath());
           };


### PR DESCRIPTION
## Description
My previous PR #977 introduced auto activation for no specified tab. Except that each time you call the `.tab()` method for one of thoses tabs, it checks again and change the active one...

This fix just consist of checking if tabs were initializes before, so it doesn't have to recheck again...

## Testcase
[JSFiddle](https://jsfiddle.net/spj408zw/)
[JSFiddle (Fixed)](https://jsfiddle.net/bw89drqL/)

## Closes
#1014
