### PR TITLE
feat(table): add colored left & right row border

### DIFF
--- a/src/definitions/collections/table.less
+++ b/src/definitions/collections/table.less
@@ -141,9 +141,6 @@
   padding: @cellVerticalPadding @cellHorizontalPadding;
   text-align: @cellTextAlign;
 }
-.ui.table tr.left > :first-child {
-  padding-left: @cellHorizontalPadding - @coloredBorderSize;
-}
 
 /* Icons */
 .ui.table > .icon {
@@ -194,10 +191,10 @@
   .ui.table:not(.unstackable) > tfoot {
     display: @responsiveFooterDisplay;
   }
-  .ui.table:not(.unstackable) > tr,
-  .ui.table:not(.unstackable) > thead > tr,
-  .ui.table:not(.unstackable) > tbody > tr,
-  .ui.table:not(.unstackable) > tfoot > tr {
+  .ui.ui.ui.ui.table:not(.unstackable) > tr,
+  .ui.ui.ui.ui.table:not(.unstackable) > thead > tr,
+  .ui.ui.ui.ui.table:not(.unstackable) > tbody > tr,
+  .ui.ui.ui.ui.table:not(.unstackable) > tfoot > tr {
     padding-top: @responsiveRowVerticalPadding;
     padding-bottom: @responsiveRowVerticalPadding;
     box-shadow: @responsiveRowBoxShadow;
@@ -227,6 +224,27 @@
   .ui.definition.table:not(.unstackable) > thead > tr > th:first-child {
     box-shadow: none !important;
   }
+  each(@colors, {
+    @color: replace(@key, '@', '');
+    @c: @colors[@@color][color];
+    @l: @colors[@@color][light];
+    .ui.ui.ui.ui.table:not(.unstackable) tr.marked.@{color} {
+      &.left {
+        box-shadow: @responsiveRowBoxShadow, @coloredBorderSize 0 0 0 @c inset;
+      }
+      &.right {
+        box-shadow: @responsiveRowBoxShadow, -@coloredBorderSize 0 0 0 @c inset;
+      }
+    }
+    .ui.ui.ui.ui.inverted.table:not(.unstackable) tr.marked.@{color} {
+      &.left {
+        box-shadow: @responsiveRowBoxShadow, @coloredBorderSize 0 0 0 @l inset;
+      }
+      &.right {
+        box-shadow: @responsiveRowBoxShadow, -@coloredBorderSize 0 0 0 @l inset;
+      }
+    }
+  })
 }
 
 
@@ -437,10 +455,10 @@
   .ui[class*="tablet stackable"].table > tfoot {
     display: @responsiveFooterDisplay;
   }
-  .ui[class*="tablet stackable"].table > thead > tr,
-  .ui[class*="tablet stackable"].table > tbody > tr,
-  .ui[class*="tablet stackable"].table > tfoot > tr,
-  .ui[class*="tablet stackable"].table > tr {
+  .ui.ui.ui.ui[class*="tablet stackable"].table > thead > tr,
+  .ui.ui.ui.ui[class*="tablet stackable"].table > tbody > tr,
+  .ui.ui.ui.ui[class*="tablet stackable"].table > tfoot > tr,
+  .ui.ui.ui.ui[class*="tablet stackable"].table > tr {
     padding-top: @responsiveRowVerticalPadding;
     padding-bottom: @responsiveRowVerticalPadding;
     box-shadow: @responsiveRowBoxShadow;
@@ -461,6 +479,27 @@
   .ui.definition[class*="tablet stackable"].table > thead > tr > th:first-child {
     box-shadow: none !important;
   }
+  each(@colors, {
+    @color: replace(@key, '@', '');
+    @c: @colors[@@color][color];
+    @l: @colors[@@color][light];
+    .ui.ui.ui.ui[class*="tablet stackable"].table tr.marked.@{color} {
+      &.left {
+        box-shadow: @responsiveRowBoxShadow, @coloredBorderSize 0 0 0 @c inset;
+      }
+      &.right {
+        box-shadow: @responsiveRowBoxShadow, -@coloredBorderSize 0 0 0 @c inset;
+      }
+    }
+    .ui.ui.ui.ui[class*="tablet stackable"].inverted.table tr.marked.@{color} {
+      &.left {
+        box-shadow: @responsiveRowBoxShadow, @coloredBorderSize 0 0 0 @l inset;
+      }
+      &.right {
+        box-shadow: @responsiveRowBoxShadow, -@coloredBorderSize 0 0 0 @l inset;
+      }
+    }
+  })
 }
 
 /*--------------
@@ -686,9 +725,11 @@ each(@colors, {
     background-color: @c;
     color: @white;
   }
-  .ui.ui.ui.ui.table tr.@{color}:not(.left),
+  .ui.ui.ui.ui.table tr.@{color}:not(.marked),
   .ui.ui.table td.@{color} {
-    box-shadow: @stateMarkerWidth 0 0 @r inset;
+    & when (@stateMarkerWidth > 0) {
+      box-shadow: @stateMarkerWidth 0 0 @r inset;
+    }
     & when (@isDark) {
       background: @l;
     }
@@ -702,7 +743,7 @@ each(@colors, {
       color: @t;
     }
   }
-  .ui.ui.selectable.table tr.@{color}:not(.left):hover,
+  .ui.ui.selectable.table tr.@{color}:not(.marked):hover,
   .ui.table tr td.selectable.@{color}:hover,
   .ui.selectable.table tr:hover td.@{color} {
     & when (@isDark) {
@@ -718,11 +759,21 @@ each(@colors, {
       color: @ht;
     }
   }
-  .ui.table tr.left.@{color} :first-child {
-    border-left: @coloredBorderSize solid @c;
+  .ui.table tr.marked.@{color} {
+    &.left {
+      box-shadow: @coloredBorderSize 0 0 0 @c inset;
+    }
+    &.right {
+      box-shadow: -@coloredBorderSize 0 0 0 @c inset;
+    }
   }
-  .ui.inverted.table tr.left.@{color} :first-child {
-    border-left: @coloredBorderSize solid @l;
+  .ui.inverted.table tr.marked.@{color} {
+    &.left {
+      box-shadow: @coloredBorderSize 0 0 0 @l inset;
+    }
+    &.right {
+      box-shadow: -@coloredBorderSize 0 0 0 @l inset;
+    }
   }
 
 })
@@ -1086,9 +1137,6 @@ each(@colors, {
 .ui.padded.table > tbody > tr > td {
   padding: @paddedVerticalPadding @paddedHorizontalPadding;
 }
-.ui.padded.table tr.left > :first-child {
-  padding-left: @paddedHorizontalPadding - @coloredBorderSize;
-}
 
 /* Very */
 .ui[class*="very padded"].table > tr > th,
@@ -1101,9 +1149,6 @@ each(@colors, {
 .ui[class*="very padded"].table > tr > td,
 .ui[class*="very padded"].table > tbody > tr > td {
   padding: @veryPaddedVerticalPadding @veryPaddedHorizontalPadding;
-}
-.ui[class*="very padded"].table tr.left > :first-child {
-  padding-left: @veryPaddedHorizontalPadding - @coloredBorderSize;
 }
 
 /*--------------
@@ -1121,9 +1166,6 @@ each(@colors, {
 .ui.compact.table > tbody > tr > td {
   padding: @compactVerticalPadding @compactHorizontalPadding;
 }
-.ui.compact.table tr.left > :first-child {
-  padding-left: @compactHorizontalPadding - @coloredBorderSize;
-}
 
 /* Very */
 .ui[class*="very compact"].table > tr > th,
@@ -1136,9 +1178,6 @@ each(@colors, {
 .ui[class*="very compact"].table > tr > td,
 .ui[class*="very compact"].table > tbody > tr > td {
   padding: @veryCompactVerticalPadding @veryCompactHorizontalPadding;
-}
-.ui[class*="very compact"].table tr.left > :first-child {
-  padding-left: @veryCompactHorizontalPadding - @coloredBorderSize;
 }
 
 /*--------------

--- a/src/definitions/collections/table.less
+++ b/src/definitions/collections/table.less
@@ -141,6 +141,9 @@
   padding: @cellVerticalPadding @cellHorizontalPadding;
   text-align: @cellTextAlign;
 }
+.ui.table tr.left > :first-child {
+  padding-left: @cellHorizontalPadding - @coloredBorderSize;
+}
 
 /* Icons */
 .ui.table > .icon {
@@ -683,7 +686,7 @@ each(@colors, {
     background-color: @c;
     color: @white;
   }
-  .ui.ui.ui.ui.table tr.@{color},
+  .ui.ui.ui.ui.table tr.@{color}:not(.left),
   .ui.ui.table td.@{color} {
     box-shadow: @stateMarkerWidth 0 0 @r inset;
     & when (@isDark) {
@@ -699,7 +702,7 @@ each(@colors, {
       color: @t;
     }
   }
-  .ui.ui.selectable.table tr.@{color}:hover,
+  .ui.ui.selectable.table tr.@{color}:not(.left):hover,
   .ui.table tr td.selectable.@{color}:hover,
   .ui.selectable.table tr:hover td.@{color} {
     & when (@isDark) {
@@ -715,6 +718,13 @@ each(@colors, {
       color: @ht;
     }
   }
+  .ui.table tr.left.@{color} :first-child {
+    border-left: @coloredBorderSize solid @c;
+  }
+  .ui.inverted.table tr.left.@{color} :first-child {
+    border-left: @coloredBorderSize solid @l;
+  }
+
 })
 
 /*--------------
@@ -1076,6 +1086,9 @@ each(@colors, {
 .ui.padded.table > tbody > tr > td {
   padding: @paddedVerticalPadding @paddedHorizontalPadding;
 }
+.ui.padded.table tr.left > :first-child {
+  padding-left: @paddedHorizontalPadding - @coloredBorderSize;
+}
 
 /* Very */
 .ui[class*="very padded"].table > tr > th,
@@ -1088,6 +1101,9 @@ each(@colors, {
 .ui[class*="very padded"].table > tr > td,
 .ui[class*="very padded"].table > tbody > tr > td {
   padding: @veryPaddedVerticalPadding @veryPaddedHorizontalPadding;
+}
+.ui[class*="very padded"].table tr.left > :first-child {
+  padding-left: @veryPaddedHorizontalPadding - @coloredBorderSize;
 }
 
 /*--------------
@@ -1105,6 +1121,9 @@ each(@colors, {
 .ui.compact.table > tbody > tr > td {
   padding: @compactVerticalPadding @compactHorizontalPadding;
 }
+.ui.compact.table tr.left > :first-child {
+  padding-left: @compactHorizontalPadding - @coloredBorderSize;
+}
 
 /* Very */
 .ui[class*="very compact"].table > tr > th,
@@ -1117,6 +1136,9 @@ each(@colors, {
 .ui[class*="very compact"].table > tr > td,
 .ui[class*="very compact"].table > tbody > tr > td {
   padding: @veryCompactVerticalPadding @veryCompactHorizontalPadding;
+}
+.ui[class*="very compact"].table tr.left > :first-child {
+  padding-left: @veryCompactHorizontalPadding - @coloredBorderSize;
 }
 
 /*--------------

--- a/src/themes/default/collections/table.variables
+++ b/src/themes/default/collections/table.variables
@@ -70,7 +70,7 @@
 @responsiveHeaderDisplay: block;
 @responsiveFooterDisplay: block;
 @responsiveRowVerticalPadding: 1em;
-@responsiveRowBoxShadow: 0 -1px 0 0 rgba(0, 0, 0, 0.1) inset !important;
+@responsiveRowBoxShadow: 0 -1px 0 0 rgba(0, 0, 0, 0.1) inset;
 @responsiveCellVerticalPadding: 0.25em;
 @responsiveCellHorizontalPadding: 0.75em;
 @responsiveCellBoxShadow: none !important;


### PR DESCRIPTION
## Description
This PR adds optional `left marked` or `right marked` to  table row `tr`.
This way a colored table row can be displayed with a small border bar instead of the whole row background

## Testcase
https://jsfiddle.net/j0x1cfqo/8/

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/66004286-ba22eb00-e4a8-11e9-94cd-4b761bddb883.png)

## Closes
#1030 