### PR TITLE
feat(dropdown): optional skip focus when calling 'show' behavior

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -484,7 +484,7 @@ $.fn.dropdown = function(parameters) {
           }
         },
 
-        show: function(callback) {
+        show: function(callback, preventFocus) {
           callback = $.isFunction(callback)
             ? callback
             : function(){}
@@ -506,7 +506,7 @@ $.fn.dropdown = function(parameters) {
                 if( module.can.click() ) {
                   module.bind.intent();
                 }
-                if(module.has.search()) {
+                if(module.has.search() && !preventFocus) {
                   module.focusSearch();
                 }
                 module.set.visible();


### PR DESCRIPTION
## Description
This PR adds the possibility to provide a second parameter `preventFocus` to the `show` behavior method.
That second parameter controls if a search dropdown should be _prevented_ to be focussed on open 
(default false/undefined to stay backward compatible)
This might be useful to prevent 

## Usage
As the `show`  method already got an optional `callback` parameter, you have to provide at least `null` (if no real callback is necessary) as a first parameter, before providing `true` as the second parameter for the focus prevention.

```javascript
$('.ui.dropdown').dropdown('show',null,true);
```

## Testcase
Click the second button, it will open the bottom right dropdown and...

#### Before
... scrolls to it because search field is getting focused
https://jsfiddle.net/ad1h8u03/

#### After
... does not scroll
https://jsfiddle.net/ragfLzky/

## Closes
#1040 
