### PR TITLE
[Checkbox] Fix gap in form fields

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -47,14 +47,17 @@
   margin: @fieldMargin;
 }
 
-.ui.form .field:last-child,
-.ui.form .fields:last-child .field {
+.ui.form .field:last-child {
   margin-bottom: 0;
 }
 
 .ui.form .fields .field {
   clear: both;
   margin: 0;
+}
+
+.ui.form .fields .field {
+  margin-bottom: 14px;
 }
 
 
@@ -167,13 +170,13 @@
 .ui.form .fields:not(.grouped):not(.inline) .field:not(:only-child) label + .ui.ui.checkbox {
   margin-top: @checkboxLabelFieldTopMargin;
 }
-.ui.form .fields:not(.grouped):not(.inline) .field:not(:only-child) .ui.checkbox {
+.ui.form .fields:not(.grouped):not(.inline) > .field:not(:only-child) > .ui.checkbox {
   margin-top: @inputLineHeight + @checkboxFieldTopMargin;
 }
-.ui.form .fields:not(.grouped):not(.inline) .field:not(:only-child) .ui.toggle.checkbox {
+.ui.form .fields:not(.grouped):not(.inline) > .field:not(:only-child) > .ui.toggle.checkbox {
   margin-top: @inputLineHeight + @checkboxToggleFieldTopMargin;
 }
-.ui.form .fields:not(.grouped):not(.inline) .field:not(:only-child) .ui.slider.checkbox {
+.ui.form .fields:not(.grouped):not(.inline) > .field:not(:only-child) > .ui.slider.checkbox {
   margin-top: @inputLineHeight + @checkboxSliderFieldTopMargin;
 }
 .ui.ui.form .field .fields .field:not(:only-child) .ui.checkbox {


### PR DESCRIPTION
## Description

This PR resolves a big gap that was inside `.field` `divs` due to `form.less` styling on last items from `.fields`, removing the line for the last child of `.fields`,  adding more precedence on the selectors for `.ui.[class].checkbox` and adding a `margin-bottom` of `14px` to the `.field` inside a `.ui.form` resolves the issue with the examples attached below:

## JS Fiddles

- [Way too separated](https://jsfiddle.net/yfesupjh/2/)
- [Too close](https://jsfiddle.net/jneLo378/1/)

## Before

![image](https://user-images.githubusercontent.com/4975574/66075477-b4211e80-e529-11e9-946f-2c884263359c.png)

## After

![image](https://user-images.githubusercontent.com/4975574/66075522-cd29cf80-e529-11e9-986c-919acf6553d5.png)

Much better spacing.

## Closes

https://github.com/fomantic/Fomantic-UI/issues/834

### Original

Credits and shout out to @ko2in for coming with the JSFiddle to resolve this 🚀 
