### PR TITLE
fix(calendar): prevent toggle range class at today button

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -416,6 +416,10 @@ $.fn.calendar = function(parameters) {
                 ((!!startDate && module.helper.isDateInRange(cellDate, mode, startDate, rangeDate)) ||
                 (!!endDate && module.helper.isDateInRange(cellDate, mode, rangeDate, endDate)));
               cell.toggleClass(className.focusCell, focused && (!isTouch || isTouchDown) && (!adjacent || (settings.selectAdjacentDays && adjacent)) && !disabled);
+
+              if (module.helper.isTodayButton(cell)) {
+                return;
+              }
               cell.toggleClass(className.rangeCell, inRange && !active && !disabled);
             });
           }
@@ -950,6 +954,9 @@ $.fn.calendar = function(parameters) {
           mergeDateTime: function (date, time) {
             return (!date || !time) ? time :
               new Date(date.getFullYear(), date.getMonth(), date.getDate(), time.getHours(), time.getMinutes());
+          },
+          isTodayButton: function(element) {
+            return element.text() === settings.text.today;
           }
         },
 


### PR DESCRIPTION
<!--
  Please read the contibuting guide before you submit a pull request
  https://github.com/fomantic/Fomantic-UI/blob/master/CONTRIBUTING.md
-->

## Description

As reported in #901 that today button is also affected when select the end date because it's toggle when that's in range or not.

So I created helper `isTodayButton`, that check text inside the cell if that same with `settings.text.today`. If return true then don't toggle the range class.

## Testcase
### Before
https://jsfiddle.net/t7f50Lk8/

### After
https://jsfiddle.net/t7f50Lk8/1/

## Screenshot
### Before
![before](https://i.ibb.co/z43kT0m/before.gif)

### After
![after](https://i.ibb.co/sFpKp1Y/after.gif)

## Closes
#901 