### PR TITLE
feat(form): accept 1 in addition to true as checked value for checkboxes

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1053,7 +1053,7 @@ $.fn.form = function(parameters) {
                 }
                 else if(isCheckbox) {
                   module.verbose('Setting checkbox value', value, $element);
-                  if(value === true) {
+                  if(value === true || value === 1) {
                     $element.checkbox('check');
                   }
                   else {


### PR DESCRIPTION
## Description
When using the behavior `set value` or `set values`, checkbox elements were only supporting a real boolean `true` to check any checkbox.
This PR additionally supports the integer value `1` to have a checkbox checked now.

## Testcase
#### Not working
https://jsfiddle.net/6eL31k90

#### Working
https://jsfiddle.net/6eL31k90/1/

## Closes
#987 
