### PR TITLE
fix(form): trigger correct dirty handlers to fix function of checkboxes

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -168,7 +168,7 @@ $.fn.form = function(parameters) {
           }
 
           $field.on('change click keyup keydown blur', function(e) {
-            $(this).trigger(e.type + ".dirty");
+            $(this).triggerHandler(e.type + ".dirty");
           });
 
           $field.on('change.dirty click.dirty keyup.dirty keydown.dirty blur.dirty', module.determine.isDirty);


### PR DESCRIPTION
## Description
Wow, that one was quite hard to find out... 

This PR fixes a behavior when non JS initialized components were used in forms. Especially checkboxes were affected.
The dirty-events were triggered on appropriate `change click keyup keydown blur` events.
By using jQuery's `.trigger()` method it was not only triggering the wanted `.dirty` events, but also any existing behavior having the same name. Unfortunately it exists jquery's `.click` method, which was now also called whenever a raw (non JS initialized) component like checkbox was clicked. 
This resulted in un-clicking the checkbox immediatly when it was clicked. Thus clicking on it had no effect.
Whenever a form component already was initialized by JS before, this was not happening, because there the click-event was explicitely handled in the appropriate module...

The final fix was to use jquery's `.triggerHandler()` instead, which makes sure only the events are called and same-named bahaviors are ignored.

## Testcase
- Try to click on the checkbox itself (not the label, although even the label is not working at least in firefox)

#### Broken
Checkbox does not change
https://jsfiddle.net/t3dcnqjL

#### Fixed
Checkbox and label works as expected
https://jsfiddle.net/t3dcnqjL/1/

## Closes
#1053 
