### PR TITLE
chore(templates): add labels to new issue to reduce triage effort

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: 🐛 Bug Report
 about: When something isn't working correctly
-
+labels: ":mag_right: needs investigating"
 ---
 
 # Bug Report

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: 🚀 Feature Request
 about: Suggest a new feature
-
+labels: ":zap: enhancement"
 ---
 
 # Feature Request

--- a/.github/ISSUE_TEMPLATE/Help_wanted.md
+++ b/.github/ISSUE_TEMPLATE/Help_wanted.md
@@ -1,6 +1,7 @@
 ---
 name: 📓 Support Question
 about: If you have a question or need a helping hand
+labels: ":thought_balloon: usage question"
 ---
 
 # Help Wanted


### PR DESCRIPTION
## Description

Added `labels` property to GitHub issue template, so new issues are labeled automatically.
This may reduce triaging effort from maintainers.

<del>For "Bug Report" template, no label are automatially added.
Because I think an existing label ":bug: Confirmed Bug" should be manually added.
(Maybe we change our workflow to automate "bug" labeling?)</del>


TIPS) It also allow attaching multiple labels in a form of comma-separated `labels: "labelA, labelB"`.

## Testcase

You may try new template from:

* https://github.com/fomantic/Fomantic-UI/issues/new?template=Feature_request.md&labels=:zap:%20enhancement
* https://github.com/fomantic/Fomantic-UI/issues/new?template=Help_wanted.md&labels=:thought_balloon:%20usage%20question
* https://github.com/fomantic/Fomantic-UI/issues/new?template=Bug_report.md&labels=:mag_right:%20needs%20investigating
