### PR TITLE
feat(progress): made setting to 100% optional when set error/warning

### DIFF
--- a/src/definitions/modules/progress.js
+++ b/src/definitions/modules/progress.js
@@ -151,10 +151,12 @@ $.fn.progress = function(parameters) {
           module.update.progress(0);
         },
 
-        complete: function() {
+        complete: function(keepState) {
           if(module.percent === undefined || module.percent < 100) {
             module.remove.progressPoll();
-            module.set.percent(100);
+            if(keepState !== true){
+                module.set.percent(100);
+            }
           }
         },
 
@@ -647,14 +649,14 @@ $.fn.progress = function(parameters) {
               settings.onActive.call(element, module.value, module.total);
             });
           },
-          success : function(text) {
+          success : function(text, keepState) {
             text = text || settings.text.success || settings.text.active;
             module.debug('Setting success state');
             $module.addClass(className.success);
             module.remove.active();
             module.remove.warning();
             module.remove.error();
-            module.complete();
+            module.complete(keepState);
             if(settings.text.success) {
               text = settings.onLabelUpdate('success', text, module.value, module.total);
               module.set.label(text);
@@ -667,14 +669,14 @@ $.fn.progress = function(parameters) {
               settings.onSuccess.call(element, module.total);
             });
           },
-          warning : function(text) {
+          warning : function(text, keepState) {
             text = text || settings.text.warning;
             module.debug('Setting warning state');
             $module.addClass(className.warning);
             module.remove.active();
             module.remove.success();
             module.remove.error();
-            module.complete();
+            module.complete(keepState);
             text = settings.onLabelUpdate('warning', text, module.value, module.total);
             if(text) {
               module.set.label(text);
@@ -683,14 +685,14 @@ $.fn.progress = function(parameters) {
               settings.onWarning.call(element, module.value, module.total);
             });
           },
-          error : function(text) {
+          error : function(text, keepState) {
             text = text || settings.text.error;
             module.debug('Setting error state');
             $module.addClass(className.error);
             module.remove.active();
             module.remove.success();
             module.remove.warning();
-            module.complete();
+            module.complete(keepState);
             text = settings.onLabelUpdate('error', text, module.value, module.total);
             if(text) {
               module.set.label(text);


### PR DESCRIPTION
## Description
When using any of the following behaviors, the progress bar is always set to 100%.

- `set error`
- `set warning`
- `set success`

In some cases it might be a desired feature to keep the state instead
This PR adds support for another parameter `keepState` to those behavior calls to make this possible. If the parameter is omitted (as in all existing applications) the progressbar is still working as before for backward compatibility.

```javascript
//as before: will set to 100%
$(.ui.progess).progress('set error');
$(.ui.progess).progress('set error','oups');

//stay at the current percentage state
$(.ui.progess).progress('set error','oups',true);
$(.ui.progess).progress('set error',null,true); //null, if label should not be changed
```

## Testcase
https://jsfiddle.net/d3wc8p5m/

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/66494273-adf5e980-eab7-11e9-8a91-4c078f0f5ece.png)

