### PR TITLE
[Slider] preventCrossover setting for range sliders

### DIFF
--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -658,6 +658,9 @@ $.fn.slider = function(parameters) {
               secondThumbPos = parseFloat(module.determine.thumbPos($secondThumb)),
               secondThumbDelta = Math.abs(eventPos - secondThumbPos)
             ;
+            if(thumbDelta === secondThumbDelta && module.get.thumbValue() === module.get.min()) {
+              return $secondThumb;
+            }
             return thumbDelta <= secondThumbDelta ? $thumb : $secondThumb;
           },
           closestThumbPos: function(eventPos) {

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -336,8 +336,16 @@ $.fn.slider = function(parameters) {
                 thumbSmoothVal = module.determine.smoothValueFromEvent(event, originalEvent)
               ;
               if(!$currThumb.hasClass('second')) {
+                if(settings.preventCrossover) {
+                  value = Math.min(secondThumbVal, value);
+                  thumbSmoothVal = Math.min(secondThumbVal, thumbSmoothVal);
+                }
                 thumbVal = value;
               } else {
+                if(settings.preventCrossover) {
+                  value = Math.max(thumbVal, value);
+                  thumbSmoothVal = Math.max(thumbVal, thumbSmoothVal);
+                }
                 secondThumbVal = value;
               }
               value = Math.abs(thumbVal - (secondThumbVal || 0));
@@ -885,8 +893,14 @@ $.fn.slider = function(parameters) {
               module.thumbVal = value;
             } else {
               if(!$currThumb.hasClass('second')) {
+                if(settings.preventCrossover) {
+                  newValue = Math.min(module.secondThumbVal, newValue);
+                }
                 module.thumbVal = newValue;
               } else {
+                if(settings.preventCrossover) {
+                  newValue = Math.max(module.thumbVal, newValue);
+                }
                 module.secondThumbVal = newValue;
               }
               value = Math.abs(module.thumbVal - module.secondThumbVal);
@@ -1222,6 +1236,7 @@ $.fn.slider.settings = {
   smooth           : false,
   autoAdjustLabels : true,
   labelDistance    : 100,
+  preventCrossover : true,
 
   //the decimal place to round to if step is undefined
   decimalPlaces  : 2,


### PR DESCRIPTION
## Description
Adds a new setting called `preventCrossover` which prevents the lower thumb to crossover the upper thumb.

This is set to `true` by default, making this a breaking change.

Does not prevent calling `$("#slider").slider("set rangeValue", 50, 25);`

## Testcase
https://jsfiddle.net/nb4x7ukm/2/

## Screenshot (when possible)
![Peek 2019-10-10 10-40](https://user-images.githubusercontent.com/5517677/66552920-82700f00-eb4a-11e9-829d-23435a283c5f.gif)

## Closes
#1021