### PR TITLE
[Calendar] Popup arrow color doesn't match container background

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -137,7 +137,7 @@ $.fn.calendar = function(parameters) {
                   domPositionFunction = $activatorParent.closest(selector.append).length !== 0 ? 'appendTo' : 'prependTo';
               $container = $('<div/>').addClass(className.popup)[domPositionFunction]($activatorParent);
             }
-            $container.addClass(className.calendar);
+            $container.addClass(className.calendar).addClass(settings.type);
             var onVisible = settings.onVisible;
             var onHidden = settings.onHidden;
             if (!$input.length) {

--- a/src/definitions/modules/calendar.less
+++ b/src/definitions/modules/calendar.less
@@ -28,6 +28,10 @@
   user-select: none;
 }
 
+.ui.calendar .ui.popup:before {
+  background: @headerBackground;
+}
+
 /*******************************
             Calendar
 *******************************/
@@ -131,6 +135,11 @@
   color: @adjacentTextColor;
   background: @adjacentBackground;
 }
+
+.ui.calendar .ui.table > thead > tr > th {
+  background: @headerBackground;
+}
+
 
 /*--------------
      States

--- a/src/definitions/modules/calendar.less
+++ b/src/definitions/modules/calendar.less
@@ -28,7 +28,7 @@
   user-select: none;
 }
 
-.ui.calendar .ui.popup:before {
+.ui.calendar .ui.popup:not(.time):before {
   background: @headerBackground;
 }
 

--- a/src/themes/default/modules/calendar.variables
+++ b/src/themes/default/modules/calendar.variables
@@ -16,3 +16,5 @@
 
 @adjacentTextColor: @mutedTextColor;
 @adjacentBackground: @subtleTransparentBlack;
+
+@headerBackground: @offWhite;


### PR DESCRIPTION
## Description
Added a new header background color variable to calendar, which is used for the table header and the popup arrow. Timepicker are excluded, because they don't have a header in the popup.

## Testcase
https://jsfiddle.net/72q8Lxrw/

## Closes
#744 
