### PR TITLE
[Modal] Don't close modal when scrollbar is clicked in rtl enviroment

### DIFF
--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -34,6 +34,7 @@ $.fn.modal = function(parameters) {
 
     time           = new Date().getTime(),
     performance    = [],
+    isRtl          = $body.attr('dir') === 'rtl' || $body.css('direction') === 'rtl',
 
     query          = arguments[0],
     methodInvoked  = (typeof query == 'string'),
@@ -285,7 +286,7 @@ $.fn.modal = function(parameters) {
             if(initialMouseDownInModal) {
               module.verbose('Mouse down event registered inside the modal');
             }
-            initialMouseDownInScrollbar = module.is.scrolling() && $(window).outerWidth() - settings.scrollbarWidth <= event.clientX;
+            initialMouseDownInScrollbar = module.is.scrolling() && ((!isRtl && $(window).outerWidth() - settings.scrollbarWidth <= event.clientX) || (isRtl && settings.scrollbarWidth >= event.clientX));
             if(initialMouseDownInScrollbar) {
               module.verbose('Mouse down event registered inside the scrollbar');
             }


### PR DESCRIPTION
## Description
When body direction was set to rtl, clicking on the scrollbar closed the modal.
This was fixed in #437 , but missed to support rtl environments.

## Testcase
#### Broken
http://jsfiddle.net/vz92gfLo/

#### Fixed
http://jsfiddle.net/e59rqp8n/

## Closes
#1087 