### PR TITLE
fix(modal): make bottom margin scrolling modals work in firefox & edge

### DIFF
--- a/src/definitions/modules/modal.less
+++ b/src/definitions/modules/modal.less
@@ -401,7 +401,7 @@
   margin: @scrollingMargin auto;
 }
 /* Fix for Firefox, Edge, IE11 */
-.modals.dimmer .ui.scrolling.modal:not(.fullscreen)::after {
+.modals.dimmer .ui.scrolling.modal:not([class*="overlay fullscreen"])::after {
   content:'\00A0';
   position: absolute;
   height: @scrollingMargin;

--- a/src/definitions/modules/modal.less
+++ b/src/definitions/modules/modal.less
@@ -400,7 +400,12 @@
 .modals.dimmer .ui.scrolling.modal:not(.fullscreen) {
   margin: @scrollingMargin auto;
 }
-
+/* Fix for Firefox, Edge, IE11 */
+.modals.dimmer .ui.scrolling.modal:not(.fullscreen)::after {
+  content:'\00A0';
+  position: absolute;
+  height: @scrollingMargin;
+}
 /* Undetached Scrolling */
 .scrolling.undetached.dimmable.dimmed {
   overflow: auto;


### PR DESCRIPTION
## Description
The bottom margin of scrolling modals was only working in Chrome. Turned out that IE, Edge and Firefox were ignoring it, because the modal DOM node is moved by the modal module  to become the last node of the body. 
Fixed it by adding a pseudo element with a height (not margin, because margin was still not working there!) Also, firefox was still ignoring it unless the content value had at least one character (but space was also ignored!), so i used a non-printable, thus invisible character instead to also convince Firefox  😄 
The additional pseudo element however is swallowed by chrome (because chrome respects the given margin), so it looks the same everywhere now 🙂 

## Testcase
https://jsfiddle.net/zt0cfo6d/1/

## Closes
#1075 
