### PR TITLE
[Calendar] Support type setting as metadata and initialize through form without extra JS

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -991,12 +991,17 @@ $.fn.form = function(parameters) {
                 $parent    = $el.parent(),
                 isCheckbox = ($el.filter(selector.checkbox).length > 0),
                 isDropdown = $parent.is(selector.uiDropdown) && module.can.useElement('dropdown'),
+                $calendar   = $el.closest(selector.uiCalendar),
+                isCalendar  = ($calendar.length > 0  && module.can.useElement('calendar')),
                 value      = (isCheckbox)
                   ? $el.is(':checked')
                   : $el.val()
               ;
               if (isDropdown) {
                 $parent.dropdown('save defaults');
+              }
+              else if (isCalendar) {
+                $calendar.calendar('refresh');
               }
               $el.data(metadata.defaultValue, value);
               $el.data(metadata.isDirty, false);

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -115,6 +115,7 @@ $.fn.calendar = function(parameters) {
             if (module.get.maxDate() !== null) {
               module.set.maxDate($module.data(metadata.maxDate));
             }
+            module.setting('type', module.get.type());
           },
           popup: function () {
             if (settings.inline) {
@@ -185,17 +186,15 @@ $.fn.calendar = function(parameters) {
             }
           },
           date: function () {
+            var date;
             if (settings.initialDate) {
-              var date = parser.date(settings.initialDate, settings);
-              module.set.date(date, settings.formatInput, false);
+              date = parser.date(settings.initialDate, settings);
             } else if ($module.data(metadata.date) !== undefined) {
-              var date = parser.date($module.data(metadata.date), settings);
-              module.set.date(date, settings.formatInput, false);
+              date = parser.date($module.data(metadata.date), settings);
             } else if ($input.length) {
-              var val = $input.val();
-              var date = parser.date(val, settings);
-              module.set.date(date, settings.formatInput, false);
+              date = parser.date($input.val(), settings);
             }
+            module.set.date(date, settings.formatInput, false);
           }
         },
 
@@ -622,6 +621,9 @@ $.fn.calendar = function(parameters) {
             return settings.type === 'time' ? 'hour' :
               settings.type === 'month' ? 'month' :
                 settings.type === 'year' ? 'year' : 'day';
+          },
+          type: function() {
+            return $module.data(metadata.type) || settings.type;
           },
           validModes: function () {
             var validModes = [];
@@ -1553,6 +1555,7 @@ $.fn.calendar.settings = {
     minDate: 'minDate',
     maxDate: 'maxDate',
     mode: 'mode',
+    type: 'type',
     monthOffset: 'monthOffset',
     message: 'message',
     class: 'class'


### PR DESCRIPTION
## Description
This PR allows to define the `type` setting as metadata.
It then also supports to automatically instantiate the calendar module when inside a form.
I also micro-optimized some small codeparts

## Testcase
Only the form is initialized via JS, but not (additionally) the calendar field (its done within the form itself)
Click into the calendar field
#### Before
- Calendar is not working/opening
https://jsfiddle.net/10vyedaL

#### After
- Calendar opens and is set as 'date' only field (default of calendar would usually 'datetime' instead)
https://jsfiddle.net/10vyedaL/1/

## Usage
Defined type and initialdate via metadata instead of JS setting
```html
<div class="ui calendar" data-type="date" data-date="2019-12-24">
	<div class="ui input left icon">
		<i class="calendar icon"></i>
		<input type="text" placeholder="Date">
	</div>
</div>
```
```javascript
$('.ui.calendar').calendar();
```