### PR TITLE
fix(dropdown): prevent blur when hiding dropdown directly after search

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -278,7 +278,7 @@ $.fn.dropdown = function(parameters) {
             module.filter(query);
           }
           else {
-            module.hide();
+            module.hide(null,true);
           }
         },
 
@@ -516,7 +516,7 @@ $.fn.dropdown = function(parameters) {
           }
         },
 
-        hide: function(callback) {
+        hide: function(callback, preventBlur) {
           callback = $.isFunction(callback)
             ? callback
             : function(){}
@@ -527,7 +527,7 @@ $.fn.dropdown = function(parameters) {
               module.animate.hide(function() {
                 module.remove.visible();
                 // hidding search focus
-                if ( module.is.focusedOnSearch() ) {
+                if ( module.is.focusedOnSearch() && preventBlur !== true ) {
                   $search.blur();
                 }
                 callback.call(element);


### PR DESCRIPTION
## Description
- Create a dropdown with an API search and minCharacters set to something >1
- Enter something into the dropdown, so API search get triggered
- After a response from the server, deleting some characters from the searchfield, so they get less as defined in the `minCharacters` setting
- Menu hides but field gets blurred

## Testcase
#### Broken
http://jsfiddle.net/4tacdvLq/1/

#### Fixed
http://jsfiddle.net/4tacdvLq/2/

## Screenshot
#### Broken
![1089_bad](https://user-images.githubusercontent.com/18379884/66722656-ce53da00-ee10-11e9-93a2-60f4655f05be.gif)

#### Fixed
![1089_good](https://user-images.githubusercontent.com/18379884/66722658-d744ab80-ee10-11e9-9c47-2304cd0f2be4.gif)

## Closes
#1089 
