### PR TITLE
fix(modal): correct undetached positioning when large modal is used

### DIFF
--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -804,11 +804,14 @@ $.fn.modal = function(parameters) {
           },
           modalOffset: function() {
             if (!settings.detachable) {
+              var canFit = module.can.fit();
               $module
                 .css({
-                  top: (!$module.hasClass('aligned') && module.can.fit())
-                    ? parseInt(($(window).height() / 2) + $(document).scrollTop() - ($module.height() - settings.padding))
-                    : $(document).scrollTop() + (settings.padding / 2),
+                  top: (!$module.hasClass('aligned') && canFit)
+                    ? $(document).scrollTop() + (module.cache.contextHeight - module.cache.height) / 2
+                    : !canFit || $module.hasClass('top')
+                      ? $(document).scrollTop() + settings.padding
+                      : $(document).scrollTop() + (module.cache.contextHeight - module.cache.height - settings.padding),
                   marginLeft: -(module.cache.width / 2)
                 }) 
               ;
@@ -817,7 +820,7 @@ $.fn.modal = function(parameters) {
                 .css({
                   marginTop: (!$module.hasClass('aligned') && module.can.fit())
                     ? -(module.cache.height / 2)
-                    : 0,
+                    : settings.padding / 2,
                   marginLeft: -(module.cache.width / 2)
                 }) 
               ;

--- a/src/definitions/modules/modal.less
+++ b/src/definitions/modules/modal.less
@@ -364,18 +364,18 @@
    Aligned
 ---------------*/
 
-.ui.top.aligned.modal {
+.modals.dimmer .ui.top.aligned.modal {
   top: @topAlignedMargin;
 }
-.ui.bottom.aligned.modal {
+.modals.dimmer .ui.bottom.aligned.modal {
   bottom: @bottomAlignedMargin;
 }
 
 @media only screen and (max-width : @largestMobileScreen) {
-  .ui.top.aligned.modal {
+  .modals.dimmer .ui.top.aligned.modal {
     top: @mobileTopAlignedMargin;
   }
-  .ui.bottom.aligned.modal {
+  .modals.dimmer .ui.bottom.aligned.modal {
     bottom: @mobileBottomAlignedMargin;
   }
 }
@@ -412,7 +412,6 @@
 .scrolling.undetached.dimmable .ui.scrolling.modal:not(.fullscreen) {
   position: absolute;
   left: 50%;
-  margin-top: @scrollingMargin !important;
 }
 
 /* Scrolling Content */

--- a/src/themes/default/modules/modal.variables
+++ b/src/themes/default/modules/modal.variables
@@ -124,7 +124,7 @@
 @mobileBottomAlignedMargin: @mobileTopAlignedMargin;
 
 /* Scrolling Margin */
-@scrollingMargin: 1rem;
+@scrollingMargin: 2rem;
 @mobileScrollingMargin: @mobileTopAlignedMargin;
 
 /* Scrolling Content */


### PR DESCRIPTION
## Description
This PR enhances the fix by @prudho and corrects positioning calculation when `detachable: false` was used together with large modals.
This now works in any possible combination: detachable true/false, useFlex: true/false, top aligned, bottom aligned

## Testcase
http://jsfiddle.net/5er1f3va/2/

## Closes
#1079 
https://github.com/Semantic-Org/Semantic-UI/issues/4676

