### PR TITLE
fix(dropdown): use regular event handler for allowAdditions input blur

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -981,17 +981,12 @@ $.fn.dropdown = function(parameters) {
               : $activeItem,
             hasSelected = ($selectedItem.length > 0)
           ;
-          if(hasSelected && !module.is.multiple()) {
+          if(settings.allowAdditions || (hasSelected && !module.is.multiple())) {
             module.debug('Forcing partial selection to selected item', $selectedItem);
             module.event.item.click.call($selectedItem, {}, true);
           }
           else {
-            if(settings.allowAdditions) {
-              module.set.selected(module.get.query());
-            }
-            else {
-              module.remove.searchTerm();
-            }
+            module.remove.searchTerm();
           }
         },
 


### PR DESCRIPTION
Closes https://github.com/fomantic/Fomantic-UI/issues/997

## Description
The blur event for dropdowns that allowed additions wasn't calling the regular event handler, and it was bypassing some of the preprocessing, checks and side effects, like sanitization or flushing the values.

## Testcase
broken: https://jsfiddle.net/Lxv71m8k/
fixed: https://jsfiddle.net/cyL5r09k/

## Screenshot
### Broken
![2019-10-17 02 33 49](https://user-images.githubusercontent.com/8055505/66968730-cac98880-f086-11e9-905d-40b5b13e17d5.gif)

### Fixed
![2019-10-17 02 34 38](https://user-images.githubusercontent.com/8055505/66968745-d87f0e00-f086-11e9-8680-4bf39e971d2a.gif)

## Closes
#997 
