### PR TITLE
chore(ci): Add job to enforce commit message convention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,11 @@ jobs:
       run: npm install --ignore-scripts
     - name: pre fomantic install & gulp build
       run: npx gulp install
+  commitsar:
+    name: Verify commit messages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v1
+      - name: Run commitsar
+        uses: docker://commitsar/commitsar:0.8.0


### PR DESCRIPTION
## Description

Seeing that fomantic ui requests following the Angular git commit message convention, which is precisely what was used as base for the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/) proposal, I wanted to suggest using a CI tool for making sure that the commits follow the convention.

`commitsar` is a small go binary that does just that, I personally know and work with the developer, I don't think it matters but I just don't want to hide it. I think it could be a good and lightweight solution for https://github.com/fomantic/Fomantic-UI/issues/341