### PR TITLE
fix(popup): avoid detection of wrong existing popup

### DIFF
--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -286,18 +286,18 @@ $.fn.popup = function(parameters) {
             }
             settings.onCreate.call($popup, element);
           }
-          else if($target.next(selector.popup).length !== 0) {
-            module.verbose('Pre-existing popup found');
-            settings.inline = true;
-            settings.popup  = $target.next(selector.popup).data(metadata.activator, $module);
+          else if(settings.popup) {
+            $(settings.popup).data(metadata.activator, $module);
+            module.verbose('Used popup specified in settings');
             module.refresh();
             if(settings.hoverable) {
               module.bind.popup();
             }
           }
-          else if(settings.popup) {
-            $(settings.popup).data(metadata.activator, $module);
-            module.verbose('Used popup specified in settings');
+          else if($target.next(selector.popup).length !== 0) {
+            module.verbose('Pre-existing popup found');
+            settings.inline = true;
+            settings.popup  = $target.next(selector.popup).data(metadata.activator, $module);
             module.refresh();
             if(settings.hoverable) {
               module.bind.popup();


### PR DESCRIPTION
## Description
When a popup was defined to get its content out of an existing DOM-Node it was in some situations wrongly reused on another, totally different popup because the popup-creation  code was searching for existing nodes _before__checking for a specific domnode. That way a previously detached domnode from another  popup was used by accident.
This PR switched priorities to always check for a specific defined DOM node in `settings.popup` before looking for an existing dom node next to the popup.

## Testcase
#### Wrong Popup detection
https://jsfiddle.net/61L98vxt

#### Fixed
https://jsfiddle.net/61L98vxt/1/

## Screenshot
|Wrong|Fixed|
|-|-|
|![6331_bad](https://user-images.githubusercontent.com/18379884/67151925-d3f86680-f2cd-11e9-9d3f-1b40a0692db7.gif)|![6331_good](https://user-images.githubusercontent.com/18379884/67151926-d955b100-f2cd-11e9-8dde-dcda0b254ebe.gif)|

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6331
