### PR TITLE
fix(dropdown): parameter count resulted in wrong data for onchange

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -2908,7 +2908,7 @@ $.fn.dropdown = function(parameters) {
             else {
               settings.onAdd.call(element, addedValue, addedText, $selectedItem);
             }
-            module.set.value(newValue, addedValue, addedText, $selectedItem);
+            module.set.value(newValue, addedText, $selectedItem);
             module.check.maxSelections();
           },
         },


### PR DESCRIPTION
## Description
When in multiple selection dropdowns a value is selected, the amount of parameters provided to the `set value` method is not matching. It provides 4 values instead of 3 expected, therefore inconsistent, and because of this also in wrong order. Four parameters are never used anywhere else and not even documented:
![image](https://user-images.githubusercontent.com/18379884/67879231-e4fe6e80-fb3c-11e9-9350-3cd7fdfe2e06.png)

Providing the additional single value is not necessary because there also exists the `onAdd` event fetching that value and in multiple dropdowns its only the  value itself that counts.

## Testcase
### Wrong
https://jsfiddle.net/onp7vtwz
### Correct
https://jsfiddle.net/onp7vtwz/1/

## Screenshot
### Wrong
![parameter_count_wrong](https://user-images.githubusercontent.com/18379884/67878811-38bc8800-fb3c-11e9-8e0c-ce937ce41c58.gif)
### Correct
![parameter_count_correct](https://user-images.githubusercontent.com/18379884/67878822-3e19d280-fb3c-11e9-9329-2bc1d1149390.gif)


