### PR TITLE
[Card] Right images in horizontal cards had wrong border radius

### DIFF
--- a/src/definitions/views/card.less
+++ b/src/definitions/views/card.less
@@ -459,6 +459,10 @@
   height: 100%;
   border-radius: @defaultBorderRadius 0 0 @defaultBorderRadius;
 }
+.ui.horizontal.cards > .card > .image:last-child > img,
+.ui.card.horizontal > .image:last-child > img {
+  border-radius: 0 @defaultBorderRadius @defaultBorderRadius 0;
+}
 .ui.horizontal.cards > .card > .content, .ui.horizontal.card > .content {
   flex-basis: 1px;
 }


### PR DESCRIPTION
## Description
The border radius of an image in horizontal cards always assumes that the image is positioned to the left. If its placed to the right, the border radius was wrong.

## Testcase
https://jsfiddle.net/esk27L1m/

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/68087923-6cf4b900-fe5a-11e9-8ca5-f18a623e6bc0.png)

