### PR TITLE
[Card] Horizontal cards on mobile got cut

### DIFF
--- a/src/themes/default/views/card.variables
+++ b/src/themes/default/views/card.variables
@@ -161,7 +161,7 @@
 ;
 
 /* Horizontal */
-@horizontalMinWidth: 300px;
+@horizontalMinWidth: 270px;
 @horizontalWidth: 400px;
 @horizontalImageWidth: 150px;
 

--- a/src/themes/default/views/card.variables
+++ b/src/themes/default/views/card.variables
@@ -161,7 +161,7 @@
 ;
 
 /* Horizontal */
-@horizontalMinWidth: 400px;
+@horizontalMinWidth: 300px;
 @horizontalWidth: 400px;
 @horizontalImageWidth: 150px;
 


### PR DESCRIPTION
## Description
Horizontal cards had a too strong minimum width, so they got cut on small mobile screens

## Testcase
https://jsfiddle.net/84ga57xd/show
- Open the fiddle on mobile device or switch to mobile view in developer  tools
- Remove CSS to see the issue

## Screenshot
### Before
![image](https://user-images.githubusercontent.com/18379884/68088400-2d7c9b80-fe5f-11e9-9d05-a37117a4222a.png)

### After
![image](https://user-images.githubusercontent.com/18379884/68088390-058d3800-fe5f-11e9-9711-6f4512d213de.png)

## Closes
#828
