### PR TITLE
[Slider] Fix touch events handling when jquery 2 is used 

### DIFF
--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -317,11 +317,11 @@ $.fn.slider = function(parameters) {
         },
 
         event: {
-          down: function(event, originalEvent) {
+          down: function(event) {
             event.preventDefault();
             if(module.is.range()) {
               var
-                eventPos = module.determine.eventPos(event, originalEvent),
+                eventPos = module.determine.eventPos(event),
                 newPos = module.determine.pos(eventPos)
               ;
               // Special handling if range mode and both thumbs have the same value
@@ -336,12 +336,12 @@ $.fn.slider = function(parameters) {
               module.bind.slidingEvents();
             }
           },
-          move: function(event, originalEvent) {
+          move: function(event) {
             event.preventDefault();
-            var value = module.determine.valueFromEvent(event, originalEvent);
+            var value = module.determine.valueFromEvent(event);
             if($currThumb === undefined) {
               var
-                eventPos = module.determine.eventPos(event, originalEvent),
+                eventPos = module.determine.eventPos(event),
                 newPos = module.determine.pos(eventPos)
               ;
               $currThumb = initialPosition > newPos ? $thumb : $secondThumb;
@@ -350,7 +350,7 @@ $.fn.slider = function(parameters) {
               var
                 thumbVal = module.thumbVal,
                 secondThumbVal = module.secondThumbVal,
-                thumbSmoothVal = module.determine.smoothValueFromEvent(event, originalEvent)
+                thumbSmoothVal = module.determine.smoothValueFromEvent(event)
               ;
               if(!$currThumb.hasClass('second')) {
                 if(settings.preventCrossover) {
@@ -374,9 +374,9 @@ $.fn.slider = function(parameters) {
               });
             }
           },
-          up: function(event, originalEvent) {
+          up: function(event) {
             event.preventDefault();
-            var value = module.determine.valueFromEvent(event, originalEvent);
+            var value = module.determine.valueFromEvent(event);
             module.set.value(value);
             module.unbind.slidingEvents();
           },
@@ -723,9 +723,9 @@ $.fn.slider = function(parameters) {
             ;
             return adjustedPos;
           },
-          valueFromEvent: function(event, originalEvent) {
+          valueFromEvent: function(event) {
             var
-              eventPos = module.determine.eventPos(event, originalEvent),
+              eventPos = module.determine.eventPos(event),
               newPos = module.determine.pos(eventPos),
               value
             ;
@@ -738,12 +738,12 @@ $.fn.slider = function(parameters) {
             }
             return value;
           },
-          smoothValueFromEvent: function(event, originalEvent) {
+          smoothValueFromEvent: function(event) {
             var
               min = module.get.min(),
               max = module.get.max(),
               trackLength = module.get.trackLength(),
-              eventPos = module.determine.eventPos(event, originalEvent),
+              eventPos = module.determine.eventPos(event),
               newPos = eventPos - module.get.trackOffset(),
               ratio,
               value
@@ -756,17 +756,19 @@ $.fn.slider = function(parameters) {
             value = ratio * (max - min) + min;
             return value;
           },
-          eventPos: function(event, originalEvent) {
+          eventPos: function(event) {
             if(module.is.touch()) {
               var
-                touchY = event.changedTouches[0].pageY || event.touches[0].pageY,
-                touchX = event.changedTouches[0].pageX || event.touches[0].pageX
+                touchEvent = event.changedTouches ? event : event.originalEvent,
+                touches = touchEvent.changedTouches[0] ? touchEvent.changedTouches : touchEvent.touches,
+                touchY = touches[0].pageY,
+                touchX = touches[0].pageX
               ;
               return module.is.vertical() ? touchY : touchX;
             }
             var
-              clickY = event.pageY || originalEvent.pageY,
-              clickX = event.pageX || originalEvent.pageX
+              clickY = event.pageY || event.originalEvent.pageY,
+              clickX = event.pageX || event.originalEvent.pageX
             ;
             return module.is.vertical() ? clickY : clickX;
           },


### PR DESCRIPTION
## Description
When jquery 2 is used together with FUI the `changedTouches` or `touches` property was not attached to the event object, but still exists at the `event.originalEvent` Object.
Slider was always expecting it at the event object which results in a JS error when trying to move the slider using touch devices.
This is especially the case when trying to simulate touch devices using chrome developer tools.

I also removed the completely unused second originalEvent parameter in all event handlers , just because it is never provided by any jquery version and always undefined. instead `originalEvent` is always provided as a child of `event` itself.

Why support jquery 2? Because this might be bundled with other packages like wordpress.

## Testcase
- Open any of the below testcases in chrome
- open developer tools 
- switch to device view
- probably reload the page 
- watch console

|jquery version|testcase|result|
|-|-|-|
|jquery 2|https://jsfiddle.net/xju4Lqhe/3/|breaks|
|jquery 2+this PR fix|https://jsfiddle.net/xju4Lqhe/2/|works|
|jquery 3|https://jsfiddle.net/xju4Lqhe/4/|works|


## Screenshot
![slider_simulated_touch_bad](https://user-images.githubusercontent.com/18379884/68243920-edaae500-0013-11ea-9516-0bf9930053fa.gif)

## Closes
#1147 
