### PR TITLE
[Slider] Hidden sliders render in an endless while loop freezing the browser

### DIFF
--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -643,22 +643,23 @@ $.fn.slider = function(parameters) {
             if( settings.autoAdjustLabels ) {
               var 
                 numLabels = module.get.numLabels(),
+                trackLength = module.get.trackLength(),
                 gapCounter = 1
               ;
 
               // While the distance between two labels is too short,
               // we divide the number of labels at each iteration
               // and apply only if the modulo of the operation is an odd number.
-              while ((module.get.trackLength() / numLabels) * gapCounter < settings.labelDistance) {
-                if( !(numLabels % gapCounter) ) {
-                  gapRatio = gapCounter;
+              if(trackLength>0){
+                while ((trackLength / numLabels) * gapCounter < settings.labelDistance) {
+                  if( !(numLabels % gapCounter) ) {
+                    gapRatio = gapCounter;
+                  }
+                  gapCounter += 1;
                 }
-                gapCounter += 1;
               }
-              return gapRatio;
-            } else {
-              return 1;
             }
+            return gapRatio;
           }
         },
 


### PR DESCRIPTION
## Description
A `labeled slider` which is hidden , for example inside an accordion, and  autoadjusts its labels (default) will freeze the browser, because the calculation gets stuck in an endless loop.
Reason: the calculation uses the current tracklength, which is 0 when the slider is hidden, not letting the while loop end and get stuck forever.

## Testcase
### Broken
Beware: This will just freeze the browser and loads forever. (Use a separate browser window, which you can kill safely)
https://jsfiddle.net/dqn2sb1L/1/

### Fixed
https://jsfiddle.net/dqn2sb1L/

## Closes
#1140 
