### PR TITLE
[Task] Make sure permission value is tranformed into correct octal value for gulp chmod

### DIFF
--- a/tasks/config/defaults.js
+++ b/tasks/config/defaults.js
@@ -10,8 +10,8 @@ module.exports = {
   // base path when installed with npm
   pmRoot: 'semantic/',
 
-  // octal permission for output files, i.e. 644 (false does not adjust)
-  permission : 744,
+  // octal permission for output files, i.e. 0o644 or '644' (false does not adjust)
+  permission : '744',
 
   // whether to generate rtl files
   rtl        : false,


### PR DESCRIPTION
## Description
The permission value in the install task was set as integer, whereas gulp chmod expects an octal value.
@ColinFrick already implemented a conversion in case the value was given as string, so i just put the value in quotes 😄 

## Closes
#1153
