### PR TITLE
[List] Fix horizontal divided list first item extra padding

### DIFF
--- a/dist/components/list.css
+++ b/dist/components/list.css
@@ -754,7 +754,7 @@ ol.ui.suffixed.list li:before,
 .ui.divided.horizontal.list {
   margin-left: 0;
 }
-.ui.divided.horizontal.list > .item {
+.ui.divided.horizontal.list > .item:not(:first-child) {
   padding-left: 0.5em;
 }
 .ui.divided.horizontal.list > .item:not(:last-child) {

--- a/src/definitions/elements/list.less
+++ b/src/definitions/elements/list.less
@@ -764,7 +764,7 @@ ol.ui.suffixed.list li:before,
 .ui.divided.horizontal.list {
   margin-left: 0;
 }
-.ui.divided.horizontal.list > .item {
+.ui.divided.horizontal.list > .item:not(:first-child) {
   padding-left: @horizontalDividedSpacing;
 }
 .ui.divided.horizontal.list > .item:not(:last-child) {


### PR DESCRIPTION
## Description
Fixes horizontal divided list first item extra padding.
All the details here in bug: #1158 

## Testcase
https://jsfiddle.net/sergei_krylov/zu39pxo5/2/

## Closes
#1158 
