### PR TITLE
fix(emoji): change emoji path to use svg

### DIFF
--- a/src/themes/default/elements/emoji.variables
+++ b/src/themes/default/elements/emoji.variables
@@ -5,8 +5,8 @@
 /*--------------
     Path
 ---------------*/
-@emojiPath: "https://twemoji.maxcdn.com/v/latest/72x72/";
-@emojiFileType: "png";
+@emojiPath: "https://twemoji.maxcdn.com/v/latest/svg/";
+@emojiFileType: "svg";
 
 /*--------------
    Definition


### PR DESCRIPTION
## Description
Change the emoji path to use svg instead of png to stop pixelation when using larger sizes.

## Screenshot (when possible)
Before:
![image](https://user-images.githubusercontent.com/11588822/68805031-ed859780-065a-11ea-8592-b9469b2d8f42.png)

After:
![image](https://user-images.githubusercontent.com/11588822/68805118-1443ce00-065b-11ea-8188-3d60b7a7dd1a.png)

