### PR TITLE
fix(table): dont show background on sortable headers if table is basic

### DIFF
--- a/src/definitions/collections/table.less
+++ b/src/definitions/collections/table.less
@@ -1016,14 +1016,18 @@ each(@colors, {
     color: @sortableDisabledColor;
   }
   .ui.sortable.table > thead > tr > th:hover {
-    background: @sortableHoverBackground;
     color: @sortableHoverColor;
+  }
+  .ui.sortable.table:not(.basic) > thead > tr > th:hover {
+    background: @sortableHoverBackground;
   }
 
   /* Sorted */
   .ui.sortable.table thead th.sorted {
-    background: @sortableActiveBackground;
     color: @sortableActiveColor;
+  }
+  .ui.sortable.table:not(.basic) thead th.sorted {
+    background: @sortableActiveBackground;
   }
   .ui.sortable.table thead th.sorted:after {
     display: inline-block;
@@ -1031,20 +1035,26 @@ each(@colors, {
 
   /* Sorted Hover */
   .ui.sortable.table thead th.sorted:hover {
-    background: @sortableActiveHoverBackground;
     color: @sortableActiveHoverColor;
+  }
+  .ui.sortable.table:not(.basic) thead th.sorted:hover {
+    background: @sortableActiveHoverBackground;
   }
   & when (@variationTableInverted) {
     /* Inverted */
     .ui.inverted.sortable.table thead th.sorted {
-      background: @sortableInvertedActiveBackground;
       color: @sortableInvertedActiveColor;
     }
+    .ui.inverted.sortable.table:not(.basic) thead th.sorted {
+      background: @sortableInvertedActiveBackground;
+    }
     .ui.inverted.sortable.table > thead > tr > th:hover {
-      background: @sortableInvertedHoverBackground;
       color: @sortableInvertedHoverColor;
     }
-    .ui.inverted.sortable.table > thead > tr > th {
+    .ui.inverted.sortable.table:not(.basic) > thead > tr > th:hover {
+      background: @sortableInvertedHoverBackground;
+    }
+    .ui.inverted.sortable.table:not(.basic) > thead > tr > th {
       border-left-color: @sortableInvertedBorderColor;
       border-right-color: @sortableInvertedBorderColor;
     }


### PR DESCRIPTION
## Description
A sortable table always showed a background in its sortable headers .
`(very) basic` tables instead are supposed to not have any background in their table header rows at all

## Testcase
#### Broken
https://jsfiddle.net/tsynqk3L

#### Fixed
https://jsfiddle.net/tsynqk3L/1/

## Screenshot
#### Broken
![image](https://user-images.githubusercontent.com/18379884/69727400-c337dd80-1122-11ea-881c-1a5c6a092317.png)

#### Fixed
![image](https://user-images.githubusercontent.com/18379884/69727423-ce8b0900-1122-11ea-9ce5-31999368151f.png)

## Closes
#1194 
