### PR TITLE
fix(form): avoid additional margin with nested fields

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -47,6 +47,7 @@
   margin: @fieldMargin;
 }
 
+.ui.form .fields .fields,
 .ui.form .field:last-child,
 .ui.form .fields:last-child .field {
   margin-bottom: 0;


### PR DESCRIPTION
## Description
When there is a fields class in another fields class, an extra margin-bottom is added.

Thanks to @dutrieux , who already provided the fix in the related issue 😄 

## Testcase
https://jsfiddle.net/ya4b9prt/
Remove The CSS to see the issue

## Screenshot
### Before
![image](https://user-images.githubusercontent.com/18379884/70326121-fb7ea080-1833-11ea-90b8-d4b55da03f49.png)

### After
![image](https://user-images.githubusercontent.com/18379884/70326079-dee26880-1833-11ea-96da-3ec74b6c3572.png)

## Closes
#1202 
