### PR TITLE
fix(dropdown): do not use value as name when name is empty

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1017,7 +1017,7 @@ $.fn.dropdown = function(parameters) {
                 var
                   value = settings.templates.deQuote(item[fields.value]),
                   name = settings.templates.escape(
-                    item[fields.name] || item[fields.value],
+                    item[fields.name] || '',
                     settings.preserveHTML
                   )
                 ;
@@ -4157,10 +4157,10 @@ $.fn.dropdown.settings.templates = {
         if(option[fields.icon]) {
           html += '<i class="'+deQuote(option[fields.icon])+' '+(option[fields.iconClass] ? deQuote(option[fields.iconClass]) : className.icon)+'"></i>';
         }
-        html +=   escape(option[fields.name] || option[fields.value],preserveHTML);
+        html +=   escape(option[fields.name] || '', preserveHTML);
         html += '</div>';
       } else if (itemType === 'header') {
-        var groupName = escape(option[fields.name],preserveHTML),
+        var groupName = escape(option[fields.name] || '', preserveHTML),
             groupIcon = option[fields.icon] ? deQuote(option[fields.icon]) : className.groupIcon
         ;
         if(groupName !== '' || groupIcon !== '') {

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -119,6 +119,7 @@
   display: block;
   border: @itemBorder;
   height: @itemHeight;
+  min-height: @itemMinHeight;
   text-align: @itemTextAlign;
 
   border-top: @itemDivider;

--- a/src/themes/default/modules/dropdown.variables
+++ b/src/themes/default/modules/dropdown.variables
@@ -61,6 +61,7 @@
 @itemLineHeightOffset: (@itemLineHeight - 1em);
 @itemTextTransform: none;
 @itemBoxShadow: none;
+@itemMinHeight: unit(@itemLineHeight + 2 * @itemVerticalPadding, rem);
 
 /* Sub Menu */
 @subMenuTop: 0;


### PR DESCRIPTION
## Description
In #1112 a missing name of an selection option was fetched and replaced by the value instead when converting select tags into dropdowns.
But this is not the same behavior as for a usual html select where a missing name is rendered as an empty select entry (which of course still has its individual value)

## Testcase
The first  entry has a value but an empty name. Standard html select would keep the empty name, while...
### Broken 
... FUI replaces it with the value by default
https://jsfiddle.net/mons57e2/

### Fixed
... keeps an empty/non-existing name
https://jsfiddle.net/4oxpwhv2/

## Closes
#1191 
