### PR TITLE
fix(dropdown): values are incorrect if they contain some special chars

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -2099,7 +2099,7 @@ $.fn.dropdown = function(parameters) {
                       optionValue = optionValue.toLowerCase();
                       value = value.toLowerCase();
                     }
-                    if( String(optionValue) == String(value)) {
+                    if(module.escape.htmlEntities(String(optionValue)) === module.escape.htmlEntities(String(value))) {
                       module.verbose('Found select item by value', optionValue, value);
                       $selectedItem = $choice;
                       return true;

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -2079,9 +2079,8 @@ $.fn.dropdown = function(parameters) {
                   if(optionValue === null || optionValue === undefined) {
                     return;
                   }
-                  optionValue = module.escape.htmlEntities(optionValue);
                   if(isMultiple) {
-                    if($.inArray( String(optionValue), value) !== -1) {
+                    if($.inArray(module.escape.htmlEntities(String(optionValue)), value) !== -1) {
                       $selectedItem = ($selectedItem)
                         ? $selectedItem.add($choice)
                         : $choice

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -3661,10 +3661,9 @@ $.fn.dropdown = function(parameters) {
           },
           htmlEntities: function(string) {
               var
-                  badChars     = /[&<>"'`]/g,
+                  badChars     = /[<>"'`]/g,
                   shouldEscape = /[&<>"'`]/,
                   escape       = {
-                      "&": "&amp;",
                       "<": "&lt;",
                       ">": "&gt;",
                       '"': "&quot;",
@@ -3676,6 +3675,7 @@ $.fn.dropdown = function(parameters) {
                   }
               ;
               if(shouldEscape.test(string)) {
+                  string = string.replace(/&(?![a-z0-9#]{1,6};)/, "&amp;");
                   return string.replace(badChars, escapedChar);
               }
               return string;
@@ -4087,10 +4087,9 @@ $.fn.dropdown.settings.templates = {
       return string;
     }
     var
-        badChars     = /[&<>"'`]/g,
+        badChars     = /[<>"'`]/g,
         shouldEscape = /[&<>"'`]/,
         escape       = {
-          "&": "&amp;",
           "<": "&lt;",
           ">": "&gt;",
           '"': "&quot;",
@@ -4102,6 +4101,7 @@ $.fn.dropdown.settings.templates = {
         }
     ;
     if(shouldEscape.test(string)) {
+      string = string.replace(/&(?![a-z0-9#]{1,6};)/, "&amp;");
       return string.replace(badChars, escapedChar);
     }
     return string;

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -2079,6 +2079,7 @@ $.fn.dropdown = function(parameters) {
                   if(optionValue === null || optionValue === undefined) {
                     return;
                   }
+                  optionValue = module.escape.htmlEntities(optionValue);
                   if(isMultiple) {
                     if($.inArray( String(optionValue), value) !== -1) {
                       $selectedItem = ($selectedItem)
@@ -3072,6 +3073,7 @@ $.fn.dropdown = function(parameters) {
               values = module.get.values(),
               newValue
             ;
+            removedValue = module.escape.htmlEntities(removedValue);
             if( module.has.selectInput() ) {
               module.verbose('Input is <select> removing selected option', removedValue);
               newValue = module.remove.arrayValue(removedValue, values);

--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -1496,10 +1496,9 @@ $.fn.popup.settings = {
   templates: {
     escape: function(string) {
       var
-        badChars     = /[&<>"'`]/g,
+        badChars     = /[<>"'`]/g,
         shouldEscape = /[&<>"'`]/,
         escape       = {
-          "&": "&amp;",
           "<": "&lt;",
           ">": "&gt;",
           '"': "&quot;",
@@ -1511,6 +1510,7 @@ $.fn.popup.settings = {
         }
       ;
       if(shouldEscape.test(string)) {
+        string = string.replace(/&(?![a-z0-9#]{1,6};)/, "&amp;");
         return string.replace(badChars, escapedChar);
       }
       return string;

--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -1369,10 +1369,9 @@ $.fn.search.settings = {
         return string;
       }
       var
-        badChars     = /[&<>"'`]/g,
+        badChars     = /[<>"'`]/g,
         shouldEscape = /[&<>"'`]/,
         escape       = {
-          "&": "&amp;",
           "<": "&lt;",
           ">": "&gt;",
           '"': "&quot;",
@@ -1384,6 +1383,7 @@ $.fn.search.settings = {
         }
       ;
       if(shouldEscape.test(string)) {
+        string = string.replace(/&(?![a-z0-9#]{1,6};)/, "&amp;");
         return string.replace(badChars, escapedChar);
       }
       return string;

--- a/src/definitions/modules/toast.js
+++ b/src/definitions/modules/toast.js
@@ -519,10 +519,9 @@ $.fn.toast = function(parameters) {
               return string;
             }
             var
-              badChars     = /[&<>"'`]/g,
+              badChars     = /[<>"'`]/g,
               shouldEscape = /[&<>"'`]/,
               escape       = {
-                "&": "&amp;",
                 "<": "&lt;",
                 ">": "&gt;",
                 '"': "&quot;",
@@ -534,6 +533,7 @@ $.fn.toast = function(parameters) {
               }
             ;
             if(shouldEscape.test(string)) {
+              string = string.replace(/&(?![a-z0-9#]{1,6};)/, "&amp;");
               return string.replace(badChars, escapedChar);
             }
             return string;


### PR DESCRIPTION
##  Description
Dropdown values which are supposed to be encoded into htmlentities like `&lt;` were wrongly encoded whenever the values changed. Especially when working with mulitple selection dropdowns.
Reason for this was the overseen fact that an ampersand `&` was also encoded into `&amp;`. As htmlentities are in general encoded by starting with an ampersand aswell this was totally messing up the value string.

As the escape routine was also implemented in other modules, this PR fixes the logic there as well

## Testcase
### Broken
https://jsfiddle.net/4cqtnf0d/

### Fixed
https://jsfiddle.net/yfgwph04/

## Screenshot
|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/70354235-5b466d00-186f-11ea-8406-f81b37e314ec.png)|![image](https://user-images.githubusercontent.com/18379884/70354164-3e119e80-186f-11ea-8332-f8fc820d234a.png)|

## Closes
#1207 
