### PR TITLE
feat(popup): add variant to ensure width if parent container is to small

### DIFF
--- a/src/definitions/modules/popup.less
+++ b/src/definitions/modules/popup.less
@@ -721,6 +721,12 @@
   }
 }
 
+& when (@variationPopupFixed) {
+  .ui.fixed.popup {
+    width: @maxWidth;
+  }
+}
+
 & when (@variationPopupWide) {
   /*--------------
        Wide
@@ -728,15 +734,24 @@
 
   .ui.wide.popup {
     max-width: @wideWidth;
+    &.fixed when (@variationPopupFixed) {
+      width: @wideWidth;
+    }
   }
   .ui[class*="very wide"].popup {
     max-width: @veryWideWidth;
+    &.fixed when (@variationPopupFixed) {
+      width: @veryWideWidth;
+    }
   }
 
   @media only screen and (max-width: @largestMobileScreen) {
     .ui.wide.popup,
     .ui[class*="very wide"].popup {
       max-width: @maxWidth;
+      &.fixed when (@variationPopupFixed) {
+        width:@maxWidth;
+      }
     }
   }
 }

--- a/src/definitions/modules/popup.less
+++ b/src/definitions/modules/popup.less
@@ -205,7 +205,23 @@
   [data-tooltip][data-position="bottom right"]:hover:after {
     transform: scale(1) !important;
   }
-
+  & when (@variationPopupFixed) {
+    [data-tooltip][data-variation~="fixed"]:after {
+      white-space: normal;
+      width: @maxWidth;
+    }
+    [data-tooltip][data-variation*="wide fixed"]:after {
+      width: @wideWidth;
+    }
+    [data-tooltip][data-variation*="very wide fixed"]:after {
+      width: @veryWideWidth;
+    }
+    @media only screen and (max-width: @largestMobileScreen) {
+      [data-tooltip][data-variation~="fixed"]:after {
+        width: @maxWidth;
+      }
+    }
+  }
   & when (@variationPopupInverted) {
     /*--------------
         Inverted

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -442,6 +442,7 @@
 @variationPopupWide: true;
 @variationPopupFluid: true;
 @variationPopupFlowing: true;
+@variationPopupFixed: true;
 @variationPopupSizes: @variationAllSizes;
 
 /* Progress */


### PR DESCRIPTION
## Description
When a popup is used directly from any html source, it inherits its default width by its parent container. width.
This leads into situations where popups appear too small and text wraps looking ugly

The only solution without changing existing html code is to give such popups a fixed width.
Therefore i added a new optional `fixed` variant.

This PR also supports css-only tooltips , so if `data-variation="fixed"` is used on `data-tooltip` the behavior is the same as for popups

## Testcase
#### Before
https://jsfiddle.net/baukrwxq/

#### After
https://jsfiddle.net/pfdLt8aq/

## Screenshots
### Popup Before
![popup_width_normal](https://user-images.githubusercontent.com/18379884/70636168-5c8fe500-1c35-11ea-8317-3c3a8c32bbfe.gif)

### Popup using `fixed`
![popup_width_fixed](https://user-images.githubusercontent.com/18379884/70636142-53067d00-1c35-11ea-840f-4065182b8852.gif)

### Tooltip Before
![image](https://user-images.githubusercontent.com/18379884/70647201-b352ea00-1c48-11ea-92b9-39c139154631.png)

### Tooltip using `data-variation="fixed"`
![image](https://user-images.githubusercontent.com/18379884/70647161-a0401a00-1c48-11ea-99af-57d58217eeaf.png)


## Closes
#1213
https://github.com/Semantic-Org/Semantic-UI/issues/6434