### PR TITLE
fix(popup): tooltips don't work on safari <= 12.1

### DIFF
--- a/src/definitions/modules/popup.less
+++ b/src/definitions/modules/popup.less
@@ -149,30 +149,27 @@
   [data-tooltip]:after {
     pointer-events: none;
     visibility: hidden;
+    opacity: 0;
+    transition:
+            transform @tooltipDuration @tooltipEasing,
+            opacity @tooltipDuration @tooltipEasing
+    ;
   }
   [data-tooltip]:before {
-    opacity: 0;
     transform: rotate(45deg) scale(0) !important;
     transform-origin: center top;
-    transition:
-      all @tooltipDuration @tooltipEasing
-    ;
   }
   [data-tooltip]:after {
-    opacity: 1;
     transform-origin: center bottom;
-    transition:
-      all @tooltipDuration @tooltipEasing
-    ;
   }
   [data-tooltip]:hover:before,
   [data-tooltip]:hover:after {
     visibility: visible;
     pointer-events: auto;
+    opacity: 1;
   }
   [data-tooltip]:hover:before {
     transform: rotate(45deg) scale(1) !important;
-    opacity: 1;
   }
 
   /* Animation Position */


### PR DESCRIPTION
## Description
Safari up to 12.1 has a bug to sometimes not work when `transition: all` is used .
This leads into tooltips not working 

## Testcase
https://jsfiddle.net/n8jed76x/1
Remove CSS to see the issue

## Screenshot 
#### Before
![safari_tooltip_bad](https://user-images.githubusercontent.com/18379884/70667527-659ea780-1c71-11ea-86ee-e4ec3ef58ebb.gif)

#### After
![safari_tooltip_good](https://user-images.githubusercontent.com/18379884/70667522-620b2080-1c71-11ea-8c0e-773ba4121aab.gif)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6702
