### PR TITLE
fix(dropdown): handle text metadata on select build dropdowns

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1975,6 +1975,9 @@ $.fn.dropdown = function(parameters) {
                     value    = ( $option.attr('value') !== undefined )
                       ? $option.attr('value')
                       : name,
+                    text     = ( $option.data('text') !== undefined )
+                      ? $option.data('text')
+                      : name,
                     group = $option.parent('optgroup')
                   ;
                   if(settings.placeholder === 'auto' && value === '') {
@@ -1992,6 +1995,7 @@ $.fn.dropdown = function(parameters) {
                     select.values.push({
                       name     : name,
                       value    : value,
+                      text     : text,
                       disabled : disabled
                     });
                   }

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1975,8 +1975,8 @@ $.fn.dropdown = function(parameters) {
                     value    = ( $option.attr('value') !== undefined )
                       ? $option.attr('value')
                       : name,
-                    text     = ( $option.data('text') !== undefined )
-                      ? $option.data('text')
+                    text     = ( $option.data(metadata.text) !== undefined )
+                      ? $option.data(metadata.text)
                       : name,
                     group = $option.parent('optgroup')
                   ;


### PR DESCRIPTION
## Description
This PR preserve the `data-text` attribute when creating the dropdown from a select, so the displayed text can be different than the in-dropdown text.

## Testcase
Before: [JSFiddle](https://jsfiddle.net/6hdtzybr/)
After: [JSFiddle](https://jsfiddle.net/1x4caqfm/2/)

## Closes
#1103
