### PR TITLE
fix(chore): duplicate variable declaration

### DIFF
--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -15,7 +15,6 @@
 @variationButtonInverted: true;
 @variationButtonSocial: true;
 @variationButtonFloated: true;
-@variationButtonFloated: true;
 @variationButtonCompact: true;
 @variationButtonBasic: true;
 @variationButtonTertiary: true;


### PR DESCRIPTION
## Description
Just removed a duplicate variable declaration. The same variable is declared one line before already.

