### PR TITLE
fix(dimmer): borders on partial segment dimmers are incorrect

### DIFF
--- a/src/definitions/modules/dimmer.less
+++ b/src/definitions/modules/dimmer.less
@@ -295,14 +295,14 @@ body.dimmable > .dimmer {
     -webkit-transform: translateY(calc(-50% - .5px));
   }
 
-  .ui.segment > .ui[class*="top dimmer"] {
+  .ui.segment > .ui.ui[class*="top dimmer"] {
       border-bottom-left-radius: 0 !important;
       border-bottom-right-radius: 0 !important;
   }
-  .ui.segment > .ui[class*="center dimmer"] {
+  .ui.segment > .ui.ui[class*="center dimmer"] {
       border-radius: 0 !important;
   }
-  .ui.segment > .ui[class*="bottom dimmer"] {
+  .ui.segment > .ui.ui[class*="bottom dimmer"] {
       border-top-left-radius: 0 !important;
       border-top-right-radius: 0 !important;
   }

--- a/src/definitions/modules/dimmer.less
+++ b/src/definitions/modules/dimmer.less
@@ -64,7 +64,7 @@
 
 /* Loose Coupling */
 .ui.segment > .ui.dimmer:not(.page) {
-  border-radius: inherit !important;
+  border-radius: inherit;
 }
 
 /* Scrollbars */
@@ -296,15 +296,15 @@ body.dimmable > .dimmer {
   }
 
   .ui.segment > .ui.ui[class*="top dimmer"] {
-      border-bottom-left-radius: 0 !important;
-      border-bottom-right-radius: 0 !important;
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
   }
   .ui.segment > .ui.ui[class*="center dimmer"] {
-      border-radius: 0 !important;
+      border-radius: 0;
   }
   .ui.segment > .ui.ui[class*="bottom dimmer"] {
-      border-top-left-radius: 0 !important;
-      border-top-right-radius: 0 !important;
+      border-top-left-radius: 0;
+      border-top-right-radius: 0;
   }
 
   .ui[class*="center dimmer"].transition[class*="fade up"].in {


### PR DESCRIPTION
## Description
The change in #1027 changed the specificity. This lead into the border correction for partial dimmers in segments to not work anymore.
This PR increases their specificity so they are adjusted again.

I also removed the unnecessary `!important` settings for the `segment > dimmer` border settings

## Testcase
####  Broken corners
https://jsfiddle.net/q1Lfgpk2

#### Fixed again and `!important` removed
https://jsfiddle.net/hq8tcs6w/

## Screenshot
#### Broken
![image](https://user-images.githubusercontent.com/18379884/70856111-70a64180-1ed6-11ea-9bff-947ac5841116.png)

### Fixed
![image](https://user-images.githubusercontent.com/18379884/70856096-3a68c200-1ed6-11ea-9791-9b91db9828a2.png)
