### PR TITLE
build(actions): stop nightly error on forks

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,9 +3,10 @@ on:
   schedule:
   - cron: 00 23 * * *
 jobs:
-  build:
+  publish:
     name: Build nightly distribution
     runs-on: ubuntu-latest
+    if: github.repository == 'fomantic/Fomantic-UI'
     steps:
     - uses: actions/checkout@v1
       with:


### PR DESCRIPTION
## Description
Add an `if` condition for the publish job so the nightly build only runs on the upstream repository.
