### PR TITLE
[Form] `add rule` was overwriting existing rules

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -818,26 +818,36 @@ $.fn.form = function(parameters) {
             module.add.field(name, rules);
           },
           field: function(name, rules) {
+            // Validation should have at least a standard format
+            if(validation[name] === undefined || validation[name].rules === undefined) {
+              validation[name] = {
+                rules: []
+              }
+            }
             var
-              newValidation = {}
+              newValidation = {
+                rules: []
+              }
             ;
             if(module.is.shorthandRules(rules)) {
               rules = Array.isArray(rules)
                 ? rules
                 : [rules]
               ;
-              newValidation[name] = {
-                rules: []
-              };
-              $.each(rules, function(index, rule) {
-                newValidation[name].rules.push({ type: rule });
+              $.each(rules, function(_index, rule) {
+                newValidation.rules.push({ type: rule });
               });
             }
             else {
-              newValidation[name] = rules;
+              newValidation.rules = rules.rules;
             }
-            validation = $.extend({}, validation, newValidation);
-            module.debug('Adding rules', newValidation, validation);
+            // For each new rule, check if there's not already one with the same type
+            $.each(newValidation.rules, function (_index, rule) {
+              if (validation[name].rules.findIndex(function(item) { return item.type == rule.type }) == -1) {
+                validation[name].rules.push(rule);
+              }
+            });
+            module.debug('Adding rules', newValidation.rules, validation);
           },
           fields: function(fields) {
             var

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -822,7 +822,7 @@ $.fn.form = function(parameters) {
             if(validation[name] === undefined || validation[name].rules === undefined) {
               validation[name] = {
                 rules: []
-              }
+              };
             }
             var
               newValidation = {
@@ -843,7 +843,7 @@ $.fn.form = function(parameters) {
             }
             // For each new rule, check if there's not already one with the same type
             $.each(newValidation.rules, function (_index, rule) {
-              if (validation[name].rules.findIndex(function(item) { return item.type == rule.type }) == -1) {
+              if ($.grep(validation[name].rules, function(item){ return item.type == rule.type; }).length == 0) {
                 validation[name].rules.push(rule);
               }
             });


### PR DESCRIPTION
## Description
While investigating on adding some autoset rules on required fields, I found that adding a rule trought the `add rule` behavior was overwritting existing rules.

This PR fixes this bad behavior and add some checks in the related function (checks if args are defined, check is a rule already exists...).

## Testcase
Before: [JSFiddle](https://jsfiddle.net/ohvu2q84/)
After: [JSFiddle](https://jsfiddle.net/jsmvop9h/)
