### PR TITLE
[Modal] Return control over useflex again, but provide unsupported debug warning

### DIFF
--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -708,7 +708,15 @@ $.fn.modal = function(parameters) {
             return module.cache.leftBodyScrollbar;
           },
           useFlex: function() {
-            return settings.useFlex && settings.detachable && !module.is.ie();
+            if (settings.useFlex === 'auto') {
+              return settings.detachable && !module.is.ie();
+            }
+            if(settings.useFlex && module.is.ie()) {
+              module.debug('useFlex true is not supported in IE');
+            } else if(settings.useFlex && !settings.detachable) {
+              module.debug('useFlex true in combination with detachable false is not supported');
+            }
+            return settings.useFlex;
           },
           fit: function() {
             var


### PR DESCRIPTION
## Description
This PR gives full control over the `useFlex` setting again.
Some combinations are not working for correct positioning, which was basically  fixed by #1079 and #1096
However, the fixes ignored a possible explicit given `useFlex:true` and always assumes `auto` instead (which makes sure the positioning will work all the time)
As it turned out [here](https://github.com/fomantic/Fomantic-UI/pull/1013#issuecomment-567530502) there are some usecases, where people need the explicit setting of `useFlex:true`, i reverted the logic for the `can.useFlex` method but added some debug warnings instead when unsupported combinations occur, because the positioning for `useFlex:true` will not work when:

- IE11 is used
- `detachable:false` is used

As the default of `useFlex` is `auto`,  existing code should basically work as before without any visual issues

I am totally fine if @fomantic/maintainers  will disagree and would like to reject this PR and keep the current implementation because
-  there won't be visual positioning issues when using any of the above combinations
- Users would need to enable the `debug` setting of their modals in order to see the message telling them why the positioning seems to be broken

If we reject this PR and keep the source as it is, we might change the docs, because `useFlex:true` will definately not work as intended and is currently always treated as `auto`

## 🗯 Let me know about your opinion

## Testcase
Scroll down to see the button to open the moda
http://jsfiddle.net/9cf2o75b/

## Screenshots
When `useFlex:true` is used in combination with 

- IE
![image](https://user-images.githubusercontent.com/18379884/71322942-a9917800-24cd-11ea-8e7b-f96601c0de54.png)

- detachable: false
![image](https://user-images.githubusercontent.com/18379884/71322968-26bced00-24ce-11ea-8abd-3251149580d3.png)

