### PR TITLE
[Form] Auto add empty rule validation for required fields

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1121,7 +1121,7 @@ $.fn.form = function(parameters) {
                 isDisabled = $el.prop('disabled') || $elGroup.hasClass(className.disabled) || $elGroup.parent().hasClass(className.disabled),
                 validation = module.get.validation($el),
                 hasEmptyRule = validation
-                  ? (validation.rules.findIndex(function(rule) { return rule.type == "empty" }) > -1)
+                  ? $.grep(validation.rules, function(rule) { return rule.type == "empty" }) !== 0
                   : false,
                 identifier = validation.identifier || $el.attr('id') || $el.attr('name') || $el.data(metadata.validate)
               ;


### PR DESCRIPTION
## Description
This PR adds the ability to add automatically an 'empty' rule for fields that got the `required` class (or `checked` for checkboxes). It's disabled by default since I don't want it to be a breaking change, but can be enabled at initialization with `autoCheckRequired: true` or any time with the `.form('set auto check')` behavior.

It can handle all fields types, grouped fields as well, and is able to detect disabled fields or groups. Rule is added to others if there's already some defined, and isn't duplicated if already set.

## Testcase
[JSFiddle](https://jsfiddle.net/m2xaLgsz/)

## Closes
#1094 
