### PR TITLE
[Checkbox] dont show visual changes on disabled checkboxes

### DIFF
--- a/src/definitions/modules/checkbox.less
+++ b/src/definitions/modules/checkbox.less
@@ -353,6 +353,7 @@
     cursor: default !important;
     opacity: @disabledCheckboxOpacity;
     color: @disabledCheckboxLabelColor;
+    pointer-events: none;
   }
 }
 


### PR DESCRIPTION
## Description
When any checkbox variant was disabled, it was still showing visual changes on hover which would indicate a possibility to change the checkbox (although greyed out and not possible)

Thanks to @tenKinetic , I adopted the PR idea from https://github.com/Semantic-Org/Semantic-UI/pull/6896 

## Testcase
https://jsfiddle.net/rn86ysde/
- Remove the CSS to see the difference

## Screenshot
|Before|After|
|-|-|
|![checkbox_pointer_events_bad](https://user-images.githubusercontent.com/18379884/71528806-f9af7680-28e1-11ea-9e79-fbe76cbf61c0.gif)|![checkbox_pointer_events_good](https://user-images.githubusercontent.com/18379884/71528810-ff0cc100-28e1-11ea-847a-01665ddcc9b4.gif)|

