### PR TITLE
build(config): respect browserslist config

### DIFF
--- a/tasks/config/tasks.js
+++ b/tasks/config/tasks.js
@@ -1,9 +1,21 @@
 var
+  browserslist = require('browserslist'),
   console = require('better-console'),
   config  = require('./user'),
   release = require('./project/release')
 ;
 
+var defaultBrowsers = browserslist(browserslist.defaults)
+var userBrowsers = browserslist()
+var hasBrowserslistConfig = JSON.stringify(defaultBrowsers) !== JSON.stringify(userBrowsers)
+
+var overrideBrowserslist = hasBrowserslistConfig ? undefined : [
+  'last 2 versions',
+  '> 1%',
+  'opera 12.1',
+  'bb 10',
+  'android 4'
+]
 
 module.exports = {
 
@@ -118,13 +130,7 @@ module.exports = {
 
     /* What Browsers to Prefix */
     prefix: {
-      overrideBrowserslist: [
-        'last 2 versions',
-        '> 1%',
-        'opera 12.1',
-        'bb 10',
-        'android 4'
-      ]
+      overrideBrowserslist
     },
 
     /* File Renames */


### PR DESCRIPTION
## Description

Currently `gulp-autoprefixer` has forced settings via `overrideBrowserslist`, however it's not [recommended](https://github.com/postcss/autoprefixer/#options) and breaks best practices as it silently overrides user's settings. As user's settings in `package.json` for example are not respected there will be useless CSS properties for modern browsers, for example [existing config](https://browserl.ist/?q=last+2+versions%2C+++%3E+1%25%2C+++opera+12.1%2C+++bb+10%2C+android+4) includes even IE 10 😨

### With current preset

```bash
gzip-size button.css
12.6 kB
```

```css
  -webkit-box-shadow: 0 0 0 1px transparent inset, 0 0 0 0 rgba(34, 36, 38, 0.15) inset;
          box-shadow: 0 0 0 1px transparent inset, 0 0 0 0 rgba(34, 36, 38, 0.15) inset;
  -webkit-user-select: none;
     -moz-user-select: none;
      -ms-user-select: none;
          user-select: none;
```

### With custom preset

```json
{
  "browserslist": ["> 1%", "not dead", "not IE > 0", "not op_mini all"]
}
```

```bash
gzip-size button.css
11.6 kB
```

```css
  box-shadow: 0 0 0 1px transparent inset, 0 0 0 0 rgba(34, 36, 38, 0.15) inset;
  -webkit-user-select: none;
      -ms-user-select: none;
          user-select: none;
```
