### PR TITLE
[Modal] Basic Modal header should not have a border

### DIFF
--- a/src/definitions/modules/modal.less
+++ b/src/definitions/modules/modal.less
@@ -309,6 +309,7 @@
   }
   .ui.basic.modal > .header {
     color: @basicModalHeaderColor;
+    border-bottom: none;
   }
   .ui.basic.modal > .close {
     top: @basicModalCloseTop;


### PR DESCRIPTION


## Description
A Modal header has a bottom border. A `basic modal` instead should not ( the border for actions in basic modals is already removed,  and it just looks misplaced, especially when there is noticable background)

Using the default dimmer settings the dimmer color is identical to the bottom border, thus invisible.
However, when the dimmer has a different shade or is inverted, the border gets visible.

## Testcase
https://jsfiddle.net/z086mn1s/

## Screenshot
### Before
![image](https://user-images.githubusercontent.com/18379884/71840252-37b85180-30bd-11ea-9281-56b11a80f839.png)


### After
![image](https://user-images.githubusercontent.com/18379884/71840213-1bb4b000-30bd-11ea-9933-f4f9bf544476.png)

### Before on default dimmer background (you just wont notice it)
![image](https://user-images.githubusercontent.com/18379884/71840685-160b9a00-30be-11ea-9a30-c48375704001.png)
