### PR TITLE
fix(segment): sub headers in inverted segments were not changed to white when inside content div of header

### DIFF
--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -62,7 +62,7 @@
 --------------------*/
 & when (@variationSegmentInverted) {
   /* Header */
-  .ui.inverted.segment > .ui.header > .sub.header,
+  .ui.inverted.segment > .ui.header .sub.header,
   .ui.inverted.segment > .ui.header {
     color: @white;
   }


### PR DESCRIPTION
## Description
Sub headers in inverted segments were not changed to white when inside content div of header

## Testcase
#### Broken
https://jsfiddle.net/ub3m5vsL/1/

#### Fixed
https://jsfiddle.net/ub3m5vsL/2/

## Screenshot
#### Broken
![image](https://user-images.githubusercontent.com/18379884/72326911-62ec0380-36b0-11ea-8650-cb5193a27bf7.png)

#### Fixed
![image](https://user-images.githubusercontent.com/18379884/72326866-523b8d80-36b0-11ea-9ba6-be65f44b77a4.png)


## Closes
#1261 