### PR TITLE
[Toast ]Make sure element does still exist before transition ends

### DIFF
--- a/src/definitions/modules/toast.js
+++ b/src/definitions/modules/toast.js
@@ -389,13 +389,15 @@ $.fn.toast = function(parameters) {
                   onBeforeHide: function(callback){
                       callback = $.isFunction(callback)?callback : function(){};
                       if(settings.transition.closeEasing !== ''){
-                          $toastBox.css('opacity',0);
-                          $toastBox.wrap('<div/>').parent().slideUp(500,settings.transition.closeEasing,function(){
-                            if($toastBox){
-                              $toastBox.parent().remove();
-                              callback.call($toastBox);
-                            }
-                          });
+                          if($toastBox) {
+                            $toastBox.css('opacity', 0);
+                            $toastBox.wrap('<div/>').parent().slideUp(500, settings.transition.closeEasing, function () {
+                              if ($toastBox) {
+                                $toastBox.parent().remove();
+                                callback.call($toastBox);
+                              }
+                            });
+                          }
                       } else {
                         callback.call($toastBox);
                       }


### PR DESCRIPTION
## Description
In situations where a toast is going to be closed via Javascript while the hide animation is still in progress, access to the element is not possible anymore leading to a console.error

```console
semantic.js:23153 Uncaught TypeError: Cannot read property 'css' of undefined
    at HTMLDivElement.onBeforeHide (semantic.js:23153)
    at Object.hide (semantic.js:24414)
```
## Testcase
Click very fast on the second button and watch the console.
> Note: The transition message `Element is no longer attached to DOM. ` in some cases is still standard of fomantic and fetched so that does not matter here

## Broken
Shows `Cannot read property 'css' of undefined` in some cases
http://jsfiddle.net/hgs9fzdx/8

## Fixed
It doesnt
https://jsfiddle.net/jas1896m/