### PR TITLE
[Modal] Border radius for inner dimmer should inherit from the modal

### DIFF
--- a/src/definitions/modules/modal.less
+++ b/src/definitions/modules/modal.less
@@ -53,6 +53,10 @@
   border-bottom-right-radius: @borderRadius;
 }
 
+.ui.modal > .ui.dimmer {
+  border-radius: inherit;
+}
+
 /*******************************
             Content
 *******************************/


### PR DESCRIPTION
## Description
The inner dimmer which covers a parent modal in case `allowMultiple: true` is used, didn't have a border radius. This results in visually removing the border from the modal itself.

## Testcase
Reomve the CSS to see the issue
https://jsfiddle.net/10dbpftg/


## Screenshot 
Look at the top left corner 

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/72664240-bd13fe00-39fb-11ea-9698-0043a1e6c01b.png)|![image](https://user-images.githubusercontent.com/18379884/72664234-a372b680-39fb-11ea-9de8-a368bf73cfdb.png)|


## Closes
#1274 