### PR TITLE
[Shape] make sure chrome renders the z-translated faces properly

### DIFF
--- a/src/definitions/modules/shape.less
+++ b/src/definitions/modules/shape.less
@@ -31,6 +31,7 @@
   transition: @transition;
 }
 
+.ui.shape .side,
 .ui.shape .sides {
   transform-style: preserve-3d;
 }


### PR DESCRIPTION
## Description
When doing CSS 3D transforms there is an old chrome bug which does not handle translateZ properly in some cases.
This had the side effect of not seeing some shape faces when transitions took place right after each other and seemed to be vanished

## Testcase
- Click the animation arrows quickly, so animation is stacked
- Remove the CSS to see the issue 
https://jsfiddle.net/gbem84ry/

## Screenshot 
|Before|After|
|-|-|
|![shape_bad](https://user-images.githubusercontent.com/18379884/73087190-6eba9f80-3ed2-11ea-9f21-435109926792.gif)|![shape_good](https://user-images.githubusercontent.com/18379884/73087203-737f5380-3ed2-11ea-9568-3b46cda625ce.gif)|

## Closes
#1283 