### PR TITLE
[Form, Calendar] Calendar inline fields did not display properly

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -1097,6 +1097,16 @@
     font-size: @inlineInputSize;
   }
 
+  .ui.form .inline.fields .field .calendar:not(.popup),
+  .ui.form .inline.field .calendar:not(.popup) {
+    display:inline-block;
+  }
+
+  .ui.form .inline.fields .field .calendar:not(.popup) > .input > input,
+  .ui.form .inline.field .calendar:not(.popup) > .input > input {
+    width: @inlineCalendarWidth;
+  }
+
   /* Label */
   .ui.form .inline.fields .field > :first-child,
   .ui.form .inline.field > :first-child {

--- a/src/themes/default/collections/form.variables
+++ b/src/themes/default/collections/form.variables
@@ -158,6 +158,7 @@
 @inlineLabelFontSize: @labelFontSize;
 @inlineLabelFontWeight: @labelFontWeight;
 @inlineLabelTextTransform: @labelTextTransform;
+@inlineCalendarWidth: 13.11em;
 
 @groupedInlineLabelMargin: 0.035714em 1em 0 0;
 


### PR DESCRIPTION
## Description
When a `ui calendar` is used within a `inline field`, its display was broken (shrunk and not inline)
I had to use a proper direct em setting to fix this, as the input field is inside the calendar component making the usual `width: auto` not work as for the other standard input form fields.

## Testcase
- remove the CSS to see the issue
https://jsfiddle.net/3payxo5h/1/


## Screenshot
### Before
![image](https://user-images.githubusercontent.com/18379884/73558518-a2a63f80-4453-11ea-8b7a-78f662e9a5e3.png)

### After
![image](https://user-images.githubusercontent.com/18379884/73558484-915d3300-4453-11ea-9f59-c1d3ae81a2c1.png)

## Closes
#1296 