### PR TITLE
[Dropdown] Cursor in search field was barely visible when field has error class

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -643,7 +643,7 @@ select.ui.dropdown {
     cursor: text;
     position: relative;
     left: @textCursorSpacing;
-    z-index: 3;
+    z-index: auto;
   }
 
   & when (@variationDropdownSelection) {


### PR DESCRIPTION
## Description
If a search dropdown has an error class, the, the cursor is not properly visible when the field has focus

## Testcase
https://jsfiddle.net/84gdzxyh/
Remove the CSS to see the issue

## Screenshot 
Watch the blinking Text cursor inside the dropdownfield

|Before|After|
|-|-|
|![errorcursor_bad](https://user-images.githubusercontent.com/18379884/73666019-66b4e980-46a2-11ea-989c-35247bcde5e7.gif)|![errorcursor_good](https://user-images.githubusercontent.com/18379884/73666028-6c123400-46a2-11ea-9512-64bd30c1d359.gif)|

## Closes
#1235 