### PR TITLE
fix(#1315): allow optional compression

### DIFF
--- a/tasks/config/defaults.js
+++ b/tasks/config/defaults.js
@@ -116,8 +116,8 @@ module.exports = {
 
   // globs used for matching file patterns
   globs      : {
-    ignored    : '!(*.min|*.map|*.rtl)',
-    ignoredRTL : '!(*.min|*.map)'
+    ignored    : '!(*.map|*.rtl)',
+    ignoredRTL : '!(*.map)'
   }
 
 };


### PR DESCRIPTION
Add a build option to only generate compressed CSS and Javascript on demand.
The default is kept on the previous behavior of building both flavours.

## Closes
#1315 