### PR TITLE
[Menu] Colored active items were not displayed colored

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -1343,7 +1343,7 @@ each(@colors, {
   @c: @colors[@@color][color];
 
   & when not (@color=secondary) {
-    .ui.ui.menu .@{color}.active.item,
+    .ui.ui.ui.menu .@{color}.active.item,
     .ui.ui.@{color}.menu .active.item:hover,
     .ui.ui.@{color}.menu .active.item {
       & when not (@secondaryPointingActiveBorderColor = currentColor) {
@@ -1485,7 +1485,7 @@ each(@colors, {
     @h: @colors[@@color][hover];
 
     & when not (@color=secondary) {
-      .ui.ui.inverted.menu .@{color}.active.item,
+      .ui.ui.ui.inverted.menu .@{color}.active.item,
       .ui.ui.inverted.@{color}.menu {
         background-color: @c;
       }


### PR DESCRIPTION
## Description
Colored active items in colored menus were not displayed colored because of too low specificity

## Testcase
https://jsfiddle.net/Ley9pt6v/2/
Remove CSS to see issue

## Screenshot
The active item is actually an  `orange active item`
#### Before
![image](https://user-images.githubusercontent.com/18379884/74337002-baf55300-4d9f-11ea-9c38-b43c0ceb569a.png)

#### After
![image](https://user-images.githubusercontent.com/18379884/74336974-afa22780-4d9f-11ea-9d13-b49e9a00b73a.png)

## Closes
#1321 
