### PR TITLE
fix(form): make a difference between value 0 and false for radio buttons

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -706,7 +706,7 @@ $.fn.form = function(parameters) {
                 }
                 else {
                   if(isRadio) {
-                    if(values[name] === undefined || values[name] == false) {
+                    if(values[name] === undefined || values[name] === false) {
                       values[name] = (isChecked)
                         ? value || true
                         : false


### PR DESCRIPTION
## Description
A form gets radio values wrong, if one of them has a value of `0`, but returns `false` instead

## Testcase
#### Broken
https://jsfiddle.net/designosis/hrj97xao/

#### Fixed
https://jsfiddle.net/ab786gwe/

## Closes
#1327 