### PR TITLE
fix(emoji): disabled link emoji should not have pointer cursor

### DIFF
--- a/src/definitions/elements/emoji.less
+++ b/src/definitions/elements/emoji.less
@@ -65,7 +65,7 @@ em[data-emoji].loading:before {
          Link
 --------------------*/
 
-em[data-emoji].link {
+em[data-emoji].link:not(.disabled) {
   cursor: pointer;
 }
 


### PR DESCRIPTION
## Description
A `disabled link` emoji should not have a pointer cursor

## Testcase
### Broken
https://jsfiddle.net/1fxmwk27/

### Fixed
https://jsfiddle.net/0vwx5hn8/

## Closes
#1341 