### PR TITLE
[Calendar] new option autoAdjustDateEdges avoid invalid mindate/maxdate combinations

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -745,20 +745,26 @@ $.fn.calendar = function(parameters) {
           minDate: function (date) {
             date = module.helper.sanitiseDate(date);
             if (settings.maxDate !== null && settings.maxDate <= date) {
-              module.verbose('Unable to set minDate variable bigger that maxDate variable', date, settings.maxDate);
-            } else {
-              module.setting('minDate', date);
-              module.set.dataKeyValue(metadata.minDate, date);
+              if (!settings.autoAdjustDateEdges) {
+                module.error('Unable to set minDate variable bigger than maxDate variable', date, settings.maxDate);
+                return;
+              }
+              module.set.maxDate(date);
             }
+            module.setting('minDate', date);
+            module.set.dataKeyValue(metadata.minDate, date);
           },
           maxDate: function (date) {
             date = module.helper.sanitiseDate(date);
             if (settings.minDate !== null && settings.minDate >= date) {
-              module.verbose('Unable to set maxDate variable lower that minDate variable', date, settings.minDate);
-            } else {
-              module.setting('maxDate', date);
-              module.set.dataKeyValue(metadata.maxDate, date);
+              if(!settings.autoAdjustDateEdges) {
+                module.error('Unable to set maxDate variable lower than minDate variable', date, settings.minDate);
+                return;
+              }
+              module.set.minDate(date);
             }
+            module.setting('maxDate', date);
+            module.set.dataKeyValue(metadata.maxDate, date);
           },
           monthOffset: function (monthOffset, refreshCalendar) {
             var multiMonth = Math.max(settings.multiMonth, 1);
@@ -1224,6 +1230,7 @@ $.fn.calendar.settings = {
   startMode          : false,      // display mode to start in, can be 'year', 'month', 'day', 'hour', 'minute' (false = 'day')
   minDate            : null,       // minimum date/time that can be selected, dates/times before are disabled
   maxDate            : null,       // maximum date/time that can be selected, dates/times after are disabled
+  autoAdjustDateEdges: false,      // automatically sets min or maxdate to the same as the opposite if maxdate < mindate or mindate > maxdate
   ampm               : true,       // show am/pm in time mode
   disableYear        : false,      // disable year selection mode
   disableMonth       : false,      // disable month selection mode


### PR DESCRIPTION
## Description
This PR adds a new setting `autoAdjustDateEdges` (default `false` to stay backward compatible)

When enabled and a call to `set.minDate` or `set.maxDate` would result in an invalid range (min > max or max < min) it will automatically set the opposite edge to the same value, so the range stays valid.

The current (and still default) behavior already fetches invalid values but only shows this in the log when debug and verbose is enabled, so fails silently. As this is rather an error than a verbose information i also changed the log level to error in those cases.

## Testcase
https://jsfiddle.net/k386q42s/1/

## Closes
#1364 
