### PR TITLE
[Icon] medium/default font was missing general css properties

### DIFF
--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -288,14 +288,14 @@ each(@colors, {
 i.icon,
 i.icons {
   font-size: @medium;
+  line-height: 1;
+  vertical-align: middle;
 }
 & when not (@variationIconSizes = false) {
   each(@variationIconSizes, {
     @s: @@value;
     i.@{value}.@{value}.@{value}.icon,
     i.@{value}.@{value}.@{value}.icons {
-      line-height: 1;
-      vertical-align: middle;
       font-size: @s;
     }
   })


### PR DESCRIPTION
## Description
Normal size of icon has not the same vertical-align and line-height of each other size
`vertical-align` and `line-height` always had the same value regardless of size....however the default size was missing those

## Closes
#1371 
