### PR TITLE
fix(search) Fix padding it description when search inside modal

### DIFF
--- a/src/definitions/modules/modal.less
+++ b/src/definitions/modules/modal.less
@@ -256,7 +256,7 @@
   .ui.modal .image.content {
     flex-direction: column;
   }
-  .ui.modal .content > .image {
+  .ui.modal > .content > .image {
     display: block;
     max-width: 100%;
     margin: 0 auto !important;
@@ -269,7 +269,7 @@
   }
 
   /*rtl:ignore*/
-  .ui.modal .content > .description {
+  .ui.modal > .content > .description {
     display: block;
     width: 100% !important;
     margin: 0 !important;


### PR DESCRIPTION
Modal module adds padding to ".description" block when window size less 769px.
Search blocks can contain ".description" inside. When search block is inside modal, then ".description" inside search breaks down on screen less 769px.

[Example](https://jsfiddle.net/xrgs3eyu/) (reduce the size of the browser window)
![image](https://user-images.githubusercontent.com/1929437/77347316-b6ca3700-6d48-11ea-956b-66872cc5abaa.png)
