### PR TITLE
[Build] Allow individual components to be defined in config

### DIFF
--- a/tasks/build/css.js
+++ b/tasks/build/css.js
@@ -127,6 +127,13 @@ function buildCSS(src, type, config, opts, callback) {
     src      = config.paths.source.definitions + '/**/' + config.globs.components + '.less';
   }
 
+  if (globs.individuals !== undefined) {
+    const individuals = config.globs.individuals.replace('{','');
+    const components = config.globs.components.replace('}',',').concat(individuals);
+
+    src = config.paths.source.definitions + '/**/' + components + '.less';
+  }
+
   const buildUncompressed       = () => build(src, type, false, config, opts);
   buildUncompressed.displayName = 'Building uncompressed CSS';
 

--- a/tasks/build/javascript.js
+++ b/tasks/build/javascript.js
@@ -99,6 +99,13 @@ function buildJS(src, type, config, callback) {
     src      = config.paths.source.definitions + '/**/' + config.globs.components + (config.globs.ignored || '') + '.js';
   }
 
+  if (globs.individuals !== undefined) {
+    const individuals = config.globs.individuals.replace('{','');
+    const components = config.globs.components.replace('}',',').concat(individuals);
+
+    src = config.paths.source.definitions + '/**/' + components + (config.globs.ignored || '') + '.js';
+  }
+
   // copy source javascript
   const js       = () => build(src, type, config);
   js.displayName = "Building un/compressed Javascript";

--- a/tasks/config/project/config.js
+++ b/tasks/config/project/config.js
@@ -135,6 +135,14 @@ module.exports = {
       : '{' + defaults.components.join(',') + '}'
     ;
 
+    // components that should be built, but excluded from main .css/.js files
+    config.globs.individuals = (typeof config.individuals == 'object')
+      ? (config.individuals.length > 1)
+        ? '{' + config.individuals.join(',') + '}'
+        : config.individuals[0]
+      : undefined
+    ;
+
     return config;
 
   }


### PR DESCRIPTION
## Description

Individual components will have their .css/.js file generated under /dist/components, but are not included in semantic.css and semantic.js.

This is useful for including these components in your project only if you need them, while keeping the file size of the main .css/.js file as small as possible.

## Testcase

To make it work, create a new array in your semantic.json:
```
{
    "components": [
        ...
    ],
    "individuals": [
        form,
        modal,
        step
    ]
}
```

Don't forget to remove these items from the regular "components" array.

This change should be fully backwards compatible. It only changes the src variable if an "individuals" array has been defined in the config.
