### PR TITLE
[Dropdown] Prevent showing the whole list if showOnFocus is false

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -541,6 +541,7 @@ $.fn.dropdown = function(parameters) {
           } else if( module.can.click() ) {
               module.unbind.intent();
           }
+          iconClicked = false;
         },
 
         hideOthers: function() {


### PR DESCRIPTION
## Description
When  `showOnFocus` was set to false but the dropdown was opened by clicking on the down arrow icon, then a focus of the input field afterwards was opening the whole menu once, which isn't allowed.

The `iconClicked` value needs to be reset whenever the dropdown list gets hidden which this PR is 
fixing.

## Testcase
- Click into the dropdown input field. It should **not** open because `showOnFocus=false` ✔️ 
- Click on the dropdowns down arrow. It should open the whole menu ✔️
- Close the menu by either clicking somewhere outside the menu or by the down arrow again ✔️ 

### Broken
- Click into the dropdown input field again. It now opens the whole menu again (at least once) ❌  
https://jsfiddle.net/dutrieux/wqfnb7rj/

### Fixed
- Click into the dropdown input field again. It will **not** open the menu anymore as it should✔️ 
https://jsfiddle.net/L21jhap3/

## Closes
#1396 