### PR TITLE
Remove max-width definition from comments

### DIFF
--- a/src/definitions/views/comment.less
+++ b/src/definitions/views/comment.less
@@ -29,7 +29,6 @@
 
 .ui.comments {
   margin: @margin;
-  max-width: @maxWidth;
 }
 
 .ui.comments:first-child {


### PR DESCRIPTION
it makes problems when you have to override it to fill parent element, you can use `max-width: unset` but it's not supported in IE/Edge
