### PR TITLE
[Modal] Center fluid action buttons correctly

### DIFF
--- a/src/definitions/modules/modal.less
+++ b/src/definitions/modules/modal.less
@@ -175,7 +175,7 @@
   border-top: @actionBorder;
   text-align: @actionAlign;
 }
-.ui.modal .actions > .button {
+.ui.modal .actions > .button:not(.fluid) {
   margin-left: @buttonDistance;
 }
 .ui.basic.modal > .actions {


### PR DESCRIPTION
## Description
In case a `fluid` action button is used within a modal, it was not centered correctly because of the left margin. As fluid buttons occupy the whole width this PR removes the left margin in those cases

## Testcase
Remove CSS to see the issue
https://jsfiddle.net/kt85yapn/

## Screenshot
### Broken
![image](https://user-images.githubusercontent.com/18379884/78802619-541aa180-79be-11ea-9a47-95e499b53542.png)

### Fixed
![image](https://user-images.githubusercontent.com/18379884/78802582-4a913980-79be-11ea-8bc6-c9459e96735b.png)


## Closes
#1405 