### PR TITLE
Prevent gulp watch task from refreshing all components

### DIFF
--- a/tasks/build/css.js
+++ b/tasks/build/css.js
@@ -127,7 +127,7 @@ function buildCSS(src, type, config, opts, callback) {
     src      = config.paths.source.definitions + '/**/' + config.globs.components + '.less';
   }
 
-  if (globs.individuals !== undefined) {
+  if (globs.individuals !== undefined && typeof src === 'string') {
     const individuals = config.globs.individuals.replace('{','');
     const components = config.globs.components.replace('}',',').concat(individuals);
 

--- a/tasks/build/javascript.js
+++ b/tasks/build/javascript.js
@@ -99,7 +99,7 @@ function buildJS(src, type, config, callback) {
     src      = config.paths.source.definitions + '/**/' + config.globs.components + (config.globs.ignored || '') + '.js';
   }
 
-  if (globs.individuals !== undefined) {
+  if (globs.individuals !== undefined && typeof src === 'string') {
     const individuals = config.globs.individuals.replace('{','');
     const components = config.globs.components.replace('}',',').concat(individuals);
 


### PR DESCRIPTION
When defining individuals inside semantic.json, these components are added to the list of regular components inside the build function.

The problem is that this build function is also used by the 'watch' task to refresh individual files. So when running gulp watch with individuals defined, the src variable containing the path to the watched file is overwritten by the full list of components. The result is that each change triggers a full rebuild.

Not what we want, so I added an extra condition to the if statement that's changing the src variable. It seems the src variable is always passed as object when using watch.. So by checking if src is a string, it is only altered during regular build tasks.