### PR TITLE
[Button Animated] margin-right & vertical-align & opacity not correct with icon

### DIFF
--- a/src/definitions/elements/button.less
+++ b/src/definitions/elements/button.less
@@ -710,7 +710,8 @@
   padding: @verticalPadding @verticalPadding ( @verticalPadding + @shadowOffset );
 }
 .ui.icon.buttons .button > .icon,
-.ui.icon.button > .icon {
+.ui.icon.button > .icon,
+.ui.animated.button > .content > .icon {
   opacity: @iconButtonOpacity;
   margin: 0 !important;
   vertical-align: top;

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1080,6 +1080,9 @@ $.fn.dropdown = function(parameters) {
               if(settings.showOnFocus || (event.type !== 'focus' && event.type !== 'focusin')) {
                 module.search();
               }
+              else {
+                iconClicked = false;
+              }
             },
             blur: function(event) {
               pageLostFocus = (document.activeElement === this);


### PR DESCRIPTION
# Bug Report
When icon is in button with animated, the margin-right & vertical-align & opacity is not the same when icon is in button without animated

## Screenshot
__Icon without animated__ :
![image](https://user-images.githubusercontent.com/1622751/78916396-b393b280-7a8d-11ea-942e-8f90063f4618.png)

__icon with animated__ :
![image](https://user-images.githubusercontent.com/1622751/78916767-43396100-7a8e-11ea-9d08-7add19b6e296.png)

## Testcase
note: I use the last nightly build (08/04/2020) :
https://jsfiddle.net/dutrieux/a8mnz2yc/

fix issue #1409
