### PR TITLE
[Button Animated] Adjust vertical-align for icons & support ui.animated.icon.button

### DIFF
--- a/src/definitions/elements/button.less
+++ b/src/definitions/elements/button.less
@@ -711,8 +711,7 @@
 }
 .ui.animated.icon.button > .content > .icon,
 .ui.icon.buttons .button > .icon,
-.ui.icon.button > .icon,
-.ui.animated.button > .content > .icon {
+.ui.icon.button > .icon {
   opacity: @iconButtonOpacity;
   margin: 0 !important;
   vertical-align: top;

--- a/src/definitions/elements/button.less
+++ b/src/definitions/elements/button.less
@@ -706,13 +706,17 @@
 ---------------*/
 
 .ui.icon.buttons .button,
-.ui.icon.button {
+.ui.icon.button:not(.animated) {
   padding: @verticalPadding @verticalPadding ( @verticalPadding + @shadowOffset );
 }
+.ui.animated.icon.button > .content > .icon,
 .ui.icon.buttons .button > .icon,
 .ui.icon.button > .icon {
   opacity: @iconButtonOpacity;
   margin: 0 !important;
+  vertical-align: top;
+}
+.ui.animated.button > .content > .icon {
   vertical-align: top;
 }
 


### PR DESCRIPTION
# Bug Report
When icon is in button with animated, the margin-right & vertical-align & opacity is not the same when icon is in button without animated

## Screenshot
__Icon without animated__ :
![image](https://user-images.githubusercontent.com/1622751/78916396-b393b280-7a8d-11ea-942e-8f90063f4618.png)

__icon with animated__ :
![image](https://user-images.githubusercontent.com/1622751/78916767-43396100-7a8e-11ea-9d08-7add19b6e296.png)

## Testcase
note: I use the last nightly build (08/04/2020) :
https://jsfiddle.net/dutrieux/a8mnz2yc/

fix issue #1409