### PR TITLE
fix(build): Import 'various' gulp tasks

### DIFF
--- a/tasks/config/npm/gulpfile.js
+++ b/tasks/config/npm/gulpfile.js
@@ -15,6 +15,7 @@ var
  *******************************/
 
 require('./tasks/collections/build')(gulp);
+require('./tasks/collections/various')(gulp);
 require('./tasks/collections/install')(gulp);
 
 gulp.task('default', gulp.series('watch'));


### PR DESCRIPTION
This PR imports the tasks under `tasks/collections/various` in the `gulpfile.js` that is installed, which then imports the `clean` and `version` tasks.

My team is looking to switch from Semantic UI to Fomantic UI because Fomantic is still actively maintained, but when we made the switch from Semantic UI to Fomantic UI I found that `gulp clean` wasn't working because the task isn't in scope.

I was thinking importing it in `gulpfile.js` should suffice, unless there is a reason it was left out.
