### PR TITLE
[Step] Right vertical steps variant having the arrow to te left side

### DIFF
--- a/src/definitions/elements/step.less
+++ b/src/definitions/elements/step.less
@@ -235,6 +235,12 @@
     border-width: @verticalArrowBorderWidth;
     display: @verticalArrowDisplay;
   }
+  .ui.right.vertical.steps .step:after {
+    border-width: @verticalLeftArrowBorderWidth;
+    left: @verticalLeftArrowLeftOffset;
+    right: @verticalLeftArrowRightOffset;
+    transform: translateY(-50%) translateX(-50%) rotate(-45deg);
+  }
 
   .ui.vertical.steps .active.step:after {
     display: @verticalActiveArrowDisplay;

--- a/src/themes/default/elements/step.variables
+++ b/src/themes/default/elements/step.variables
@@ -81,6 +81,9 @@
 @verticalDivider: @divider;
 @verticalArrowTopOffset: 50%;
 @verticalArrowRightOffset: 0;
+@verticalLeftArrowLeftOffset: 0;
+@verticalLeftArrowRightOffset: 100%;
+@verticalLeftArrowBorderWidth: @borderWidth 0 0 @borderWidth;
 @verticalArrowBorderWidth: 0 @borderWidth @borderWidth 0;
 
 @verticalArrowDisplay: none;


### PR DESCRIPTION
## Description
As suggested by @ko2in , this PR adds support to display vertical step arrows to the left side by inventing a new `.ui.right.vertical.steps` variant

## Testcase
https://jsfiddle.net/3grpteq8/

## Screenshot
Left steps: Usual steps as before
Right steps: new `right.vertical.steps`  variant
![image](https://user-images.githubusercontent.com/18379884/79642967-c0f12100-81a0-11ea-8a77-b2dadc8ad4e4.png)


## Closes
#1418 
