### PR TITLE
[Progress bar] indicating background color is incorrect when data-percent have decimal number

### DIFF
--- a/src/definitions/modules/modal.less
+++ b/src/definitions/modules/modal.less
@@ -175,7 +175,7 @@
   border-top: @actionBorder;
   text-align: @actionAlign;
 }
-.ui.modal .actions > .button {
+.ui.modal .actions > .button:not(.fluid) {
   margin-left: @buttonDistance;
 }
 .ui.basic.modal > .actions {

--- a/src/definitions/modules/progress.less
+++ b/src/definitions/modules/progress.less
@@ -185,40 +185,40 @@
   }
 
   /* Single Digits */
-  .ui.indicating.progress[data-percent="1"] .bar,
-  .ui.indicating.progress[data-percent="2"] .bar,
-  .ui.indicating.progress[data-percent="3"] .bar,
-  .ui.indicating.progress[data-percent="4"] .bar,
-  .ui.indicating.progress[data-percent="5"] .bar,
-  .ui.indicating.progress[data-percent="6"] .bar,
-  .ui.indicating.progress[data-percent="7"] .bar,
-  .ui.indicating.progress[data-percent="8"] .bar,
-  .ui.indicating.progress[data-percent="9"] .bar {
+  .ui.indicating.progress[data-percent="1"] .bar, .ui.indicating.progress[data-percent^="1."] .bar,
+  .ui.indicating.progress[data-percent="2"] .bar, .ui.indicating.progress[data-percent^="2."] .bar,
+  .ui.indicating.progress[data-percent="3"] .bar, .ui.indicating.progress[data-percent^="3."] .bar,
+  .ui.indicating.progress[data-percent="4"] .bar, .ui.indicating.progress[data-percent^="4."] .bar,
+  .ui.indicating.progress[data-percent="5"] .bar, .ui.indicating.progress[data-percent^="5."] .bar,
+  .ui.indicating.progress[data-percent="6"] .bar, .ui.indicating.progress[data-percent^="6."] .bar,
+  .ui.indicating.progress[data-percent="7"] .bar, .ui.indicating.progress[data-percent^="7."] .bar,
+  .ui.indicating.progress[data-percent="8"] .bar, .ui.indicating.progress[data-percent^="8."] .bar,
+  .ui.indicating.progress[data-percent="9"] .bar, .ui.indicating.progress[data-percent^="9."] .bar {
     background-color: @indicatingFirstColor;
   }
-  .ui.indicating.progress[data-percent="0"] .label,
-  .ui.indicating.progress[data-percent="1"] .label,
-  .ui.indicating.progress[data-percent="2"] .label,
-  .ui.indicating.progress[data-percent="3"] .label,
-  .ui.indicating.progress[data-percent="4"] .label,
-  .ui.indicating.progress[data-percent="5"] .label,
-  .ui.indicating.progress[data-percent="6"] .label,
-  .ui.indicating.progress[data-percent="7"] .label,
-  .ui.indicating.progress[data-percent="8"] .label,
-  .ui.indicating.progress[data-percent="9"] .label {
+  .ui.indicating.progress[data-percent="0"] .label, .ui.indicating.progress[data-percent^="0."] .label,
+  .ui.indicating.progress[data-percent="1"] .label, .ui.indicating.progress[data-percent^="1."] .label,
+  .ui.indicating.progress[data-percent="4"] .label, .ui.indicating.progress[data-percent^="4."] .label,
+  .ui.indicating.progress[data-percent="2"] .label, .ui.indicating.progress[data-percent^="2."] .label,
+  .ui.indicating.progress[data-percent="3"] .label, .ui.indicating.progress[data-percent^="3."] .label,
+  .ui.indicating.progress[data-percent="5"] .label, .ui.indicating.progress[data-percent^="5."] .label,
+  .ui.indicating.progress[data-percent="6"] .label, .ui.indicating.progress[data-percent^="6."] .label,
+  .ui.indicating.progress[data-percent="7"] .label, .ui.indicating.progress[data-percent^="7."] .label,
+  .ui.indicating.progress[data-percent="8"] .label, .ui.indicating.progress[data-percent^="8."] .label,
+  .ui.indicating.progress[data-percent="9"] .label, .ui.indicating.progress[data-percent^="9."] .label {
     color: @indicatingFirstLabelColor;
   }
   & when (@variationProgressInverted) {
-    .ui.inverted.indicating.progress[data-percent="0"] .label,
-    .ui.inverted.indicating.progress[data-percent="1"] .label,
-    .ui.inverted.indicating.progress[data-percent="2"] .label,
-    .ui.inverted.indicating.progress[data-percent="3"] .label,
-    .ui.inverted.indicating.progress[data-percent="4"] .label,
-    .ui.inverted.indicating.progress[data-percent="5"] .label,
-    .ui.inverted.indicating.progress[data-percent="6"] .label,
-    .ui.inverted.indicating.progress[data-percent="7"] .label,
-    .ui.inverted.indicating.progress[data-percent="8"] .label,
-    .ui.inverted.indicating.progress[data-percent="9"] .label {
+    .ui.inverted.indicating.progress[data-percent="0"] .label, .ui.inverted.indicating.progress[data-percent^="0."] .label,
+    .ui.inverted.indicating.progress[data-percent="1"] .label, .ui.inverted.indicating.progress[data-percent^="1."] .label,
+    .ui.inverted.indicating.progress[data-percent="2"] .label, .ui.inverted.indicating.progress[data-percent^="2."] .label,
+    .ui.inverted.indicating.progress[data-percent="3"] .label, .ui.inverted.indicating.progress[data-percent^="3."] .label,
+    .ui.inverted.indicating.progress[data-percent="4"] .label, .ui.inverted.indicating.progress[data-percent^="4."] .label,
+    .ui.inverted.indicating.progress[data-percent="5"] .label, .ui.inverted.indicating.progress[data-percent^="5."] .label,
+    .ui.inverted.indicating.progress[data-percent="6"] .label, .ui.inverted.indicating.progress[data-percent^="6."] .label,
+    .ui.inverted.indicating.progress[data-percent="7"] .label, .ui.inverted.indicating.progress[data-percent^="7."] .label,
+    .ui.inverted.indicating.progress[data-percent="8"] .label, .ui.inverted.indicating.progress[data-percent^="8."] .label,
+    .ui.inverted.indicating.progress[data-percent="9"] .label, .ui.inverted.indicating.progress[data-percent^="9."] .label {
       color: @invertedIndicatingFirstLabelColor;
     }
   }

--- a/src/definitions/modules/progress.less
+++ b/src/definitions/modules/progress.less
@@ -198,9 +198,9 @@
   }
   .ui.indicating.progress[data-percent="0"] .label, .ui.indicating.progress[data-percent^="0."] .label,
   .ui.indicating.progress[data-percent="1"] .label, .ui.indicating.progress[data-percent^="1."] .label,
-  .ui.indicating.progress[data-percent="4"] .label, .ui.indicating.progress[data-percent^="4."] .label,
   .ui.indicating.progress[data-percent="2"] .label, .ui.indicating.progress[data-percent^="2."] .label,
   .ui.indicating.progress[data-percent="3"] .label, .ui.indicating.progress[data-percent^="3."] .label,
+  .ui.indicating.progress[data-percent="4"] .label, .ui.indicating.progress[data-percent^="4."] .label,
   .ui.indicating.progress[data-percent="5"] .label, .ui.indicating.progress[data-percent^="5."] .label,
   .ui.indicating.progress[data-percent="6"] .label, .ui.indicating.progress[data-percent^="6."] .label,
   .ui.indicating.progress[data-percent="7"] .label, .ui.indicating.progress[data-percent^="7."] .label,


### PR DESCRIPTION
## Description
[Progress bar] indicating `background-color` is incorrect when `data-percent` have decimal number.
This problem only occur when the data-number have decimal and under 10.

## Testcase
https://jsfiddle.net/dutrieux/xoz2L4sw/

## Screenshot
![bug](https://user-images.githubusercontent.com/1622751/79748042-003c8080-830d-11ea-8872-08c82c824e3d.gif)
