### PR TITLE
[modal] Add option to disable clicking the dimmer calling hideAll when allowMultiple = true

### DIFF
--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -313,7 +313,7 @@ $.fn.modal = function(parameters) {
             ;
             if(!isInModal && isInDOM && module.is.active() && $module.hasClass(className.front) ) {
               module.debug('Dimmer clicked, hiding all modals');
-              if(settings.allowMultiple) {
+              if(settings.allowMultiple && settings.multipleHideAll) {
                 if(!module.hideAll()) {
                   return;
                 }
@@ -1133,6 +1133,7 @@ $.fn.modal.settings = {
   observeChanges : false,
 
   allowMultiple  : false,
+  multipleHideAll: true,
   detachable     : true,
   closable       : true,
   autofocus      : true,


### PR DESCRIPTION
<!--
 Please read our Contributing Guide and Code of Conduct before you
 submit a pull request.
  
 Contributing Guide: https://github.com/fomantic/Fomantic-UI/blob/master/CONTRIBUTING.md
 Code of Conduct: https://github.com/fomantic/Fomantic-UI/blob/master/CODE_OF_CONDUCT.md

 ----

 Please use the following pull request title format:
 "[<scope>] <summary of what you fixed/changed>"
-->

## Description
<!-- Describe what you fixed/changed in great detail (required). -->
Add a new option, multipleHideAll, which when false makes clicking the dimmer when multiple modals have allowMultiple = true hide only the modal at the front. When true (the default) the previous behavior is used, i.e. hiding all of the open modals. 

## Testcase
I couldn't figure out how to create a testcase on JSFiddle but I tested it locally and it worked. 

## Closes
<!--
  List all the issues this pull request closes (only if it does).
-->
#1437
