### PR TITLE
[Calendar] Fix the popup show function getting called twice

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -440,7 +440,6 @@ $.fn.calendar = function(parameters) {
               $input.on('input' + eventNamespace, module.event.inputChange);
               $input.on('focus' + eventNamespace, module.event.inputFocus);
               $input.on('blur' + eventNamespace, module.event.inputBlur);
-              $input.on('click' + eventNamespace, module.event.inputClick);
               $input.on('keydown' + eventNamespace, module.event.keydown);
             } else {
               $container.on('keydown' + eventNamespace, module.event.keydown);
@@ -569,9 +568,6 @@ $.fn.calendar = function(parameters) {
               var text = formatter.datetime(date, settings);
               $input.val(text);
             }
-          },
-          inputClick: function () {
-            module.popup('show');
           }
         },
 

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -116,6 +116,7 @@ $.fn.calendar = function(parameters) {
               module.set.maxDate($module.data(metadata.maxDate));
             }
             module.setting('type', module.get.type());
+            module.setting('on', settings.on || ($input.length ? 'focus' : 'click'));
           },
           popup: function () {
             if (settings.inline) {
@@ -159,7 +160,7 @@ $.fn.calendar = function(parameters) {
               module.set.mode(settings.startMode);
               return settings.onShow.apply($container, arguments);
             };
-            var on = settings.on || ($input.length ? 'focus' : 'click');
+            var on = module.setting('on');
             var options = $.extend({}, settings.popupOptions, {
               popup: $container,
               on: on,
@@ -795,6 +796,9 @@ $.fn.calendar = function(parameters) {
               //if this is a range calendar, focus the container or input. This will open the popup from its event listeners.
               var endModule = module.get.calendarModule(settings.endCalendar);
               if (endModule) {
+                if (endModule.setting('on') !== 'focus') {
+                  endModule.popup('show');
+                }
                 endModule.focus();
               }
             }

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -792,10 +792,9 @@ $.fn.calendar = function(parameters) {
             var canceled = module.set.date(date) === false;
             if (!canceled && settings.closable) {
               module.popup('hide');
-              //if this is a range calendar, show the end date calendar popup and focus the input
+              //if this is a range calendar, focus the container or input. This will open the popup from its event listeners.
               var endModule = module.get.calendarModule(settings.endCalendar);
               if (endModule) {
-                endModule.popup('show');
                 endModule.focus();
               }
             }


### PR DESCRIPTION
## Description
This PR fixes an issue where the popup would be called to be shown twice because the two modules are listening to the events to show the popup when only one should be. I've thus removed the calendar's listeners since the popup ones that should be expected.

This PR also fixes the end calendars' popup which were also getting called to be shown twice when using the default settings for input calendars. The calendar module was focusing the input which is triggering the focus event that is also listened by the popup module. With this PR, the popup's show method is called only if the listener is not on focus, so that the input can still be focused.

This can be a big performance issue on heavy DOM trees as the popup position calculation is very heavy.

## Testcase
https://jsfiddle.net/8qyenza2/8/

## Screenshots
#### Example of when it slows down the whole page because of the two simultaneous calls
![](https://i.imgur.com/dt8K3ff.png)

#### Fiddle console result (with the fix implemented)
![](https://i.imgur.com/yJUC71w.png)

## Closes
None