### PR TITLE
[Build] Support gulp calls to find semantic.json from outside fomantic folder

### DIFF
--- a/tasks/config/user.js
+++ b/tasks/config/user.js
@@ -28,7 +28,7 @@ var
 
 try {
   // looks for config file across all parent directories
-  userConfig = requireDotFile('semantic.json');
+  userConfig = requireDotFile('semantic.json', process.cwd());
 }
 catch(error) {
   if(error.code === 'MODULE_NOT_FOUND') {

--- a/tasks/install.js
+++ b/tasks/install.js
@@ -57,7 +57,7 @@ var
 module.exports = function (callback) {
 
   var
-    currentConfig = requireDotFile('semantic.json'),
+    currentConfig = requireDotFile('semantic.json', process.cwd()),
     manager       = install.getPackageManager(),
     rootQuestions = questions.root,
     installFolder = false,


### PR DESCRIPTION
## Description
In some situations (for example in yarn workspaces), mostly within custom build chains, the users semantic.json cannot be found because the requireDotFile starts from within the fomantic folder.
Instead , the second parameter should be given as `process.cwd()` to support starting the search in a different folder

Thanks to @JMS-1 for the solution, which i just adopted by this PR

## Closes
#1466 
