### PR TITLE
fix(build): double check for existing object property in tasks

### DIFF
--- a/tasks/config/tasks.js
+++ b/tasks/config/tasks.js
@@ -105,7 +105,7 @@ module.exports = {
             theme,
             element
           ;
-          if(error.filename.match(/theme.less/)) {
+          if(error && error.filename && error.filename.match(/theme.less/)) {
             if (error.line == 9) {
               element = regExp.variable.exec(error.message)[1];
               if (element) {


### PR DESCRIPTION
## Description
In case of errors in less compilation in tasks.js a proper check for an existing filename property is not given and breaks when it's undefined

## Closes
#1463 