### PR TITLE
[Dropdown]: Initial preselected values trigger onchange event

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -117,7 +117,9 @@ $.fn.dropdown = function(parameters) {
             module.setup.layout();
 
             if(settings.values) {
+              module.set.initialLoad();
               module.change.values(settings.values);
+              module.remove.initialLoad();
             }
 
             module.refreshData();


### PR DESCRIPTION
## Description
When `values` are given on initialization of a dropdown, all entries which have a `selected` attribute set will trigger the `onChange` event

The already existing `fireOnChange` setting does not cover this situation to prevent the callback.
In comparison: When a dropdown is just converted from a select and those option values do also have the `selected` property set, then the onchange does not happen, so the behavior  does not match, but should.

## Testcase

### Broken
The second dropdown (which uses the `values` setting) will trigger the onChange event two times on initialization because of the two preseleced values.
https://jsfiddle.net/7g2ywtfc/

### Fixed
Both dropdowns won't trigger the onChange event on initialization
https://jsfiddle.net/7g2ywtfc/1/

## Closes
#1470 
