### PR TITLE
[Tab] Make auto activation of tabs optional

### DIFF
--- a/src/definitions/modules/tab.js
+++ b/src/definitions/modules/tab.js
@@ -102,7 +102,7 @@ $.fn.tab = function(parameters) {
 
           if(settings.autoTabActivation && instance === undefined && module.determine.activeTab() == null) {
             module.debug('No active tab detected, setting first tab active', module.get.initialPath());
-            module.changeTab(module.get.initialPath());
+            module.changeTab(settings.autoTabActivation === true ? module.get.initialPath() : settings.autoTabActivation);
           };
 
           module.instantiate();

--- a/src/definitions/modules/tab.js
+++ b/src/definitions/modules/tab.js
@@ -100,7 +100,7 @@ $.fn.tab = function(parameters) {
             initializedHistory = true;
           }
 
-          if(instance === undefined && module.determine.activeTab() == null) {
+          if(settings.autoTabActivation && instance === undefined && module.determine.activeTab() == null) {
             module.debug('No active tab detected, setting first tab active', module.get.initialPath());
             module.changeTab(module.get.initialPath());
           };
@@ -953,6 +953,7 @@ $.fn.tab.settings = {
 
   apiSettings     : false,      // settings for api call
   evaluateScripts : 'once',     // whether inline scripts should be parsed (true/false/once). Once will not re-evaluate on cached content
+  autoTabActivation: true,      // whether a non existing active tab will auto activate the first available tab
 
   onFirstLoad : function(tabPath, parameterArray, historyEvent) {}, // called first time loaded
   onLoad      : function(tabPath, parameterArray, historyEvent) {}, // called on every load


### PR DESCRIPTION
## Description
The implemented auto activation of tabs when no active tab is found #977 #1025 lead into some situations where a manual set of the active tab does not work anymore and always the last tab was selected. 
This especially happens when tabs are initialized separately. Such situations need the old until FUI 2.7.7 which did not check for existing active tabs at all

This PR adds a new option `autoTabActivation` (default true to avoid being a breaking change within the 2.8.x branch)
When set to false the behavior is the same as until 2.7.7
When set to a string and no active tab exists, it will use that string as the path name for the tab to be activated.


## Testcase
The third tab is supposed to be active

### Broken
The last initiated tab is selected
https://jsfiddle.net/z632cfq5

### Fixed
The previous selected tab stays selected
https://jsfiddle.net/z632cfq5/1/

## Closes
#1255 
#1188
https://github.com/atk4/ui/issues/1044