### PR TITLE
fix(dimmer): page dimmer in firefox results in misaligned modals

### DIFF
--- a/src/definitions/modules/dimmer.less
+++ b/src/definitions/modules/dimmer.less
@@ -151,6 +151,9 @@
     transform-style: @transformStyle;
     perspective: @perspective;
     transform-origin: center center;
+    &.modals {
+      -moz-perspective: none;
+    }
   }
 }
 


### PR DESCRIPTION
## Description
Firefox messes around with (large) modals in certain situations. For example when trying to drag inside an input inside a modal, it scrolls to the top of the modal. Even worse on Mac where the whole modals overlays other div containers...

Reason for this is the `perspective` setting for the page dimmer. It seems this was introduced some years back to also fix some firefox issues, so i don't dare to remove this setting completely to avoid possible other, currently unknown, issues in probably other browsers as well.

## Testcase
- Try to drag in the below input inside of the modal

### Broken (in Firefox only)
- The modal scrolls to the top (on macos it also overlaps the upper CSS container of jsfiddle (tried using browerstack)
https://jsfiddle.net/hzk7vwa4/7/

### Fixed
- Nothing happens even in Firefox now
https://jsfiddle.net/hy2fzkca/

## Closes
#1490 