### PR TITLE
[Calendar ]Fix timezone issue when time is not given and fix json dates for Firefox

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -1342,16 +1342,20 @@ $.fn.calendar.settings = {
       if (!text) {
         return null;
       }
-      text = ('' + text).trim().toLowerCase();
+      text = String(text).trim();
       if (text.length === 0) {
         return null;
       }
+      if(text.match(/^[0-9]{4}[\/\-\.][0-9]{2}[\/\-\.][0-9]{2}$/)){
+        text += ' 00:00:00';
+      }
       // Reverse date and month in some cases
-      text = settings.monthFirst ? text : text.replace(/[\/\-\.]/g,'/').replace(/([0-9]+)\/([0-9]+)/,'$2/$1');
+      text = settings.monthFirst || !text.match(/^[0-9]{2}[\/\-\.]/) ? text : text.replace(/[\/\-\.]/g,'/').replace(/([0-9]+)\/([0-9]+)/,'$2/$1');
       var textDate = new Date(text);
       if(!isNaN(textDate.getDate())) {
         return textDate;
       }
+      text = text.toLowerCase();
 
       var i, j, k;
       var minute = -1, hour = -1, day = -1, month = -1, year = -1;


### PR DESCRIPTION
## Description
When using JSON dates (YYYY-MM-DD**T**HH:II:SS) Firefox parses those dates wrong, because the 'T' gets lowercased and Firefox does not support that
Additionally when living in areas with a large timezone difference Javascript does not always return the correct Date when only "2020-05-11" is given, but the current timezone already is beyond the current day resulting in 2020-05-12 instead. 
To fix this i added a fixed midnight time in case dateonly pickers are used with format YYYY-MM-DD, so the resulting JS Date will always return the exact date that was provided to the calendar module.

## Testcase
https://jsfiddle.net/8b3rta4u/

## Closes
#1462 
