### PR TITLE
[Grid] Fix very compact grid

### DIFF
--- a/src/definitions/collections/grid.less
+++ b/src/definitions/collections/grid.less
@@ -1906,25 +1906,25 @@ each(@colors, {
       Very compact
   -----------------*/
 
-  .ui[class*="very compact"].grid > .column:not(.row),
-  .ui[class*="very compact"].grid > .row > .column {
+  .ui.ui.ui[class*="very compact"].grid > .column:not(.row),
+  .ui.ui.ui[class*="very compact"].grid > .row > .column {
     padding-left: (@veryCompactGutterWidth / 2);
-    padding-right: (@compactGutterWidth / 2);
+    padding-right: (@veryCompactGutterWidth / 2);
   }
 
-  .ui[class*="very compact"].grid > * {
+  .ui.ui.ui[class*="very compact"].grid > * {
     padding-left: (@veryCompactGutterWidth / 2);
     padding-right: (@veryCompactGutterWidth / 2);
   }
 
   /* Row */
-  .ui[class*="very compact"].grid > .row {
+  .ui.ui.ui[class*="very compact"].grid > .row {
     padding-top: (@veryCompactRowSpacing / 2);
     padding-bottom: (@veryCompactRowSpacing / 2);
   }
 
   /* Columns */
-  .ui[class*="very compact"].grid > .column:not(.row) {
+  .ui.ui.ui[class*="very compact"].grid > .column:not(.row) {
     padding-top: (@veryCompactRowSpacing / 2);
     padding-bottom: (@veryCompactRowSpacing / 2);
   }

--- a/src/definitions/collections/grid.less
+++ b/src/definitions/collections/grid.less
@@ -1921,6 +1921,8 @@ each(@colors, {
   .ui.ui.ui[class*="very compact"].grid > .row {
     padding-top: (@veryCompactRowSpacing / 2);
     padding-bottom: (@veryCompactRowSpacing / 2);
+    padding-left: (@veryCompactGutterWidth * 1.5);
+    padding-right: (@veryCompactGutterWidth * 1.5);
   }
 
   /* Columns */


### PR DESCRIPTION
The padding rules weren't specific enough, so they were always overruled by those of compact grid.

Also padding-right on line 1912 contained an incorrect placeholder.

## Description

The padding rules weren't specific enough, so they were always overruled by those of compact grid.

In addition, the row of a very compact grid didn't reveive any padding left and right, which broke alignment with other items in the same container.

Also padding-right on line 1912 contained an incorrect placeholder.

## Testcase

Here you can see that 'compact' and 'very compact' have exactly the same padding:
https://jsfiddle.net/x7tzkghc/

Here the correct padding is applied, but row padding is out of line:
https://jsfiddle.net/ob1vgm5u/

Final fix, with additional padding for row:
https://jsfiddle.net/ob1vgm5u/1/
