### PR TITLE
[dropdown] Fix a sizer element being created every time dropdown is initialized

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -4035,7 +4035,7 @@ $.fn.dropdown.settings = {
     message      : '.message',
     menuIcon     : '.dropdown.icon',
     search       : 'input.search, .menu > .search > input, .menu input.search',
-    sizer        : '> input.sizer',
+    sizer        : '> span.sizer',
     text         : '> .text:not(.icon)',
     unselectable : '.disabled, .filtered',
     clearIcon    : '> .remove.icon'


### PR DESCRIPTION
## Description
This PR ensures that a dropdown has only one sizer element no matter how many times it is initialized.

It looks like `!module.has.sizer()` of [this line](https://github.com/fomantic/Fomantic-UI/blob/master/src/definitions/modules/dropdown.js#L360) already ensures it, but actually does not. `$sizer.length > 0` inside `has.sizer()` always returns `false` because `sizer.selector` is `> input.sizer` even though the sizer element is created as `span` element (I think `> span.sizer` is needed instead of `> input.sizer`).

I'm not 100% sure whether this is a bug, so feel free to close this PR if anything is wrong.
## Testcase

Both test cases initialize the dropdown twice.
Try to see how many sizer elements are created via your developer tool.

### Broken

* Two sizer elements are created
https://jsfiddle.net/c5oz8fhk/

### Fixed

* Only one sizer element is created
https://jsfiddle.net/yz8ptx21/

## Closes
no-issue
