### PR TITLE
fix(build): missing extra parameter for current directory in release task leads into missing build number

### DIFF
--- a/tasks/config/project/release.js
+++ b/tasks/config/project/release.js
@@ -15,7 +15,7 @@ var
 *******************************/
 
 try {
-  config = requireDotFile('semantic.json');
+  config = requireDotFile('semantic.json', process.cwd());
 }
 catch(error) {}
 


### PR DESCRIPTION
## Description
By #1467 we added the current directory location. The release task was still missing that extra parameter. According to @JMS-1 this lead into a missing version number in semantic.json when the release is build locally from a different path

## Closes
#1498 