### PR TITLE
[Icon,Text] Fix vertical alignment

### DIFF
--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -288,8 +288,7 @@ each(@colors, {
 i.icon,
 i.icons {
   font-size: @medium;
-  line-height: 1;
-  vertical-align: middle;
+  line-height: @lineHeight;
 }
 & when not (@variationIconSizes = false) {
   each(@variationIconSizes, {
@@ -297,6 +296,7 @@ i.icons {
     i.@{value}.@{value}.@{value}.icon,
     i.@{value}.@{value}.@{value}.icons {
       font-size: @s;
+      vertical-align: middle;
     }
   })
 }

--- a/src/definitions/elements/text.less
+++ b/src/definitions/elements/text.less
@@ -22,6 +22,9 @@
 /*******************************
              Text
 *******************************/
+span.ui.text {
+  line-height: @lineHeight;
+}
 
 each(@colors, {
   @color: replace(@key, '@', '');

--- a/src/themes/default/elements/icon.variables
+++ b/src/themes/default/elements/icon.variables
@@ -53,6 +53,7 @@
 @width: @iconWidth;
 @height: 1em;
 @distanceFromText: 0.25rem;
+@lineHeight: 1;
 
 
 /* Variations */

--- a/src/themes/default/elements/text.variables
+++ b/src/themes/default/elements/text.variables
@@ -5,6 +5,8 @@
 /*-------------------
        Element
 --------------------*/
+@lineHeight: 1;
+
 @mini: 0.4em;
 @tiny: 0.5em;
 @small: 0.75em;


### PR DESCRIPTION
## Description
This PR corrects/partly reverts the vertical alignment of unsized icons of #1372 which unfortunately breaks the vertical alignment in most cases when icons are just used beside inline texts which is probably the most used case.
I obviously hadn't really tested the old PR 🙄

While testing this now, i also recognized the `text` element needs the same line-height setting to avoid overlapping which is also fixed now.

## Testcase
### Broken
https://jsfiddle.net/usfh3tpw/2/

### Fixed
https://jsfiddle.net/usfh3tpw/3/
## Screenshot
### Icon Alignment
#### 2.8.4 
![image](https://user-images.githubusercontent.com/18379884/83912370-0c21bc00-a76e-11ea-87db-1cb6df0c69ab.png)

#### 2.8.5 Broken
![image](https://user-images.githubusercontent.com/18379884/83912425-25c30380-a76e-11ea-9e03-b9b316a7f006.png)

#### 2.8.5 Fixed
![image](https://user-images.githubusercontent.com/18379884/83912487-383d3d00-a76e-11ea-931d-65b85682cc01.png)

### Text Height
#### Broken
![image](https://user-images.githubusercontent.com/18379884/83912832-cca79f80-a76e-11ea-809f-84c8ec15f09c.png)

#### Fixed
![image](https://user-images.githubusercontent.com/18379884/83912969-0f697780-a76f-11ea-9bcd-62c7b40f9730.png)

## Closes
https://github.com/go-gitea/gitea/pull/11767
#1371
