### PR TITLE
fix(dropdown): fix some bugs introduce by the previous commit (#1473)

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -318,9 +318,10 @@
 }
 
 /* Automatically float dropdown menu right on last menu item */
-.ui.menu .right.menu .dropdown:last-child .menu:not(.left),
-.ui.menu .right.dropdown.item .menu:not(.left),
-.ui.buttons > .ui.dropdown:last-child .menu:not(.left) {
+.ui.menu .right.menu .dropdown:last-child > .menu:not(.left),
+.ui.menu .right.dropdown.item > .menu:not(.left),
+.ui.buttons > .ui.dropdown:last-child > .menu:not(.left) {
+  left: auto;
   right: 0;
 }
 
@@ -1096,7 +1097,7 @@ select.ui.dropdown {
 
   .ui.dropdown > .left.menu .menu,
   .ui.dropdown .menu .left.menu {
-    left: auto !important;
+    left: auto;
     right: 100%;
     margin: @leftSubMenuMargin !important;
     border-radius: @leftSubMenuBorderRadius !important;
@@ -1324,6 +1325,13 @@ select.ui.dropdown {
     top: 0 !important;
     left: 100%;
     opacity: 1;
+  }
+  .ui.simple.dropdown > .menu > .item:active > .left.menu,
+  .ui.simple.dropdown .menu .item:hover > .left.menu, 
+  .right.menu .ui.simple.dropdown > .menu > .item:active > .menu:not(.right), 
+  .right.menu .ui.simple.dropdown > .menu .item:hover > .menu:not(.right) {
+    left: auto;
+    right: 100%;
   }
   & when (@variationDropdownDisabled) {
     .ui.simple.disabled.dropdown:hover .menu {

--- a/src/themes/default/modules/dropdown.variables
+++ b/src/themes/default/modules/dropdown.variables
@@ -68,7 +68,7 @@
 @subMenuLeft: 100%;
 @subMenuRight: auto;
 @subMenuDistanceAway: -0.5em;
-@subMenuMargin: 0 0 0 @subMenuDistanceAway;
+@subMenuMargin: 0 @subMenuDistanceAway;
 @subMenuBorderRadius: @borderRadius;
 @subMenuZIndex: 21;
 


### PR DESCRIPTION
## Description
This PR fixes the first level of simple dropdown inside the right menu was cropped and out of the screen when the parent menu item has short text, and the dropdown doesn't specify the class name `left`.

To avoid this, all dropdown inside the right menu will be forced to appear leftward by default. The dropdown can also appear leftward or rightward by having `left` or `right` class name for it's nested dropdown menus.

This PR also fix the dropdown inside the buttons which are positioned incorrectly.

## Testcase
### Broken
https://jsfiddle.net/18jogrs9/
https://jsfiddle.net/usfh3tpw/1/

### Fixed
https://jsfiddle.net/ymo0f9st/

## Closes
#1502
#1514 
