### PR TITLE
[Label] Basic Labels had different height and adjusted (attached) image labels 

### DIFF
--- a/src/definitions/elements/label.less
+++ b/src/definitions/elements/label.less
@@ -174,7 +174,7 @@ a.ui.label {
 .ui.segment:not(.basic) > .ui.bottom.attached.label {
   margin-bottom: @attachedOffset;
 }
-.ui.segment:not(.basic) > .ui.left.attached.label {
+.ui.segment:not(.basic) > .ui.attached.label:not(.right) {
   margin-left: @attachedOffset;
 }
 .ui.segment:not(.basic) > .ui.right.attached.label {

--- a/src/definitions/elements/label.less
+++ b/src/definitions/elements/label.less
@@ -222,6 +222,17 @@ a.ui.label {
     padding: @imageLabelDetailPadding;
     border-radius: 0 @imageLabelBorderRadius @imageLabelBorderRadius 0;
   }
+  & when (@variationLabelAttached) {
+    .ui.bottom.attached.image.label:not(.right) > img,
+    .ui.top.right.attached.image.label > img {
+      border-top-left-radius: 0;
+    }
+
+    .ui.top.attached.image.label:not(.right) > img,
+    .ui.bottom.right.attached.image.label > img {
+      border-bottom-left-radius: 0;
+    }
+  }
 }
 
 & when (@variationLabelTag) {
@@ -503,7 +514,7 @@ a.ui.label {
 
   .ui[class*="top left attached"].label {
     width: auto;
-    margin-top: 0 !important;
+    margin-top: 0;
     border-radius: @attachedCornerBorderRadius 0 @attachedBorderRadius 0;
   }
 

--- a/src/definitions/elements/label.less
+++ b/src/definitions/elements/label.less
@@ -168,6 +168,23 @@ a.ui.label {
   margin-bottom: @attachedSegmentPadding !important;
 }
 
+.ui.segment:not(.basic) > .ui.top.attached.label {
+  margin-top: @attachedOffset;
+}
+.ui.segment:not(.basic) > .ui.bottom.attached.label {
+  margin-bottom: @attachedOffset;
+}
+.ui.segment:not(.basic) > .ui.left.attached.label {
+  margin-left: @attachedOffset;
+}
+.ui.segment:not(.basic) > .ui.right.attached.label {
+  margin-right: @attachedOffset;
+}
+.ui.segment:not(.basic) > .ui.attached.label:not(.left):not(.right) {
+  width: @attachedWidthOffset;
+}
+
+
 
 /*******************************
              Types

--- a/src/definitions/elements/label.less
+++ b/src/definitions/elements/label.less
@@ -174,7 +174,7 @@ a.ui.label {
 *******************************/
 & when (@variationLabelImage) {
   .ui.image.label {
-    width: auto !important;
+    width: auto;
     margin-top: 0;
     margin-bottom: 0;
     max-width: 9999px;
@@ -185,6 +185,9 @@ a.ui.label {
     padding: @imageLabelPadding;
     border-radius: @imageLabelBorderRadius;
     box-shadow: @imageLabelBoxShadow;
+    &.attached:not(.basic) when (@variationLabelAttached) {
+      padding: @imageLabelPadding;
+    }
   }
 
   .ui.image.label img {
@@ -610,6 +613,18 @@ a.ui.active.label:hover:before {
     border: @basicBorder;
     color: @basicColor;
     box-shadow: @basicBoxShadow;
+    padding-top: @basicVerticalPadding;
+    padding-bottom: @basicVerticalPadding;
+    padding-right: @basicHorizontalPadding;
+  }
+  .ui.basic.labels:not(.tag):not(.image):not(.ribbon) .label,
+  .ui.basic.label:not(.tag):not(.image):not(.ribbon) {
+    padding-left: @basicHorizontalPadding;
+  }
+  & when (@variationLabelImage) {
+    .ui.basic.image.label {
+      padding-left: @basicImageLabelPadding;
+    }
   }
 
   /* Link */

--- a/src/themes/default/elements/label.variables
+++ b/src/themes/default/elements/label.variables
@@ -116,6 +116,10 @@
 @basicHoverBorder: @basicBorder;
 @basicHoverBoxShadow: @basicBoxShadow;
 
+@basicVerticalPadding: e(%("calc(%d - %d)", @verticalPadding, @basicBorderWidth));
+@basicHorizontalPadding: e(%("calc(%d - %d)", @horizontalPadding, @basicBorderWidth));
+@basicImageLabelPadding: e(%("calc(%d - %d)", @imageLabelTextDistance, @basicBorderWidth));
+
 /* Tag */
 @tagCircleColor: @white;
 @tagCircleSize: 0.5em;

--- a/src/themes/default/elements/label.variables
+++ b/src/themes/default/elements/label.variables
@@ -204,6 +204,9 @@
 @attachedCornerBorderRadius: @3px;
 @attachedBorderRadius: @borderRadius;
 
+@attachedOffset: -@borderWidth;
+@attachedWidthOffset: e(%("calc(100%% + %d)", @borderWidth * 2));
+
 /* Corner */
 @cornerSizeRatio: 1;
 @cornerTransition: color @labelTransitionDuration @labelTransitionEasing;


### PR DESCRIPTION
## Description
- `basic labels` have a border which increases the height in comparison to usual labels.
When inline together the line height gets increased
- Because of that, a `basic image label` was not properly supported
- All attached labels were not really attached to the boundary of a segment (as every other `attached` component is doing)  . That was especially visible when a `basic attached label` was used

## Testcase
### Before
Watch the height and width difference on basic labels as well as the misaligned image labels and unattached borders in attached labels
https://jsfiddle.net/lubber/wt0heq5k/60/

### After
https://jsfiddle.net/lubber/wt0heq5k/99/

## Screenshots
### Before
Watch the height and width difference on basic labels as well as the misaligned image labels and unattached borders in attached labels
![image](https://user-images.githubusercontent.com/18379884/83977589-e4635d00-a901-11ea-93b0-1e727d5afc88.png)
![image](https://user-images.githubusercontent.com/18379884/83982318-36b67500-a926-11ea-8912-911ba13832ca.png)
![image](https://user-images.githubusercontent.com/18379884/83982354-7d0bd400-a926-11ea-9f8e-701b393af601.png)


### After
![image](https://user-images.githubusercontent.com/18379884/83982306-1d152d80-a926-11ea-8a7d-635caed81bf0.png)
![image](https://user-images.githubusercontent.com/18379884/83982332-4e8df900-a926-11ea-8f48-d2f23c73eaab.png)
![image](https://user-images.githubusercontent.com/18379884/84023157-dfe18780-a987-11ea-9791-e74b9f288a5b.png)
![image](https://user-images.githubusercontent.com/18379884/84023174-e839c280-a987-11ea-97c3-69adcca734a1.png)



## Closes
#1430 
