### PR TITLE
[Calendar] Fix popup closing when the calendar event listener is not click

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -165,6 +165,7 @@ $.fn.calendar = function(parameters) {
               popup: $container,
               on: on,
               hoverable: on === 'hover',
+              closable: on !== 'focus',
               onShow: onShow,
               onVisible: onVisible,
               onHide: settings.onHide,

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -165,7 +165,7 @@ $.fn.calendar = function(parameters) {
               popup: $container,
               on: on,
               hoverable: on === 'hover',
-              closable: on !== 'focus',
+              closable: on === 'click',
               onShow: onShow,
               onVisible: onVisible,
               onHide: settings.onHide,


### PR DESCRIPTION
## Description

When the calendar module has its `on` option set to something else than `click`, the popup should not be closed when the user clicks elsewhere on the page.

For example, if the calendar is set to `hover`, the popup should close only if the user stops hovering the field/button, not when they click.

## Testcase

[Ly1ng3u0/5/](https://jsfiddle.net/Ly1ng3u0/5/)

## Closes

#1506
