### PR TITLE
[Slider] interpretLabel is undefined instead of false by default

### DIFF
--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -1271,6 +1271,7 @@ $.fn.slider.settings = {
   labelDistance    : 100,
   preventCrossover : true,
   fireOnInit       : false,
+  interpretLabel   : false,
 
   //the decimal place to round to if step is undefined
   decimalPlaces  : 2,


### PR DESCRIPTION
## Description
The `interpretLabel` setting is not defined as a settings property by default. It's also supposed to be `false` by default instead of `undefined` 

## Closes
#1526