### PR TITLE
[Calendar] Avoid unnecessary redraw which slows down the module

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -157,7 +157,7 @@ $.fn.calendar = function(parameters) {
             var onShow = function () {
               //reset the focus date onShow
               module.set.focusDate(module.get.date());
-              module.set.mode(settings.startMode);
+              module.set.mode(module.get.validatedMode(settings.startMode));
               return settings.onShow.apply($container, arguments);
             };
             var on = module.setting('on');
@@ -197,6 +197,7 @@ $.fn.calendar = function(parameters) {
               date = parser.date($input.val(), settings);
             }
             module.set.date(date, settings.formatInput, false);
+            module.set.mode(module.get.mode(), false);
           }
         },
 
@@ -622,6 +623,9 @@ $.fn.calendar = function(parameters) {
           mode: function () {
             //only returns valid modes for the current settings
             var mode = $module.data(metadata.mode) || settings.startMode;
+            return module.get.validatedMode(mode);
+          },
+          validatedMode: function(mode){
             var validModes = module.get.validModes();
             if ($.inArray(mode, validModes) >= 0) {
               return mode;
@@ -739,7 +743,7 @@ $.fn.calendar = function(parameters) {
                 module.set.monthOffset(monthOffset, false);
               }
             }
-            var changed = module.set.dataKeyValue(metadata.focusDate, date, refreshCalendar);
+            var changed = module.set.dataKeyValue(metadata.focusDate, date, !!date && refreshCalendar);
             updateFocus = (updateFocus !== false && changed && refreshCalendar === false) || focusDateUsedForRange != updateRange;
             focusDateUsedForRange = updateRange;
             if (updateFocus) {


### PR DESCRIPTION
## Description
Whenever a calendar popup is shown the calendar gets redrawn several times even if nothing was changed!

## Testcase
Open the console, i adjusted the 2.8.6 calendar as well as the fixed one to show a console.log whenever the calendar gets redrawn.
Click into the date field, but do not select anything. Instead click outside of the field, so the calendar closes again

### Broken
The calendar gets redrawn all the time. Even 2 times when no date was selected!
https://jsfiddle.net/lubber/gzsxr8t1/2/

### Fixed
The calendar only gets redrawn when something changed (date value, mode view (day/time))
https://jsfiddle.net/lubber/gzsxr8t1/3/

## Screenshots
### Broken
![calendarrefreshbroken](https://user-images.githubusercontent.com/18379884/85238329-8f5d3600-b42d-11ea-9b14-1416e41ca4b8.gif)

### Fixed
![calendarrefreshfixed](https://user-images.githubusercontent.com/18379884/85238338-9d12bb80-b42d-11ea-84f6-48e1997833dd.gif)

## Closes
https://github.com/mdehoog/Semantic-UI-Calendar/issues/130