### PR TITLE
[Menu] Fix icon group position and alignment in submenus

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -252,7 +252,8 @@
 .ui.menu .ui.dropdown.item .menu .item:not(.filtered) {
   display: block;
 }
-.ui.menu .ui.dropdown .menu > .item .icon:not(.dropdown) {
+.ui.menu .ui.dropdown .menu > .item > .icons,
+.ui.menu .ui.dropdown .menu > .item > .icon:not(.dropdown) {
   display: inline-block;
   font-size: @dropdownItemIconFontSize !important;
   float: @dropdownItemIconFloat;


### PR DESCRIPTION
## Description
When icon groups were used in submenus, they were wrongly positioned and the the icon group itself was totally messed up

## Testcase
https://jsfiddle.net/lubber/8bn2rqwt/21/

## Screenshot
![iconssubmenus](https://user-images.githubusercontent.com/18379884/85772840-87e3a880-b71d-11ea-89a9-0e5d99773418.gif)

## Closes
#936 