### PR TITLE
[Dropdown] HTML in placeholders was not preserved

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1772,7 +1772,7 @@ $.fn.dropdown = function(parameters) {
             return $module.data(metadata.placeholderText) || '';
           },
           text: function() {
-            return $text.text();
+            return settings.preserveHTML ? $text.html() : $text.text();
           },
           query: function() {
             return String($search.val()).trim();


### PR DESCRIPTION
## Description
If a placeholder text contained HTML (for example an icon) if was not remembered when reused (for example when the dropdown is cleared.

## Testcase
Select something, then clear it via Button.
### Broken
 The original placeholder misses the icon
https://jsfiddle.net/lubber/L8hof4jp/2/

### Fixed
The icon is preserved
https://jsfiddle.net/lubber/L8hof4jp/4/

## Screenshot
|Broken|Fixed|
|-|-|
|![htmlplaceholder_broken](https://user-images.githubusercontent.com/18379884/86036443-2c2b5f00-ba3e-11ea-862c-6cd8de3fe225.gif)|![htmlplaceholder_fixed](https://user-images.githubusercontent.com/18379884/86036453-32214000-ba3e-11ea-8204-ec3f3c321fd0.gif)|



## Closes
#1403 
