### PR TITLE
[Slider] operation sometimes returns not rounded value

### DIFF
--- a/dist/components/slider.js
+++ b/dist/components/slider.js
@@ -789,7 +789,6 @@ $.fn.slider = function(parameters) {
             }
             // Use precision to avoid ugly Javascript floating point rounding issues
             // (like 35 * .01 = 0.35000000000000003)
-            difference = Math.round(difference * precision) / precision;
             module.verbose('Cutting off additional decimal places');
             return Math.round((difference + module.get.min()) * precision) / precision;
           },

--- a/dist/components/slider.js
+++ b/dist/components/slider.js
@@ -791,7 +791,7 @@ $.fn.slider = function(parameters) {
             // (like 35 * .01 = 0.35000000000000003)
             difference = Math.round(difference * precision) / precision;
             module.verbose('Cutting off additional decimal places');
-            return difference + module.get.min();
+            return Math.round((difference + module.get.min()) * precision) / precision;
           },
           keyMovement: function(event) {
             var


### PR DESCRIPTION
## Description
I changed the return result, beacause of this https://floating-point-gui.de/
variables values where rounded when they arrive thanks to rounded difference, but the result of difference and module.get.min whas not rounded

## Testcase
Issue jsfiddle: https://jsfiddle.net/dfj7urbz/

## Closes
#1545
