### PR TITLE
fix(site): duplicatedVariables

### DIFF
--- a/src/themes/default/globals/site.variables
+++ b/src/themes/default/globals/site.variables
@@ -702,7 +702,6 @@
 @hoveredTextColor            : rgba(0, 0, 0, 0.8);
 @pressedTextColor            : rgba(0, 0, 0, 0.9);
 @selectedTextColor           : rgba(0, 0, 0, 0.95);
-@disabledTextColor           : rgba(0, 0, 0, 0.2);
 
 @invertedTextColor           : rgba(255, 255, 255, 0.9);
 @invertedMutedTextColor      : rgba(255, 255, 255, 0.8);
@@ -711,7 +710,6 @@
 @invertedHoveredTextColor    : rgba(255, 255, 255, 1);
 @invertedPressedTextColor    : rgba(255, 255, 255, 1);
 @invertedSelectedTextColor   : rgba(255, 255, 255, 1);
-@invertedDisabledTextColor   : rgba(255, 255, 255, 0.2);
 
 /*-------------------
      Brand Colors


### PR DESCRIPTION
## Description

Two variables for (inverted)disabledText are declared two times in the same file. I removed the first instance, because it was already always overridden by the same declaration  200 LOC later here
https://github.com/fomantic/Fomantic-UI/blob/0269a8213ac2ff438965c6a82503e7561d2024ae/src/themes/default/globals/site.variables#L990-L991

I know it's technically not necessary because the last declaration wins in LESS (that's the concept of the override-files), but to avoid confusion and satisfy reporting users i created this PR ;)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6990