### PR TITLE
[Dimmer] Support more background types than only color

### DIFF
--- a/src/definitions/modules/dimmer.less
+++ b/src/definitions/modules/dimmer.less
@@ -38,7 +38,7 @@
   vertical-align: @verticalAlign;
   padding: @padding;
 
-  background-color: @backgroundColor;
+  background: @backgroundColor;
   opacity: @hiddenOpacity;
   line-height: @lineHeight;
 
@@ -181,10 +181,10 @@ body.dimmable > .dimmer {
 
   /* Dimmer Color */
   .blurring.dimmable > .dimmer {
-    background-color: @blurredBackgroundColor;
+    background: @blurredBackgroundColor;
   }
   .blurring.dimmable > .inverted.dimmer {
-    background-color: @blurredInvertedBackgroundColor;
+    background: @blurredInvertedBackgroundColor;
   }
 }
 & when (@variationDimmerAligned) {
@@ -206,13 +206,13 @@ body.dimmable > .dimmer {
   ---------------*/
 
   .medium.medium.medium.medium.medium.dimmer {
-    background-color: @mediumBackgroundColor;
+    background: @mediumBackgroundColor;
   }
   .light.light.light.light.light.dimmer {
-    background-color: @lightBackgroundColor;
+    background: @lightBackgroundColor;
   }
   .very.light.light.light.light.dimmer {
-    background-color: @veryLightBackgroundColor;
+    background: @veryLightBackgroundColor;
   }
 }
 
@@ -222,7 +222,7 @@ body.dimmable > .dimmer {
   ---------------*/
 
   .ui.inverted.dimmer {
-    background-color: @invertedBackgroundColor;
+    background: @invertedBackgroundColor;
   }
   .ui.inverted.dimmer > .content,
   .ui.inverted.dimmer > .content > * {
@@ -235,13 +235,13 @@ body.dimmable > .dimmer {
     ---------------*/
 
     .medium.medium.medium.medium.medium.inverted.dimmer {
-      background-color: @mediumInvertedBackgroundColor;
+      background: @mediumInvertedBackgroundColor;
     }
     .light.light.light.light.light.inverted.dimmer {
-      background-color: @lightInvertedBackgroundColor;
+      background: @lightInvertedBackgroundColor;
     }
     .very.light.light.light.light.inverted.dimmer {
-      background-color: @veryLightInvertedBackgroundColor;
+      background: @veryLightInvertedBackgroundColor;
     }
   }
 }
@@ -259,22 +259,22 @@ body.dimmable > .dimmer {
     width: 0;
     height: 0;
     z-index: -100;
-    background-color: @simpleStartBackgroundColor;
+    background: @simpleStartBackgroundColor;
   }
   .dimmed.dimmable > .ui.simple.dimmer {
     overflow: visible;
     opacity: 1;
     width: 100%;
     height: 100%;
-    background-color: @simpleEndBackgroundColor;
+    background: @simpleEndBackgroundColor;
     z-index: @simpleZIndex;
   }
 
   .ui.simple.inverted.dimmer {
-    background-color: @simpleInvertedStartBackgroundColor;
+    background: @simpleInvertedStartBackgroundColor;
   }
   .dimmed.dimmable > .ui.simple.inverted.dimmer {
-    background-color: @simpleInvertedEndBackgroundColor;
+    background: @simpleInvertedEndBackgroundColor;
   }
 }
 

--- a/src/definitions/modules/sidebar.less
+++ b/src/definitions/modules/sidebar.less
@@ -162,7 +162,7 @@ body.pushable > .pusher {
   top: 0;
   right: 0;
   content: '';
-  background-color: @dimmerColor;
+  background: @dimmerColor;
   overflow: hidden;
   opacity: 0;
   transition: @dimmerTransition;

--- a/src/definitions/views/card.less
+++ b/src/definitions/views/card.less
@@ -343,7 +343,7 @@
 
 .ui.cards > .card .dimmer,
 .ui.card .dimmer {
-  background-color: @dimmerColor;
+  background: @dimmerColor;
   z-index: @dimmerZIndex;
 }
 


### PR DESCRIPTION
## Description

While i initially thought about implementing a new dimmer variant based on a different background, i tried to simply change the dimmer variables instead, so my idea would work by just creating a new theme.
However, as the dimmer currently only supports `background-color` this prevents to use an image or a radial gradient as dimmer background for the existing variables.
That said, this PR changes the `background-color` property to just `background` which is compatible with the default color value and allows for themes to use other other type of background than just the color.

Again: This PR does not change the default theme behavior, it just provides the possibility to use other background-types than just the color

## Screenshot
I adjusted this to my local docs page to test this and and as the background is nowhere overridden it works as before

### radial-gradient()
`@backgroundColor: radial-gradient(center,ellipse cover,rgba(0,0,0,0.7) 0,rgba(0,0,0,1) 100%);`
> Background looks a bit ugly because of gif color limit 🙄  

![dimmer_gradient](https://user-images.githubusercontent.com/18379884/86629140-3ebc1000-bfcb-11ea-8b06-1985b55bbea9.gif)

### image url()
`@backgroundColor: url('https://image.freepik.com/free-psd/banner-galaxy-abstract-background_47618-35.jpg');`
> Background looks a bit ugly because of gif color limit 🙄  Looks better in real life 😆 

![dimmer_image](https://user-images.githubusercontent.com/18379884/86629198-572c2a80-bfcb-11ea-9725-1c760bf21f75.gif)
