### PR TITLE
[Dimmer] opacity setting created invalid value on rgb background

### DIFF
--- a/src/definitions/modules/dimmer.js
+++ b/src/definitions/modules/dimmer.js
@@ -408,11 +408,11 @@ $.fn.dimmer = function(parameters) {
             var
               color      = $dimmer.css('background-color'),
               colorArray = color.split(','),
-              isRGB      = (colorArray && colorArray.length == 3),
-              isRGBA     = (colorArray && colorArray.length == 4)
+              isRGB      = (colorArray && colorArray.length >= 3)
             ;
             opacity    = settings.opacity === 0 ? 0 : settings.opacity || opacity;
-            if(isRGB || isRGBA) {
+            if(isRGB) {
+              colorArray[2] = colorArray[2].replace(')','');
               colorArray[3] = opacity + ')';
               color         = colorArray.join(',');
             }


### PR DESCRIPTION
## Description
When a dimmer already had a rgb background color, the `opacity` setting for the dimmer was not working because it created an invalid background color value .

Reason was because for a pure rgb value the third splitted string array element still had a closing parenthesis, which in turn created an invalid value like
```
rgba(111,111,111),0.1)
```

## Testcase
### Broken
https://jsfiddle.net/lubber/mt1cn3qp/13/

### Fixed
https://jsfiddle.net/lubber/mt1cn3qp/15/


## Screenshots
Given a
```
$('.ui.segment').dimmer({
  opacity: 0.3
})
```
### Before
![image](https://user-images.githubusercontent.com/18379884/87168848-64009500-c2cf-11ea-82ee-819a9719045b.png)

### After
![image](https://user-images.githubusercontent.com/18379884/87168782-4b907a80-c2cf-11ea-8c23-c46c4b30ae4f.png)
