### PR TITLE
[Calendar] Evenly divide column widths

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -42,7 +42,8 @@ $.fn.calendar = function(parameters) {
       '15': {'row': 2, 'column': 2 },
       '20': {'row': 3, 'column': 1 },
       '30': {'row': 2, 'column': 1 }
-    }
+    },
+    numberText = ['','one','two','three','four','five','six','seven','eight']
   ;
 
   $allModules
@@ -279,7 +280,7 @@ $.fn.calendar = function(parameters) {
               if (isDay && settings.showWeekNumbers){
                 tempMode += ' andweek';
               }
-              var table = $('<table/>').addClass(className.table).addClass(tempMode).appendTo(container);
+              var table = $('<table/>').addClass(className.table).addClass(tempMode).addClass(numberText[columns] + ' column').appendTo(container);
               var textColumns = columns;
               //no header for time-only mode
               if (!isTimeOnly) {


### PR DESCRIPTION
## Description
The calendar columns are not evenly divided, which this PR fixes by adding the [column count](https://fomantic-ui.com/collections/table.html#column-count) classnames to the calendars table.
This is especially visible when using an inline calendar: Monday and Wednesday are much wider than the other columns.

## Testcase
### Before
https://jsfiddle.net/lubber/5u1Lft84/1/
### After
https://jsfiddle.net/lubber/5u1Lft84/2/

## Screenshot
### Before
![image](https://user-images.githubusercontent.com/18379884/87200903-dd16e100-c2fd-11ea-9f9e-ded44503a71d.png)

### After
![image](https://user-images.githubusercontent.com/18379884/87200881-cff9f200-c2fd-11ea-80d3-6b3d6579044c.png)
