### PR TITLE
[Text] support state colors

### DIFF
--- a/src/definitions/elements/text.less
+++ b/src/definitions/elements/text.less
@@ -41,6 +41,17 @@ each(@colors, {
   }
 })
 
+& when (@variationTextStates) {
+  each(@textStates, {
+    @state: replace(@key, '@', '');
+    @c: @textStates[@@state][color];
+
+    span.ui.@{state}.text {
+      color: @c;
+    }
+  })
+}
+
 & when (@variationTextDisabled) {
   span.ui.disabled.text {
     opacity: @disabledOpacity;

--- a/src/themes/default/globals/colors.less
+++ b/src/themes/default/globals/colors.less
@@ -598,3 +598,18 @@
     transparentColor: @transparentFormWarningColor;
   };
 }
+
+@textStates: {
+  @error: {
+    color: @negativeColor;
+  };
+  @info: {
+    color: @infoColor;
+  };
+  @success: {
+    color: @positiveColor;
+  };
+  @warning: {
+    color: @warningColor;
+  };
+}

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -207,6 +207,7 @@
 /* Text */
 @variationTextInverted: true;
 @variationTextDisabled: true;
+@variationTextStates: true;
 @variationTextSizes: @variationAllSizes;
 
 


### PR DESCRIPTION
## Description
For consistency with other elements like form/button/label, etc. this PR adds the states `info`, `success`, `warning`, `error` to the `text` element. 

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/87222865-fe1c1800-c377-11ea-974c-80c44cd7c890.png)
