### PR TITLE
[Calendar] Chrome chooses wrong hour on time-only calendar

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -1357,7 +1357,8 @@ $.fn.calendar.settings = {
       // Reverse date and month in some cases
       text = settings.monthFirst || !text.match(/^[0-9]{2}[\/\-\.]/) ? text : text.replace(/[\/\-\.]/g,'/').replace(/([0-9]+)\/([0-9]+)/,'$2/$1');
       var textDate = new Date(text);
-      if(!isNaN(textDate.getDate())) {
+      var numberOnly = text.match(/^[0-9]+$/) !== null;
+      if(!numberOnly && !isNaN(textDate.getDate())) {
         return textDate;
       }
       text = text.toLowerCase();


### PR DESCRIPTION
## Description
<!-- Describe what you fixed/changed in great detail (required). -->

https://github.com/fomantic/Fomantic-UI/blob/0269a8213ac2ff438965c6a82503e7561d2024ae/src/definitions/modules/calendar.js#L1355-L1358
The above code expects parsing on partial input, e.g. `1`, to be failed on `new Date("1")`.
However, there are incosintency between browsers on how `new Date` consturctor or `Date.parse` works.

input    | Chrome | Firefox
---|----------|--------
new Date("1") | success | invalid 
new Date("10") | success | invalid  
new Date("100") | success | invalid  
new Date("1000") | success | success 
 
On Chrome,  `new Date("1")` or such can create instance of Date.
So, `getDate` is a number, then hour is not chosen correctly.

This PR adds a check input is number-only `^[0-9]+$ or not.
If input is number-only, it should go to time-only or date-only logic.

## Testcase

### Broken (on Chrome)

https://jsfiddle.net/m8a4r3t9/

### Fixed (on Chrome)

https://jsfiddle.net/9og37k1t/1/

## Closes

#1354
