### PR TITLE
feat(search): squared borders search

### DIFF
--- a/src/definitions/modules/search.less
+++ b/src/definitions/modules/search.less
@@ -393,7 +393,7 @@
 & when (@variationSearchScrolling),
   (@variationSearchShort),
   (@variationSearchLong) {
-  
+
   /*-------------------
        Scrolling
   --------------------*/
@@ -526,7 +526,7 @@
 
 & when (@variationSearchSquared) {
   .ui.squared.search .prompt {
-    border-radius: .28571429rem;
+    border-radius: @promptBorderRadiusSquared;
   }
 }
 

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -473,6 +473,7 @@
 @variationSearchCategory: true;
 @variationSearchLoading: true;
 @variationSearchAligned: true;
+@variationSearchSquared: true;
 @variationSearchFluid: true;
 @variationSearchShort: true;
 @variationSearchLong: true;

--- a/src/themes/default/modules/search.variables
+++ b/src/themes/default/modules/search.variables
@@ -11,6 +11,7 @@
 @promptPadding: (@promptVerticalPadding + ((1em - @promptLineHeight) / 2)) @promptHorizontalPadding;
 @promptBorder: 1px solid @borderColor;
 @promptBorderRadius: @circularRadius;
+@promptBorderRadiusSquared: @absoluteBorderRadius;
 @promptColor: @textColor;
 @promptTransition:
   background-color @defaultDuration @defaultEasing,


### PR DESCRIPTION
<!--
 Please read our Contributing Guide and Code of Conduct before you
 submit a pull request.
  
 Contributing Guide: https://github.com/fomantic/Fomantic-UI/blob/master/CONTRIBUTING.md
 Code of Conduct: https://github.com/fomantic/Fomantic-UI/blob/master/CODE_OF_CONDUCT.md

 ----

 Please use the following pull request title format:
 "[<scope>] <summary of what you fixed/changed>"
-->

## Description
In F-UI we have search as standalone box and as field within a form. In the first case search has rounded borders, in the second case it has squared borders. This change makes possibile to have standalone search box with squared borders, using a dedicated class.

## Testcase
Here is a JSFiddle: https://jsfiddle.net/tnfdpv5e

## Screenshot (if possible)
![image](https://user-images.githubusercontent.com/5399265/87668488-70bc3780-c76c-11ea-911c-f2acb184d0fe.png)

## Closes
<!--
  List all the issues this pull request closes (only if it does).
-->
#1558
