### PR TITLE
[Popup] Remove text-shadow explicitly on tooltip to avoid inheritance from parent

### DIFF
--- a/src/definitions/modules/popup.less
+++ b/src/definitions/modules/popup.less
@@ -108,6 +108,7 @@
     position: absolute;
     text-transform: none;
     text-align: left;
+    text-shadow: none;
     white-space: nowrap;
 
     font-size: @tooltipFontSize;


### PR DESCRIPTION
## Description
To avoid accidental inheritance of styling from parent element, `text-shado: none` is explicitly set for `[data-tooltip]` popup.

## Testcase
https://jsfiddle.net/kpbo7qjg/

## Screenshot (if possible)
![image](https://user-images.githubusercontent.com/127635/87515118-4dcf4c00-c6b6-11ea-8a4b-5ff3902ae80a.png)

## Closes
#1577 
