### PR TITLE
[Segment]: Horizontal segments' rounded corner

### DIFF
--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -469,6 +469,12 @@
     .ui.horizontal.segments:not(.stackable) > .segment:first-child {
       border-left: none;
     }
+    .ui.horizontal.segments > .segment:first-child {
+      border-radius: @borderRadius 0 0 @borderRadius;
+    }
+    .ui.horizontal.segments > .segment:last-child {
+      border-radius: 0 @borderRadius @borderRadius 0;
+    }
   }
 }
 


### PR DESCRIPTION
## Description
The horizontal segments should have the rounded corner, but the rounded corners seem to be coverd by the background of the segment inside of it.

The first and last segment inside the horizontal segments now adjust the border-radius to appear the rounded corner from the horizontal segments.

## Testcase
**Before:** https://jsfiddle.net/fax0kqd4/
**After:** https://jsfiddle.net/1ho0egx3/

## Screenshot
**Before:**
![Before](https://user-images.githubusercontent.com/930315/87662125-bfc39600-c787-11ea-98a9-3b1b15d044b4.png)

**After:**
![After](https://user-images.githubusercontent.com/930315/87662146-c6eaa400-c787-11ea-90a9-1f0105186fc6.png)
