### PR TITLE
[Table] Change default vertical alignment of table footer

### DIFF
--- a/src/themes/default/collections/table.variables
+++ b/src/themes/default/collections/table.variables
@@ -58,7 +58,7 @@
 @footerDivider: none;
 @footerBackground: @offWhite;
 @footerAlign: inherit;
-@footerVerticalAlign: middle;
+@footerVerticalAlign: inherit;
 @footerColor: @textColor;
 @footerVerticalPadding: @cellVerticalPadding;
 @footerHorizontalPadding: @cellHorizontalPadding;


### PR DESCRIPTION
## Description
The default vertical alignment of table footer were explicitly set as middle, which ignores the `top aligned` and `bottom aligned`
variant from table row and unable to align top and bottom within table footer.

By setting default value as inherit will enable to specify vertical alignment from table row without needing to specify top or bottom aligned on each cell.

## Testcase
**Before:**
The class name `top aligned` and `bottom aligned` cannot be applied from table footer row (https://jsfiddle.net/ow6b1hLv/)

**After:**
The class name `top aligned` and `bottom aligned` can be applied from table footer row (https://jsfiddle.net/c6ujLqyn/)

## Closes
#1581 
