### PR TITLE
[Icon/Button] Make sure real icon selectors are addressed

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -253,7 +253,7 @@
   display: block;
 }
 .ui.menu .ui.dropdown .menu > .item > .icons,
-.ui.menu .ui.dropdown .menu > .item > .icon:not(.dropdown) {
+.ui.menu .ui.dropdown .menu > .item > i.icon:not(.dropdown) {
   display: inline-block;
   font-size: @dropdownItemIconFontSize !important;
   float: @dropdownItemIconFloat;
@@ -284,7 +284,7 @@
 
 & when (@variationMenuVertical) {
   /* Vertical */
-  .ui.vertical.menu .dropdown.item > .icon {
+  .ui.vertical.menu .dropdown.item > i.icon {
     float: right;
     content: "\f0da";
     margin-left: 1em;
@@ -1225,24 +1225,24 @@ Floated Menu / Item
 }
 
 /* Icon */
-.ui.icon.menu .item > .icon:not(.dropdown) {
+.ui.icon.menu .item > i.icon:not(.dropdown) {
   margin: 0;
   opacity: 1;
 }
 
 /* Icon Gylph */
-.ui.icon.menu .icon:before {
+.ui.icon.menu i.icon:before {
   opacity: 1;
 }
 
 /* (x) Item Icon */
-.ui.menu .icon.item > .icon {
+.ui.menu .icon.item > i.icon {
   width: auto;
   margin: 0 auto;
 }
 
 /* Vertical Icon */
-.ui.vertical.icon.menu .item > .icon:not(.dropdown) {
+.ui.vertical.icon.menu .item > i.icon:not(.dropdown) {
   display: block;
   opacity: 1;
   margin: 0 auto;
@@ -1271,7 +1271,7 @@ Floated Menu / Item
   }
 
   /* Icon */
-  .ui.labeled.icon.menu > .item > .icon:not(.dropdown) {
+  .ui.labeled.icon.menu > .item > i.icon:not(.dropdown) {
     height: 1em;
     display: block;
     font-size: @labeledIconSize !important;

--- a/src/definitions/collections/message.less
+++ b/src/definitions/collections/message.less
@@ -107,7 +107,7 @@
 
 
 /* Icon */
-.ui.message > .icon {
+.ui.message > i.icon {
   margin-right: @iconDistance;
 }
 
@@ -225,7 +225,7 @@
     width: 100%;
     align-items: center;
   }
-  .ui.icon.message > .icon:not(.close) {
+  .ui.icon.message > i.icon:not(.close) {
     display: block;
     flex: 0 0 auto;
     width: auto;
@@ -241,10 +241,10 @@
   }
 
 
-  .ui.icon.message .icon:not(.close) + .content {
+  .ui.icon.message > i.icon:not(.close) + .content {
     padding-left: @iconContentDistance;
   }
-  .ui.icon.message .circular.icon {
+  .ui.icon.message > i.circular.icon {
     width: 1em;
   }
 }

--- a/src/definitions/collections/table.less
+++ b/src/definitions/collections/table.less
@@ -154,10 +154,10 @@
 }
 
 /* Icons */
-.ui.table > .icon {
+.ui.table > i.icon {
   vertical-align: @iconVerticalAlign;
 }
-.ui.table > .icon:only-child {
+.ui.table > i.icon:only-child {
   margin: 0;
 }
 

--- a/src/definitions/elements/header.less
+++ b/src/definitions/elements/header.less
@@ -62,7 +62,7 @@
       Icon
 ---------------*/
 
-.ui.header > .icon {
+.ui.header > i.icon {
   display: table-cell;
   opacity: @iconOpacity;
   font-size: @iconSize;
@@ -71,7 +71,7 @@
 }
 
 /* With Text Node */
-.ui.header .icon:only-child {
+.ui.header > i.icon:only-child {
   display: inline-block;
   padding: 0;
   margin-right: @iconMargin;
@@ -111,7 +111,7 @@
 }
 
 /* After Icon */
-.ui.header > .icon + .content {
+.ui.header > i.icon + .content {
   padding-left: @iconMargin;
   display: table-cell;
   vertical-align: @contentIconAlignment;
@@ -220,7 +220,7 @@
   .ui.icon.header:first-child {
     margin-top: @iconHeaderFirstMargin;
   }
-  .ui.icon.header .icon {
+  .ui.icon.header > i.icon {
     float: none;
     display: block;
     width: auto;
@@ -238,14 +238,14 @@
     display: block;
     padding: 0;
   }
-  .ui.icon.header .circular.icon {
+  .ui.icon.header > i.circular.icon {
     font-size: @circularHeaderIconSize;
   }
-  .ui.icon.header .square.icon {
+  .ui.icon.header > i.square.icon {
     font-size: @squareHeaderIconSize;
   }
   & when (@variationHeaderBlock) {
-    .ui.block.icon.header .icon {
+    .ui.block.icon.header > i.icon {
       margin-bottom: 0;
     }
   }
@@ -401,7 +401,7 @@ each(@colors, {
   .ui.dividing.header .sub.header {
     padding-bottom: @dividedSubHeaderPadding;
   }
-  .ui.dividing.header .icon {
+  .ui.dividing.header i.icon {
     margin-bottom: @dividedIconPadding;
   }
   & when (@variationHeaderInverted) {

--- a/src/definitions/elements/input.less
+++ b/src/definitions/elements/input.less
@@ -392,7 +392,7 @@
   .ui[class*="corner labeled"].icon.input:not([class*="left corner labeled"]) > input {
     padding-right: @labeledIconInputMargin !important;
   }
-  .ui[class*="corner labeled"].icon.input:not([class*="left corner labeled"]) > .icon {
+  .ui[class*="corner labeled"].icon.input:not([class*="left corner labeled"]) > i.icon {
     margin-right: @labeledIconMargin;
   }
 
@@ -406,16 +406,16 @@
     .ui[class*="left corner labeled"].icon.input > input {
       padding-left: @labeledIconInputMargin !important;
     }
-    .ui[class*="left corner labeled"].icon.input > .icon {
+    .ui[class*="left corner labeled"].icon.input > i.icon {
       margin-left: @labeledIconMargin;
     }
   }
 }
 & when (@variationInputIcon) {
-  .ui.icon.input > textarea ~ .icon {
+  .ui.icon.input > textarea ~ i.icon {
     height: @textareaIconHeight;
   }
-  :not(.field) > .ui.transparent.icon.input > textarea ~ .icon {
+  :not(.field) > .ui.transparent.icon.input > textarea ~ i.icon {
     height: @transparentTextareaIconHeight;
   }
 }

--- a/src/definitions/elements/step.less
+++ b/src/definitions/elements/step.less
@@ -144,20 +144,20 @@
 }
 
 /* Icon */
-.ui.steps .step > .icon {
+.ui.steps .step > i.icon {
   line-height: 1;
   font-size: @iconSize;
   margin: 0 @iconDistance 0 0;
 }
-.ui.steps .step > .icon,
-.ui.steps .step > .icon ~ .content {
+.ui.steps .step > i.icon,
+.ui.steps .step > i.icon ~ .content {
   display: block;
   flex: 0 1 auto;
   align-self: @iconAlign;
 }
 
 /* Horizontal Icon */
-.ui.steps:not(.vertical) .step > .icon {
+.ui.steps:not(.vertical) .step > i.icon {
   width: auto;
 }
 
@@ -299,7 +299,7 @@
   }
 
   /* Icon */
-  .ui.steps:not(.unstackable) .step > .icon,
+  .ui.steps:not(.unstackable) .step > i.icon,
   .ui.ordered.steps:not(.unstackable) .step:before {
     margin: 0 0 @mobileIconDistance 0;
   }
@@ -340,7 +340,7 @@
   color: @activeColor;
 }
 .ui.ordered.steps .step.active:before,
-.ui.steps .active.step .icon {
+.ui.steps .active.step i.icon {
   color: @activeIconColor;
 }
 
@@ -369,7 +369,7 @@
 }
 
 /* Completed */
-.ui.steps .step.completed > .icon:before,
+.ui.steps .step.completed > i.icon:before,
 .ui.ordered.steps .step.completed:before {
   color: @completedColor;
 }
@@ -441,7 +441,7 @@
     }
 
     /* Icon */
-    .ui[class*="tablet stackable"].steps .step > .icon,
+    .ui[class*="tablet stackable"].steps .step > i.icon,
     .ui[class*="tablet stackable"].ordered.steps .step:before {
       margin: 0 0 @mobileIconDistance 0;
     }
@@ -590,7 +590,7 @@
     background: @invertedActiveBackground;
   }
   .ui.inverted.ordered.steps .step.active:before,
-  .ui.inverted.steps .active.step .icon {
+  .ui.inverted.steps .active.step i.icon {
     color: @invertedSelectedTextColor;
   }
 

--- a/src/definitions/modules/calendar.less
+++ b/src/definitions/modules/calendar.less
@@ -81,7 +81,7 @@
   border-left: none;
 }
 
-.ui.calendar .ui.table tr th .icon {
+.ui.calendar .ui.table tr th i.icon {
   margin: 0;
 }
 

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -154,7 +154,7 @@
   margin-right: @floatedDistance !important;
 }
 
-.ui.dropdown .menu .item > .icon.floated,
+.ui.dropdown .menu .item > i.icon.floated,
 .ui.dropdown .menu .item > .flag.floated,
 .ui.dropdown .menu .item > .image.floated,
 .ui.dropdown .menu .item > img.floated {
@@ -198,7 +198,7 @@
   padding: @menuInputPadding;
 }
 .ui.dropdown .menu > .input:not(.transparent) .button,
-.ui.dropdown .menu > .input:not(.transparent) .icon,
+.ui.dropdown .menu > .input:not(.transparent) i.icon,
 .ui.dropdown .menu > .input:not(.transparent) .label {
   padding-top: @menuInputVerticalPadding;
   padding-bottom: @menuInputVerticalPadding;
@@ -250,14 +250,14 @@
 ---------------*/
 
 /* Icons / Flags / Labels / Image */
-.ui.dropdown > .text > .icon,
+.ui.dropdown > .text > i.icon,
 .ui.dropdown > .text > .label,
 .ui.dropdown > .text > .flag,
 .ui.dropdown > .text > img,
 .ui.dropdown > .text > .image {
   margin-top: @textLineHeightOffset;
 }
-.ui.dropdown .menu > .item > .icon,
+.ui.dropdown .menu > .item > i.icon,
 .ui.dropdown .menu > .item > .label,
 .ui.dropdown .menu > .item > .flag,
 .ui.dropdown .menu > .item > .image,
@@ -265,12 +265,12 @@
   margin-top: @itemLineHeightOffset;
 }
 
-.ui.dropdown > .text > .icon,
+.ui.dropdown > .text > i.icon,
 .ui.dropdown > .text > .label,
 .ui.dropdown > .text > .flag,
 .ui.dropdown > .text > img,
 .ui.dropdown > .text > .image,
-.ui.dropdown .menu > .item > .icon,
+.ui.dropdown .menu > .item > i.icon,
 .ui.dropdown .menu > .item > .label,
 .ui.dropdown .menu > .item > .flag,
 .ui.dropdown .menu > .item > .image,
@@ -673,7 +673,7 @@ select.ui.dropdown {
   }
 
   /* Filtered Text */
-  .ui.active.search.dropdown input.search:focus + .text .icon,
+  .ui.active.search.dropdown input.search:focus + .text i.icon,
   .ui.active.search.dropdown input.search:focus + .text .flag {
     opacity: @selectionTextUnderlayIconOpacity;
   }
@@ -1699,7 +1699,7 @@ select.ui.dropdown {
     color: @invertedDefaultTextFocusColor;
   }
 
-  .ui.inverted.active.search.dropdown input.search:focus + .text .icon,
+  .ui.inverted.active.search.dropdown input.search:focus + .text i.icon,
   .ui.inverted.active.search.dropdown input.search:focus + .text .flag {
     opacity: @invertedSelectionTextUnderlayIconOpacity;
   }

--- a/src/definitions/modules/embed.less
+++ b/src/definitions/modules/embed.less
@@ -76,7 +76,7 @@
       Icon
 ---------------*/
 
-.ui.embed > .icon {
+.ui.embed > i.icon {
   cursor: pointer;
   position: absolute;
   top: 0;
@@ -85,7 +85,7 @@
   height: 100%;
   z-index: 2;
 }
-.ui.embed > .icon:after {
+.ui.embed > i.icon:after {
   position: absolute;
   top: 0;
   left: 0;
@@ -97,7 +97,7 @@
   opacity: @placeholderBackgroundOpacity;
   transition: @placeholderBackgroundTransition;
 }
-.ui.embed > .icon:before {
+.ui.embed > i.icon:before {
   position: absolute;
   top: 50%;
   left: 50%;
@@ -118,11 +118,11 @@
      Hover
 ---------------*/
 
-.ui.embed .icon:hover:after {
+.ui.embed i.icon:hover:after {
   background: @hoverPlaceholderBackground;
   opacity: @hoverPlaceholderBackgroundOpacity;
 }
-.ui.embed .icon:hover:before {
+.ui.embed i.icon:hover:before {
   color: @hoverIconColor;
 }
 
@@ -130,7 +130,7 @@
      Active
 ---------------*/
 
-.ui.active.embed > .icon,
+.ui.active.embed > i.icon,
 .ui.active.embed > .placeholder {
   display: none;
 }

--- a/src/definitions/modules/modal.less
+++ b/src/definitions/modules/modal.less
@@ -41,9 +41,9 @@
 }
 
 .ui.modal > :first-child:not(.icon):not(.dimmer),
-.ui.modal > .icon:first-child + *,
+.ui.modal > i.icon:first-child + *,
 .ui.modal > .dimmer:first-child + *:not(.icon),
-.ui.modal > .dimmer:first-child + .icon + * {
+.ui.modal > .dimmer:first-child + i.icon + * {
   border-top-left-radius: @borderRadius;
   border-top-right-radius: @borderRadius;
 }
@@ -148,7 +148,7 @@
   align-self: @descriptionVerticalAlign;
 }
 
-.ui.modal > .content > .icon + .description,
+.ui.modal > .content > i.icon + .description,
 .ui.modal > .content > .image + .description {
   flex: 0 1 auto;
   min-width: @descriptionMinWidth;

--- a/src/definitions/modules/toast.less
+++ b/src/definitions/modules/toast.less
@@ -130,7 +130,7 @@
         & > :not(.icon):not(.actions) {
           padding-left: @toastIconMessageContentPadding;
         }
-        & > .icon:not(.close) when (@variationToastIcon) {
+        & > i.icon:not(.close) when (@variationToastIcon) {
           display: inline-block;
           position: absolute;
           width: @toastIconMessageWidth;
@@ -138,7 +138,7 @@
           transform: translateY(-50%);
         }
         &:not(.vertical) {
-          &.actions > .icon:not(.close) when (@variationToastActions) and (@variationToastIcon) {
+          &.actions > i.icon:not(.close) when (@variationToastActions) and (@variationToastIcon) {
             top: e(%("calc(50%% - %d)", @toastIconCenteredAdjustment));
             transform: none;
           }
@@ -415,11 +415,11 @@
     background-color: @toastNeutralColor;
     color: @toastNeutralTextColor;
   }
-  & > .icon:not(.close) when (@variationToastIcon) {
+  & > i.icon:not(.close) when (@variationToastIcon) {
     font-size: @toastIconFontSize;
   }
   &:not(.vertical) {
-    & > .icon:not(.close) when (@variationToastIcon) {
+    & > i.icon:not(.close) when (@variationToastIcon) {
       position: absolute;
       & + .content {
         padding-left: @toastIconContentPadding;
@@ -467,7 +467,7 @@
     }
     & when (@variationToastImage) or (@variationToastIcon) {
       & > .ui.image + .content,
-      > .icon:not(.close) + .content {
+      > i.icon:not(.close) + .content {
         padding-left: @toastImageContentPadding;
       }
     }

--- a/src/definitions/views/feed.less
+++ b/src/definitions/views/feed.less
@@ -229,10 +229,10 @@
   color: @likeColor;
   transition: @likeTransition;
 }
-.ui.feed > .event > .content .meta .like:hover .icon {
+.ui.feed > .event > .content .meta .like:hover i.icon {
   color: @likeHoverColor;
 }
-.ui.feed > .event > .content .meta .active.like .icon {
+.ui.feed > .event > .content .meta .active.like i.icon {
   color: @likeActiveColor;
 }
 
@@ -246,15 +246,15 @@
 
 /* Action */
 .ui.feed > .event > .content .meta a,
-.ui.feed > .event > .content .meta > .icon {
+.ui.feed > .event > .content .meta > i.icon {
   cursor: @metadataActionCursor;
   opacity: @metadataActionOpacity;
   color: @metadataActionColor;
   transition: @metadataActionTransition;
 }
 .ui.feed > .event > .content .meta a:hover,
-.ui.feed > .event > .content .meta a:hover .icon,
-.ui.feed > .event > .content .meta > .icon:hover {
+.ui.feed > .event > .content .meta a:hover i.icon,
+.ui.feed > .event > .content .meta > i.icon:hover {
   color: @metadataActionHoverColor;
 }
 

--- a/src/definitions/views/statistic.less
+++ b/src/definitions/views/statistic.less
@@ -135,8 +135,8 @@
    Icon Value
 ---------------*/
 
-.ui.statistics .statistic > .value .icon,
-.ui.statistic > .value .icon {
+.ui.statistics .statistic > .value > i.icon,
+.ui.statistic > .value > i.icon {
   opacity: 1;
   width: auto;
   margin: 0;
@@ -287,8 +287,8 @@
   .ui.horizontal.statistics > .statistic > .text.value {
     min-height: 0 !important;
   }
-  .ui.horizontal.statistics .statistic > .value .icon,
-  .ui.horizontal.statistic > .value .icon {
+  .ui.horizontal.statistics .statistic > .value > i.icon,
+  .ui.horizontal.statistic > .value > i.icon {
     width: @iconWidth;
   }
 


### PR DESCRIPTION
## Description
In certain situations only `.icon` selectors were used to address icons incomponents. However this interferes with a  possible `icon button`  resulting in wrong sizes or wrong aligned margins and colors for those buttons.
This PR adds the i tag to those selectors to make sure only a "real" icon is selected as it was supposed  to be.

## Testcase
### Before
https://jsfiddle.net/lubber/djy148eb/33/

### After
https://jsfiddle.net/lubber/djy148eb/32/

## Screenshots
|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/87834159-07cae180-c88a-11ea-8bfc-147e915eefab.png)<br>![image](https://user-images.githubusercontent.com/18379884/87834049-b02c7600-c889-11ea-8451-a64b6a15b216.png)|![image](https://user-images.githubusercontent.com/18379884/87833893-42804a00-c889-11ea-8d77-0f2e23a8c28a.png)|


