### PR TITLE
[Calendar] Adjust cell tooltip positions according to popup position to avoid it being hidden

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -141,12 +141,16 @@ $.fn.calendar = function(parameters) {
               $container = $('<div/>').addClass(className.popup)[domPositionFunction]($activatorParent);
             }
             $container.addClass(className.calendar);
-            var onVisible = settings.onVisible;
+            var onVisible = function () {
+              module.refreshTooltips();
+              return settings.onVisible.apply($container, arguments);
+            };
             var onHidden = settings.onHidden;
             if (!$input.length) {
               //no input, $container has to handle focus/blur
               $container.attr('tabindex', '0');
               onVisible = function () {
+                module.refreshTooltips();
                 module.focus();
                 return settings.onVisible.apply($container, arguments);
               };
@@ -436,6 +440,16 @@ $.fn.calendar = function(parameters) {
 
         refresh: function () {
           module.create.calendar();
+        },
+
+        refreshTooltips: function() {
+          var popupPos = $container.hasClass('left') ? 'left' : 'right';
+          var popupPosOpposite = popupPos === 'left' ? 'right' : 'left';
+          $container.find('td[data-position*="'+popupPos+'"]').each(function () {
+            var cell = $(this);
+            var tooltipPosition = cell.attr('data-position');
+            cell.attr('data-position',tooltipPosition.replace(popupPos,popupPosOpposite));
+           });
         },
 
         bind: {

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -182,6 +182,7 @@ $.fn.calendar = function(parameters) {
             if ($activator.length && !settings.inline) {
               return;
             }
+            settings.inline = true;
             $container = $('<div/>').addClass(className.calendar).appendTo($module);
             if (!$input.length) {
               $container.attr('tabindex', '0');
@@ -401,6 +402,10 @@ $.fn.calendar = function(parameters) {
               }
 
               module.update.focus(false, table);
+
+              if(settings.inline){
+                module.refreshTooltips();
+              }
             }
           }
         },
@@ -443,12 +448,16 @@ $.fn.calendar = function(parameters) {
         },
 
         refreshTooltips: function() {
-          var popupPos = $container.hasClass('left') ? 'left' : 'right';
-          var popupPosOpposite = popupPos === 'left' ? 'right' : 'left';
-          $container.find('td[data-position*="'+popupPos+'"]').each(function () {
+          var winWidth = $(window).width();
+          $container.find('td[data-position]').each(function () {
             var cell = $(this);
+            var tooltipWidth = window.getComputedStyle(cell[0], ':after').width.replace(/[^0-9\.]/g,'');
             var tooltipPosition = cell.attr('data-position');
-            cell.attr('data-position',tooltipPosition.replace(popupPos,popupPosOpposite));
+            // use a fallback width of 250 (calendar width) for IE/Edge (which return "auto")
+            var calcPosition = (winWidth - cell.width() - (parseInt(tooltipWidth,10) || 250)) > cell.offset().left ? 'right' : 'left';
+            if(tooltipPosition.indexOf(calcPosition) === -1) {
+              cell.attr('data-position',tooltipPosition.replace(/(left|right)/,calcPosition));
+            }
            });
         },
 


### PR DESCRIPTION
## Description
The default tooltip position of cell tooltips is `left center`. This leads into situations where the tooltip is cut to the left.
On first instantiation of a calendar popup the position of tooltips is not correctly fetched because the popup module hasn't adjusted its pointer position classes yet. Because of this ,the direction of possible cell tooltips is wrongly calculated. 
If the same calendar is opened a second time, this does not occur anymore, because the popup module has now adjusted its position.

This PR now adjusts any existing cell tooltip positions inside the calendar whenever the popup get's shown (the popup module always (re-)calculates its position then). So this not only fixes it on first instantiation but also in case the calendar position changes while scrolling , so the popup will possibly to displayed in another direction.

As this is not a module setting but a decision of the module itself, this is a backward compatible change which just fixes the behavior.
Btw. it wasn't happening before, because the calendar popup was called twice (thus correcting it's position), but that was now fixed by #1439


## Testcase
### Broken
https://jsfiddle.net/lubber/afer3s7b/1/

### Fixed
https://jsfiddle.net/lubber/afer3s7b/7/

## Screenshot
![calendarTooltips](https://user-images.githubusercontent.com/18379884/87857975-2df48e00-c92b-11ea-9f61-7f9ec29a6e72.gif)
