### PR TITLE
[Calendar]: Inverted Variant

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -357,7 +357,7 @@ $.fn.calendar = function(parameters) {
                     var disabledDate = module.helper.findDayAsObject(cellDate, mode, settings.disabledDates);
                     if (disabledDate !== null && disabledDate[metadata.message]) {
                       cell.attr("data-tooltip", disabledDate[metadata.message]);
-                      cell.attr("data-position", tooltipPosition);
+                      cell.attr("data-position", disabledDate[metadata.position] || tooltipPosition);
                       if(disabledDate[metadata.inverted] || (isInverted && disabledDate[metadata.inverted] === undefined)) {
                         cell.attr("data-inverted", '');
                       }
@@ -371,7 +371,7 @@ $.fn.calendar = function(parameters) {
                       cell.addClass(eventDate[metadata.class] || settings.eventClass);
                       if (eventDate[metadata.message]) {
                         cell.attr("data-tooltip", eventDate[metadata.message]);
-                        cell.attr("data-position", tooltipPosition);
+                        cell.attr("data-position", eventDate[metadata.position] || tooltipPosition);
                         if(eventDate[metadata.inverted] || (isInverted && eventDate[metadata.inverted] === undefined)) {
                           cell.attr("data-inverted", '');
                         }
@@ -1666,6 +1666,7 @@ $.fn.calendar.settings = {
     class: 'class',
     inverted: 'inverted',
     variation: 'variation',
+    position: 'position',
     month: 'month',
     year: 'year'
   },

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -75,6 +75,7 @@ $.fn.calendar = function(parameters) {
 
         isTouch,
         isTouchDown = false,
+        isInverted = $module.hasClass(className.inverted),
         focusDateUsedForRange = false,
         module
       ;
@@ -141,6 +142,9 @@ $.fn.calendar = function(parameters) {
               $container = $('<div/>').addClass(className.popup)[domPositionFunction]($activatorParent);
             }
             $container.addClass(className.calendar);
+            if(isInverted){
+              $container.addClass(className.inverted);
+            }
             var onVisible = settings.onVisible;
             var onHidden = settings.onHidden;
             if (!$input.length) {
@@ -281,6 +285,9 @@ $.fn.calendar = function(parameters) {
                 tempMode += ' andweek';
               }
               var table = $('<table/>').addClass(className.table).addClass(tempMode).addClass(numberText[columns] + ' column').appendTo(container);
+              if(isInverted){
+                table.addClass(className.inverted);
+              }
               var textColumns = columns;
               //no header for time-only mode
               if (!isTimeOnly) {
@@ -351,6 +358,12 @@ $.fn.calendar = function(parameters) {
                     if (disabledDate !== null && disabledDate[metadata.message]) {
                       cell.attr("data-tooltip", disabledDate[metadata.message]);
                       cell.attr("data-position", tooltipPosition);
+                      if(disabledDate[metadata.inverted] || (isInverted && disabledDate[metadata.inverted] === undefined)) {
+                        cell.attr("data-inverted", '');
+                      }
+                      if(disabledDate[metadata.variation]) {
+                        cell.attr("data-variation", disabledDate[metadata.variation]);
+                      }
                     }
                   } else {
                     var eventDate = module.helper.findDayAsObject(cellDate, mode, settings.eventDates);
@@ -359,6 +372,12 @@ $.fn.calendar = function(parameters) {
                       if (eventDate[metadata.message]) {
                         cell.attr("data-tooltip", eventDate[metadata.message]);
                         cell.attr("data-position", tooltipPosition);
+                        if(eventDate[metadata.inverted] || (isInverted && eventDate[metadata.inverted] === undefined)) {
+                          cell.attr("data-inverted", '');
+                        }
+                        if(eventDate[metadata.variation]) {
+                          cell.attr("data-variation", eventDate[metadata.variation]);
+                        }
                       }
                     }
                   }
@@ -1616,6 +1635,7 @@ $.fn.calendar.settings = {
     grid: 'ui equal width grid',
     column: 'column',
     table: 'ui celled center aligned unstackable table',
+    inverted: 'inverted',
     prev: 'prev link',
     next: 'next link',
     prevIcon: 'chevron left icon',
@@ -1644,6 +1664,8 @@ $.fn.calendar.settings = {
     monthOffset: 'monthOffset',
     message: 'message',
     class: 'class',
+    inverted: 'inverted',
+    variation: 'variation',
     month: 'month',
     year: 'year'
   },

--- a/src/definitions/modules/calendar.less
+++ b/src/definitions/modules/calendar.less
@@ -146,22 +146,31 @@
   box-shadow: @rangeBoxShadow;
 }
 
-.ui.calendar .ui.table.inverted tr td.range {
-  background: @rangeInvertedBackground;
-  color: @rangeInvertedTextColor;
-  box-shadow: @rangeInvertedBoxShadow;
-}
-
 .ui.calendar:not(.disabled) .calendar:focus .ui.table tbody tr td.focus,
 .ui.calendar:not(.disabled) .calendar.active .ui.table tbody tr td.focus {
   box-shadow: @focusBoxShadow;
 }
 
-.ui.calendar:not(.disabled) .calendar:focus .ui.table.inverted tbody tr td.focus,
-.ui.calendar:not(.disabled) .calendar.active .ui.table.inverted tbody tr td.focus {
-  box-shadow: @focusInvertedBoxShadow;
-}
+& when (@variationCalendarInverted) {
+  .ui.inverted.calendar .ui.table.inverted tr td.range {
+    background: @rangeInvertedBackground;
+    color: @rangeInvertedTextColor;
+    box-shadow: @rangeInvertedBoxShadow;
+  }
 
+  .ui.inverted.calendar:not(.disabled) .calendar:focus .ui.table.inverted tbody tr td.focus,
+  .ui.inverted.calendar:not(.disabled) .calendar.active .ui.table.inverted tbody tr td.focus {
+    box-shadow: @focusInvertedBoxShadow;
+  }
+  .ui.inverted.calendar .ui.inverted.table tr .disabled {
+    color: @invertedDisabledTextColor;
+  }
+
+  .ui.inverted.calendar .ui.inverted.table tr .adjacent:not(.disabled) {
+    color: @adjacentInvertedTextColor;
+    background: @adjacentInvertedBackground;
+  }
+}
 
 /*******************************
             States

--- a/src/definitions/modules/calendar.less
+++ b/src/definitions/modules/calendar.less
@@ -121,7 +121,7 @@
   right: 0;
 }
 
-.ui.calendar .ui.table tr .disabled {
+.ui.ui.calendar .ui.table tr .disabled {
   pointer-events: auto;
   cursor: default;
   color: @disabledTextColor;

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -367,6 +367,7 @@
 @variationAccordionFluid: true;
 
 /* Calendar */
+@variationCalendarInverted: true;
 @variationCalendarDisabled: true;
 
 /* Checkbox */

--- a/src/themes/default/modules/calendar.variables
+++ b/src/themes/default/modules/calendar.variables
@@ -16,3 +16,5 @@
 
 @adjacentTextColor: @mutedTextColor;
 @adjacentBackground: @subtleTransparentBlack;
+@adjacentInvertedTextColor: @invertedMutedTextColor;
+@adjacentInvertedBackground: @subtleTransparentWhite;


### PR DESCRIPTION
## Description
This PR adds full `inverted` support to the calendar component.
It also adds new metadata support for disabled/eventDates to supply new attributes `inverted` and `variation`. This way each cell tooltip can be adjusted on its own and makes it possible to have inverted or `basic` cell tooltips on non inverted calendars and vice versa

## Testcase
https://jsfiddle.net/lubber/xo2b9tfz/19/

## Screenshots
- `inverted calendar`
![image](https://user-images.githubusercontent.com/18379884/87862648-9e62d580-c952-11ea-96d8-ba178a492051.png)

> The darker left pointer or the calendar surrounding popup isn't part of this PR, because it's a general issue also for normal calendar and covered in #1084 

- ... keep non inverted cell tooltip
```javascript
disabledDates: [{
  date: new Date(2020, 11, 19),
  message: 'xmas gift shopping',
  inverted: false
}],
```
![image](https://user-images.githubusercontent.com/18379884/87862667-f0a3f680-c952-11ea-8700-46b5fe58aa4b.png)
- ... normal calendar, but inverted tooltip
```javascript
disabledDates: [{
  date: new Date(2020, 11, 19),
  message: 'xmas gift shopping',
  inverted: true
}],
```
![image](https://user-images.githubusercontent.com/18379884/87862679-21842b80-c953-11ea-8385-10944909503a.png)

- ... tooltip variation
```javascript
disabledDates: [{
  date: new Date(2020, 11, 19),
  message: 'xmas gift shopping',
  variation: 'basic'  // = no pointer as of docs
}],
```
![image](https://user-images.githubusercontent.com/18379884/87862690-411b5400-c953-11ea-83bc-f7d12076357d.png)
![image](https://user-images.githubusercontent.com/18379884/87862708-6d36d500-c953-11ea-973e-2e36a66520ca.png)
