### PR TITLE
[Toast] Fix the toast error progress bar visibility

### DIFF
--- a/src/definitions/modules/toast.less
+++ b/src/definitions/modules/toast.less
@@ -110,7 +110,7 @@
       &.success .bar.bar.bar {
         background: @toastSuccessProgressColor;
       }
-      .error .bar.bar.bar {
+      &.error .bar.bar.bar {
         background: @toastErrorProgressColor;
       }
       &.neutral .bar.bar.bar {


### PR DESCRIPTION
## Description
The toast error progress bar is not visibile because the build process omitted to compile for error variation of toast progress
and ended up showing the same color as error background of toast which makes the progress bar not visible.

## Testcase
**Broken:** https://jsfiddle.net/dutrieux/vunftrhx/

**Fixed:** https://jsfiddle.net/wfvqzabn/

## Closes
#1600 
