### PR TITLE
[Calendar] trigger native change event on date selection

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -215,10 +215,10 @@ $.fn.calendar = function(parameters) {
         trigger: {
           change: function() {
             var
-                events       = document.createEvent('HTMLEvents'),
                 inputElement = $input[0]
             ;
             if(inputElement) {
+              var events = document.createEvent('HTMLEvents');
               module.verbose('Triggering native change event');
               events.initEvent('change', true, false);
               inputElement.dispatchEvent(events);

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -211,6 +211,20 @@ $.fn.calendar = function(parameters) {
           }
         },
 
+        trigger: {
+          change: function() {
+            var
+                events       = document.createEvent('HTMLEvents'),
+                inputElement = $input[0]
+            ;
+            if(inputElement) {
+              module.verbose('Triggering native change event');
+              events.initEvent('change', true, false);
+              inputElement.dispatchEvent(events);
+            }
+          }
+        },
+
         create: {
           calendar: function () {
             var i, r, c, p, row, cell, pageGrid;
@@ -845,15 +859,18 @@ $.fn.calendar = function(parameters) {
             (settings.type === 'year' && mode === 'year');
           if (complete) {
             var canceled = module.set.date(date) === false;
-            if (!canceled && settings.closable) {
-              module.popup('hide');
-              //if this is a range calendar, focus the container or input. This will open the popup from its event listeners.
-              var endModule = module.get.calendarModule(settings.endCalendar);
-              if (endModule) {
-                if (endModule.setting('on') !== 'focus') {
-                  endModule.popup('show');
+            if (!canceled) {
+              module.trigger.change();
+              if(settings.closable) {
+                module.popup('hide');
+                //if this is a range calendar, focus the container or input. This will open the popup from its event listeners.
+                var endModule = module.get.calendarModule(settings.endCalendar);
+                if (endModule) {
+                  if (endModule.setting('on') !== 'focus') {
+                    endModule.popup('show');
+                  }
+                  endModule.focus();
                 }
-                endModule.focus();
               }
             }
           } else {

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -43,7 +43,8 @@ $.fn.calendar = function(parameters) {
       '20': {'row': 3, 'column': 1 },
       '30': {'row': 2, 'column': 1 }
     },
-    numberText = ['','one','two','three','four','five','six','seven','eight']
+    numberText = ['','one','two','three','four','five','six','seven','eight'],
+    selectionComplete = false
   ;
 
   $allModules
@@ -634,6 +635,10 @@ $.fn.calendar = function(parameters) {
               var text = formatter.datetime(date, settings);
               $input.val(text);
             }
+            if(selectionComplete){
+              module.trigger.change();
+              selectionComplete = false;
+            }
           }
         },
 
@@ -860,7 +865,7 @@ $.fn.calendar = function(parameters) {
           if (complete) {
             var canceled = module.set.date(date) === false;
             if (!canceled) {
-              module.trigger.change();
+              selectionComplete = true;
               if(settings.closable) {
                 module.popup('hide');
                 //if this is a range calendar, focus the container or input. This will open the popup from its event listeners.

--- a/src/definitions/modules/checkbox.js
+++ b/src/definitions/modules/checkbox.js
@@ -556,10 +556,10 @@ $.fn.checkbox = function(parameters) {
         trigger: {
           change: function() {
             var
-              events       = document.createEvent('HTMLEvents'),
               inputElement = $input[0]
             ;
             if(inputElement) {
+              var events = document.createEvent('HTMLEvents');
               module.verbose('Triggering native change event');
               events.initEvent('change', true, false);
               inputElement.dispatchEvent(events);

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1637,10 +1637,10 @@ $.fn.dropdown = function(parameters) {
         trigger: {
           change: function() {
             var
-              events       = document.createEvent('HTMLEvents'),
               inputElement = $input[0]
             ;
             if(inputElement) {
+              var events = document.createEvent('HTMLEvents');
               module.verbose('Triggering native change event');
               events.initEvent('change', true, false);
               inputElement.dispatchEvent(events);


### PR DESCRIPTION
## Description
The native `change` event should be triggered whenever a date is selected from the picker and the input field blurs.
Currently it is only triggered when the dates input field has been changed manually and the field blurs.

I adopted the same method for this as in `checkbox` or `dropdown`

## Testcase
### Broken
https://jsfiddle.net/lubber/asdjkwpo/11/

### Fixed
https://jsfiddle.net/lubber/asdjkwpo/11/

## Screenshots
|Broken|Fixed|
|-|-|
|![calendarnativechange_wrong](https://user-images.githubusercontent.com/18379884/88369948-65cb5d80-cd91-11ea-87ce-2c7974aa2d29.gif)|![calendarnativechange_right](https://user-images.githubusercontent.com/18379884/88369961-6b28a800-cd91-11ea-99a1-2336a1d986b8.gif)|

## Closes
#1251 