### PR TITLE
[Dropdown, Calendar] Pressing tab entered disabled dropdown/calendar fields

### DIFF
--- a/src/definitions/elements/input.less
+++ b/src/definitions/elements/input.less
@@ -82,7 +82,7 @@
   ---------------------*/
 
   .ui.disabled.input,
-  :not(.calendar) > .ui.input:not(.disabled) input[disabled] {
+  .ui.input:not(.disabled) input[disabled] {
     opacity: @disabledOpacity;
   }
 

--- a/src/definitions/elements/input.less
+++ b/src/definitions/elements/input.less
@@ -82,7 +82,7 @@
   ---------------------*/
 
   .ui.disabled.input,
-  .ui.input:not(.disabled) input[disabled] {
+  :not(.calendar) > .ui.input:not(.disabled) input[disabled] {
     opacity: @disabledOpacity;
   }
 

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -689,7 +689,7 @@ $.fn.calendar = function(parameters) {
 
         check: {
           disabled: function(){
-            $input.prop('disabled',module.is.disabled());
+            $input.attr('tabindex',module.is.disabled() ? -1 : 0);
           }
         },
 

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -368,9 +368,9 @@ $.fn.dropdown = function(parameters) {
             if( module.is.search() && !module.has.search() ) {
               module.verbose('Adding search input');
               $search = $('<input />')
-                  .addClass(className.search)
-                  .prop('autocomplete', 'off')
-                  .insertBefore($text)
+                 .addClass(className.search)
+                 .prop('autocomplete', 'off')
+                 .insertBefore($text)
               ;
             }
             if( module.is.multiple() && module.is.searchSelection() && !module.has.sizer()) {

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -365,16 +365,13 @@ $.fn.dropdown = function(parameters) {
                 .insertBefore($text)
               ;
             }
-            if( module.is.search()){
-              if(!module.has.search()) {
-                module.verbose('Adding search input');
-                $search = $('<input />')
-                    .addClass(className.search)
-                    .prop('autocomplete', 'off')
-                    .insertBefore($text)
-                ;
-              }
-              module.check.disabled();
+            if( module.is.search() && !module.has.search() ) {
+              module.verbose('Adding search input');
+              $search = $('<input />')
+                  .addClass(className.search)
+                  .prop('autocomplete', 'off')
+                  .insertBefore($text)
+              ;
             }
             if( module.is.multiple() && module.is.searchSelection() && !module.has.sizer()) {
               module.create.sizer();
@@ -2166,7 +2163,7 @@ $.fn.dropdown = function(parameters) {
             return true;
           },
           disabled: function(){
-            $search.prop('disabled',module.is.disabled());
+            $search.attr('tabindex',module.is.disabled() ? -1 : 0);
           }
         },
 
@@ -2432,8 +2429,8 @@ $.fn.dropdown = function(parameters) {
               module.debug('Added tabindex to searchable dropdown');
               $search
                 .val('')
-                .attr('tabindex', 0)
               ;
+              module.check.disabled();
               $menu
                 .attr('tabindex', -1)
               ;

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -368,9 +368,9 @@ $.fn.dropdown = function(parameters) {
             if( module.is.search() && !module.has.search() ) {
               module.verbose('Adding search input');
               $search = $('<input />')
-                 .addClass(className.search)
-                 .prop('autocomplete', 'off')
-                 .insertBefore($text)
+                .addClass(className.search)
+                .prop('autocomplete', 'off')
+                .insertBefore($text)
               ;
             }
             if( module.is.multiple() && module.is.searchSelection() && !module.has.sizer()) {

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -97,6 +97,7 @@ $.fn.dropdown = function(parameters) {
         id,
         selectObserver,
         menuObserver,
+        classObserver,
         module
       ;
 
@@ -162,15 +163,18 @@ $.fn.dropdown = function(parameters) {
           ;
           module.disconnect.menuObserver();
           module.disconnect.selectObserver();
+          module.disconnect.classObserver();
         },
 
         observeChanges: function() {
           if('MutationObserver' in window) {
             selectObserver = new MutationObserver(module.event.select.mutation);
             menuObserver   = new MutationObserver(module.event.menu.mutation);
-            module.debug('Setting up mutation observer', selectObserver, menuObserver);
+            classObserver  = new MutationObserver(module.event.class.mutation);
+            module.debug('Setting up mutation observer', selectObserver, menuObserver, classObserver);
             module.observe.select();
             module.observe.menu();
+            module.observe.class();
           }
         },
 
@@ -183,6 +187,11 @@ $.fn.dropdown = function(parameters) {
           selectObserver: function() {
             if(selectObserver) {
               selectObserver.disconnect();
+            }
+          },
+          classObserver: function() {
+            if(classObserver) {
+              classObserver.disconnect();
             }
           }
         },
@@ -200,6 +209,13 @@ $.fn.dropdown = function(parameters) {
               menuObserver.observe($menu[0], {
                 childList : true,
                 subtree   : true
+              });
+            }
+          },
+          class: function() {
+            if(module.has.search() && classObserver) {
+              classObserver.observe($module[0], {
+                attributes : true
               });
             }
           }
@@ -349,13 +365,16 @@ $.fn.dropdown = function(parameters) {
                 .insertBefore($text)
               ;
             }
-            if( module.is.search() && !module.has.search() ) {
-              module.verbose('Adding search input');
-              $search = $('<input />')
-                .addClass(className.search)
-                .prop('autocomplete', 'off')
-                .insertBefore($text)
-              ;
+            if( module.is.search()){
+              if(!module.has.search()) {
+                module.verbose('Adding search input');
+                $search = $('<input />')
+                    .addClass(className.search)
+                    .prop('autocomplete', 'off')
+                    .insertBefore($text)
+                ;
+              }
+              module.check.disabled();
             }
             if( module.is.multiple() && module.is.searchSelection() && !module.has.sizer()) {
               module.create.sizer();
@@ -1214,6 +1233,15 @@ $.fn.dropdown = function(parameters) {
                   event.preventDefault();
                 }
               }
+            }
+          },
+          class: {
+            mutation: function(mutations) {
+              mutations.forEach(function(mutation) {
+                if(mutation.attributeName === "class") {
+                  module.check.disabled();
+                }
+              });
             }
           },
           select: {
@@ -2136,6 +2164,9 @@ $.fn.dropdown = function(parameters) {
               }
             }
             return true;
+          },
+          disabled: function(){
+            $search.prop('disabled',module.is.disabled());
           }
         },
 


### PR DESCRIPTION
## Description
When a dropdown with search selection, or a calendar field, is disabled, the input fields were still accessible by using the tab key

#### Hint for reviewers
- i adopted the same observer logic code to calendar as it was already existing in dropdown
- i also fixed the variable declaration for `selectionComplete` (implemented by #1602 (was defined globally instead of module instance))

## Testcase
- Click left next to the top disabled calendar field
- Press tab 

### Broken
... it enters the disabled calendar field 😞 
... pressing tab again will enter the disabled dropdown field 😢 

https://jsfiddle.net/lubber/2qdjhrvc/5/

### Fixed
.. the first button is focused as expected
https://jsfiddle.net/lubber/2qdjhrvc/10/

## Screenshot
### Broken
![disabledtabinput_broken](https://user-images.githubusercontent.com/18379884/88466810-84843e00-ced0-11ea-883a-b1e33c0e4704.gif)

### Fixed
![disabledtabinput_fixed](https://user-images.githubusercontent.com/18379884/88466812-8bab4c00-ced0-11ea-9d14-f935b27b7b7a.gif)


## Closes
#1605 