### PR TITLE
[Form]: Remove existing error messages on clear and reset and adjust error messages on revalidation when not inline

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -219,6 +219,11 @@ $.fn.form = function(parameters) {
               $field.val('');
             }
           });
+          $module.removeClass(className.error).removeClass(className.success);
+          if(!settings.inline) {
+            module.remove.errors();
+          }
+          module.determine.isDirty();
         },
 
         reset: function() {
@@ -259,7 +264,10 @@ $.fn.form = function(parameters) {
               $field.val(defaultValue);
             }
           });
-
+          $module.removeClass(className.error).removeClass(className.success);
+          if(!settings.inline) {
+            module.remove.errors();
+          }
           module.determine.isDirty();
         },
 
@@ -461,6 +469,9 @@ $.fn.form = function(parameters) {
                 module.timer = setTimeout(function() {
                   module.debug('Revalidating field', $field,  module.get.validation($field));
                   module.validate.field( validationRules );
+                  if(!settings.inline) {
+                    module.validate.form(false,true);
+                  }
                 }, settings.delay);
               }
             }
@@ -918,6 +929,10 @@ $.fn.form = function(parameters) {
         },
 
         remove: {
+          errors: function() {
+            module.debug('Removing form error messages');
+            $message.empty();
+          },
           rule: function(field, rule) {
             var
               rules = Array.isArray(rule)
@@ -1163,6 +1178,9 @@ $.fn.form = function(parameters) {
             if( module.determine.isValid() ) {
               module.debug('Form has no validation errors, submitting');
               module.set.success();
+              if(!settings.inline) {
+                module.remove.errors();
+              }
               if(ignoreCallbacks !== true) {
                 return settings.onSuccess.call(element, event, values);
               }

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -219,11 +219,7 @@ $.fn.form = function(parameters) {
               $field.val('');
             }
           });
-          $module.removeClass(className.error).removeClass(className.success);
-          if(!settings.inline) {
-            module.remove.errors();
-          }
-          module.determine.isDirty();
+          module.remove.states();
         },
 
         reset: function() {
@@ -264,11 +260,7 @@ $.fn.form = function(parameters) {
               $field.val(defaultValue);
             }
           });
-          $module.removeClass(className.error).removeClass(className.success);
-          if(!settings.inline) {
-            module.remove.errors();
-          }
-          module.determine.isDirty();
+          module.remove.states();
         },
 
         determine: {
@@ -932,6 +924,13 @@ $.fn.form = function(parameters) {
           errors: function() {
             module.debug('Removing form error messages');
             $message.empty();
+          },
+          states: function() {
+            $module.removeClass(className.error).removeClass(className.success);
+            if(!settings.inline) {
+              module.remove.errors();
+            }
+            module.determine.isDirty();
           },
           rule: function(field, rule) {
             var


### PR DESCRIPTION
## Description
Whenever a form was cleared or reset by their respective behaviors `clear` or `reset`, any existing error messages were not removed
Additionally , when form fields are revalidated after they have been invalidated the error message was still visible in the error messages. However this was not the case when the form had inline errors.

## Testcase
#### Broken
https://jsfiddle.net/lubber/70c8tapg/10/

#### Fixed
https://jsfiddle.net/lubber/70c8tapg/12/

## Screenshot
|Broken|Fixed|
|-|-|
|![formvlearerror_wrong](https://user-images.githubusercontent.com/18379884/88725726-cf9a8d00-d12c-11ea-8edd-4dcc29fc1e57.gif)|![formvlearerror_right](https://user-images.githubusercontent.com/18379884/88725736-d6290480-d12c-11ea-8912-fe1297651d6c.gif)|

## Closes
#1610 
https://github.com/Semantic-Org/Semantic-UI/issues/4363
https://github.com/Semantic-Org/Semantic-UI/issues/702



