### PR TITLE
[Form] dirty state check failed for multiple variant of native select tag

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -366,14 +366,14 @@ $.fn.form = function(parameters) {
             var initialValue = $el.data(metadata.defaultValue);
             // Explicitly check for null/undefined here as value may be `false`, so ($el.data(dataInitialValue) || '') would not work
             if (initialValue == null) { initialValue = ''; }
+            else if(Array.isArray(initialValue)) {
+              initialValue = initialValue.toString();
+            }
             var currentValue = $el.val();
             if (currentValue == null) { currentValue = ''; }
             // multiple select values are returned as arrays which are never equal, so do string conversion first
-            if(Array.isArray(currentValue)) {
+            else if(Array.isArray(currentValue)) {
               currentValue = currentValue.toString();
-            }
-            if(Array.isArray(initialValue)) {
-              initialValue = initialValue.toString();
             }
             // Boolean values can be encoded as "true/false" or "True/False" depending on underlying frameworks so we need a case insensitive comparison
             var boolRegex = /^(true|false)$/i;

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -368,7 +368,13 @@ $.fn.form = function(parameters) {
             if (initialValue == null) { initialValue = ''; }
             var currentValue = $el.val();
             if (currentValue == null) { currentValue = ''; }
-
+            // multiple select values are returned as arrays which are never equal, so do string conversion first
+            if(Array.isArray(currentValue)) {
+              currentValue = currentValue.toString();
+            }
+            if(Array.isArray(initialValue)) {
+              initialValue = initialValue.toString();
+            }
             // Boolean values can be encoded as "true/false" or "True/False" depending on underlying frameworks so we need a case insensitive comparison
             var boolRegex = /^(true|false)$/i;
             var isBoolValue = boolRegex.test(initialValue) && boolRegex.test(currentValue);


### PR DESCRIPTION
## Description
The `fieldDirty` check failed whenever a dropdown, converted from a `select` tag, was part of the form **and** was defined as `multiple`
The comparison of currentValue and initialValue failed for those dropdowns, because the `.val()` method returned arrays instead of strings for select-multiple fields. Dropdowns made out of `div` were working, because those use an input field, which holds a string.
Raw `==` comparisons of two arrays are never true, so that fiel was always considered dirty.

## Testcase
Just click into the textarea to trigger the forms dirty check ...
### Broken
... the dirty check for the form will immediatly fail (considered dirty), even though no value has been changed, and triggers the onDirty event
https://jsfiddle.net/vtbyr8o1

### Fixed
... the dirty check successfully considers the form to be untouched, thus not triggering the onDirty event.
https://jsfiddle.net/lubber/sjnv3wkp/

## Closes
#930 