### PR TITLE
[Chore] fix cdn default js file

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "license": "MIT",
   "author": "Jack Lukic <jack@semantic-ui.com>",
-  "main": "dist/semantic",
+  "main": "dist/semantic.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/fomantic/Fomantic-UI.git"


### PR DESCRIPTION
## Description
The `main` property in package.json misses  the file extension. [jsdelivr needs the file extension](https://www.jsdelivr.com/features#publishing-packages), otherwise it does not recognize the default file. It's also [advised by npm](https://docs.npmjs.com/creating-a-package-json-file) to include the file extension.

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6999