### PR TITLE
[Form] isValid should not delete error state

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -338,18 +338,18 @@ $.fn.form = function(parameters) {
           blank: function($field) {
             return String($field.val()).trim() === '';
           },
-          valid: function(field) {
+          valid: function(field, showErrors) {
             var
               allValid = true
             ;
             if(field) {
               module.verbose('Checking if field is valid', field);
-              return module.validate.field(validation[field], field, false);
+              return module.validate.field(validation[field], field, !!showErrors);
             }
             else {
               module.verbose('Checking if form is valid');
               $.each(validation, function(fieldName, field) {
-                if( !module.is.valid(fieldName) ) {
+                if( !module.is.valid(fieldName, showErrors) ) {
                   allValid = false;
                 }
               });
@@ -1218,7 +1218,9 @@ $.fn.form = function(parameters) {
               module.debug('Field depends on another value that is not present or empty. Skipping', $dependsField);
             }
             else if(field.rules !== undefined) {
-              $field.closest($group).removeClass(className.error);
+              if(showErrors) {
+                $field.closest($group).removeClass(className.error);
+              }
               $.each(field.rules, function(index, rule) {
                 if( module.has.field(identifier)) {
                   var invalidFields = module.validate.rule(field, rule,true) || [];


### PR DESCRIPTION
## Description
the `is valid` behavior deletes possible existing error states on a field, although it shouldn't.
That's because the field validator always removes the error state by default (before probably adding it again) and did not respect a `showErrors` setting. showErrors however is only meant to show **new** errors. If it is false it should not touch any existing error state class.

I now also added the `showErrors` parameter as an option to the `is valid` behavior in case someone definately wants to show errors on **not already validated** fields.

As the parameter is optional the change is fully backwards compatible.

## Testcase
- Click on "submit" to invalidate the form
- Click on the second button to call `is valid`

#### Broken
- The invalid field loses its error state
https://jsfiddle.net/02gfdbx9/

#### Fixed
- The invalid field stays invalid
https://jsfiddle.net/lubber/1978duwp/4/

## Screenshot
|Before|After|
|-|-|
|![isvalid_wrong](https://user-images.githubusercontent.com/18379884/88770692-765b4980-d17e-11ea-9487-1c486cfcc7c9.gif)|![isvalid_right](https://user-images.githubusercontent.com/18379884/88770705-7a876700-d17e-11ea-87ea-074a3cb92e63.gif)|


## Closes
#923 