### PR TITLE
[Form] Adjust checkbox margins in grouped inline fields for nice distance of error prompts

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -860,6 +860,9 @@
     margin: @groupedFieldMargin;
     padding: 0;
   }
+  .ui.form .grouped.inline.fields .ui.checkbox {
+    margin-bottom: @groupedInlineCheckboxBottomMargin;
+  }
 }
 
 /*--------------------

--- a/src/themes/default/collections/form.variables
+++ b/src/themes/default/collections/form.variables
@@ -161,6 +161,7 @@
 @inlineCalendarWidth: 13.11em;
 
 @groupedInlineLabelMargin: 0.035714em 1em 0 0;
+@groupedInlineCheckboxBottomMargin: 0.4em;
 
 /*-------------------
        Groups


### PR DESCRIPTION
## Description

When error prompts appear on checkboxes inside of `grouped inline fields`, there was no distance between error prompts in comparison to single inline fields.
Suggested by @VanquishedWombat , this PR slightly adjusts the bottom margin , so the distance looks better (not exactly equal to single inline fields, because the grouping should still be recognizable)

## Testcase
Look at the prompt distance of the 2 groups of radios and checkboxes which are grouped inline. The top three checkboxes are single inline for comparison

#### Before
https://jsfiddle.net/lubber/8wbf1z0v/10/

#### After
https://jsfiddle.net/lubber/8wbf1z0v/9/

## Screenshot 
|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/88800515-969ffe00-d1a8-11ea-8891-e50a43d209e6.png)|![image](https://user-images.githubusercontent.com/18379884/88800584-b0414580-d1a8-11ea-9193-05892e373603.png)|

## Closes
#1387 