### PR TITLE
fix(image): Support the image to be centered when using a different H…

### DIFF
--- a/src/definitions/elements/image.less
+++ b/src/definitions/elements/image.less
@@ -91,26 +91,35 @@ img.ui.image {
     Vertical Aligned
   -------------------*/
 
-  .ui.top.aligned.images .image,
   .ui.top.aligned.image,
   .ui.top.aligned.image svg,
   .ui.top.aligned.image img {
     display: inline-block;
     vertical-align: top;
   }
-  .ui.middle.aligned.images .image,
   .ui.middle.aligned.image,
   .ui.middle.aligned.image svg,
   .ui.middle.aligned.image img {
     display: inline-block;
     vertical-align: middle;
   }
-  .ui.bottom.aligned.images .image,
   .ui.bottom.aligned.image,
   .ui.bottom.aligned.image svg,
   .ui.bottom.aligned.image img {
     display: inline-block;
     vertical-align: bottom;
+  }
+  .ui.top.aligned.images .image, 
+  .ui.images .ui.top.aligned.image {
+    align-self: flex-start;
+  }
+  .ui.middle.aligned.images .image, 
+  .ui.images .ui.middle.aligned.image {
+    align-self: center;
+  }
+  .ui.bottom.aligned.images .image, 
+  .ui.images .ui.bottom.aligned.image {
+    align-self: flex-end;
   }
 }
 
@@ -250,10 +259,17 @@ img.ui.image {
 }
 
 & when (@variationImageCentered) {
-  .ui.centered.images,
   .ui.centered.image {
+    display: block;
     margin-left: auto;
     margin-right: auto;
+  }
+  .ui.centered.images {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: stretch;
+    justify-content: center;
   }
 }
 


### PR DESCRIPTION
## Description
This PR supports the image component to be centered horizontally which doesn't use HTML `img` tag. For example, using anchor tag as image link or a DIV container wasn't able to be centered in the page despite using `centered image` class name.

The group images were supposed to be center when using `centered` class name, but it never really were. It only set auto for left and right margin but with no width declaration which doesn't make the images to stay center. So, auto margin for left and right of the group images doesn't make sense and was removed in this PR. Instead, it's rendering as flex box and the images inside are now centered as it supposed to be.

The group images can also share the same vertical alignment or can have independent alignment for it's own now.

## Testcase
**Before:** https://jsfiddle.net/v759o1rb/1/

**After:** https://jsfiddle.net/5tpk3evz/1/

## Closes
#1608 