### PR TITLE
[Form] Reset submitting flag when validation fails to keep dirtycheck with preventLeaving setting

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1186,6 +1186,7 @@ $.fn.form = function(parameters) {
             }
             else {
               module.debug('Form has errors');
+              submitting = false;
               module.set.error();
               if(!settings.inline) {
                 module.add.errors(formErrors);


### PR DESCRIPTION
## Description

When the `preventLeaving` feature is used, the dirtycheck was ignored on a submit even when the validation failed (which aborts the submit).
Whenever a validation failes it should therefore also reset a possible existing submitting flag to keep the preventLeavin feature working

## Testcase
- Enter some letter (not a number) into the input field, so the form gets dirty, but is still invalid
- Click on the "Google Link" next to the submit button
- The Browser will tell you that there are changes in the form 👍 Click Cancel
- Now click on the submit button, it will invalidate the fields
-Click on the "Google Link" again...

### Broken
- The Browser immediatly redirects to the Google site and does not warn you about the form changes
https://jsfiddle.net/lubber/tfceLxas

### Fixed
- The Browser will also tell you that there are changes in the form as it should
https://jsfiddle.net/lubber/tfceLxas/1/