### PR TITLE
[Dropdown] Use configured 'fields.values' key instead of fixed 'values'

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -795,7 +795,7 @@ $.fn.dropdown = function(parameters) {
                 }
                 module.remove.message();
                 module.setup.menu({
-                  values: values
+                  [fields.values]: values
                 });
 
                 if(values.length===0 && !settings.allowAdditions) {
@@ -992,7 +992,7 @@ $.fn.dropdown = function(parameters) {
               module.clear();
             }
             module.debug('Creating dropdown with specified values', values);
-            module.setup.menu({values: values});
+            module.setup.menu({[fields.values]: values});
             $.each(values, function(index, item) {
               if(item.selected == true) {
                 module.debug('Setting initial selection to', item[fields.value]);
@@ -1958,7 +1958,7 @@ $.fn.dropdown = function(parameters) {
               select = {},
               oldGroup = []
             ;
-            select.values = [];
+            select[fields.values] = [];
             $module
               .find('option')
                 .each(function() {
@@ -1979,14 +1979,14 @@ $.fn.dropdown = function(parameters) {
                   }
                   else {
                     if(group.length !== oldGroup.length || group[0] !== oldGroup[0]) {
-                      select.values.push({
+                      select[fields.values].push({
                         type: 'header',
                         divider: settings.headerDivider,
                         name: group.attr('label') || ''
                       });
                       oldGroup = group;
                     }
-                    select.values.push({
+                    select[fields.values].push({
                       name     : name,
                       value    : value,
                       text     : text,
@@ -2001,15 +2001,15 @@ $.fn.dropdown = function(parameters) {
             }
             if(settings.sortSelect) {
               if(settings.sortSelect === true) {
-                select.values.sort(function(a, b) {
+                select[fields.values].sort(function(a, b) {
                   return a.name.localeCompare(b.name);
                 });
               } else if(settings.sortSelect === 'natural') {
-                select.values.sort(function(a, b) {
+                select[fields.values].sort(function(a, b) {
                   return (a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
                 });
               } else if($.isFunction(settings.sortSelect)) {
-                select.values.sort(settings.sortSelect);
+                select[fields.values].sort(settings.sortSelect);
               }
               module.debug('Retrieved and sorted values from select', select);
             }

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -412,9 +412,7 @@ $.fn.dropdown = function(parameters) {
             module.refresh();
           },
           menu: function(values) {
-            const response = values;
-            response[fields.values] = values.values;
-            $menu.html( templates.menu(response, fields,settings.preserveHTML,settings.className));
+            $menu.html( templates.menu(values, fields,settings.preserveHTML,settings.className));
             $item    = $menu.find(selector.item);
             $divider = settings.hideDividers ? $item.parent().children(selector.divider) : $();
           },

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -794,9 +794,9 @@ $.fn.dropdown = function(parameters) {
                     values = [];
                 }
                 module.remove.message();
-                module.setup.menu({
-                  [fields.values]: values
-                });
+                var menuConfig = {};
+                menuConfig[fields.values] = values;
+                module.setup.menu(menuConfig);
 
                 if(values.length===0 && !settings.allowAdditions) {
                   module.add.message(message.noResults);
@@ -992,7 +992,9 @@ $.fn.dropdown = function(parameters) {
               module.clear();
             }
             module.debug('Creating dropdown with specified values', values);
-            module.setup.menu({[fields.values]: values});
+            var menuConfig = {};
+            menuConfig[fields.values] = values;
+            module.setup.menu(menuConfig);
             $.each(values, function(index, item) {
               if(item.selected == true) {
                 module.debug('Setting initial selection to', item[fields.value]);

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -795,7 +795,7 @@ $.fn.dropdown = function(parameters) {
                 }
                 module.remove.message();
                 module.setup.menu({
-                  [fields.values]: values
+                  values: values
                 });
 
                 if(values.length===0 && !settings.allowAdditions) {
@@ -992,7 +992,7 @@ $.fn.dropdown = function(parameters) {
               module.clear();
             }
             module.debug('Creating dropdown with specified values', values);
-            module.setup.menu({[[fields.values]]: values});
+            module.setup.menu({values: values});
             $.each(values, function(index, item) {
               if(item.selected == true) {
                 module.debug('Setting initial selection to', item[fields.value]);

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -795,7 +795,7 @@ $.fn.dropdown = function(parameters) {
                 }
                 module.remove.message();
                 module.setup.menu({
-                  values: values
+                  [fields.values]: values
                 });
 
                 if(values.length===0 && !settings.allowAdditions) {
@@ -992,7 +992,7 @@ $.fn.dropdown = function(parameters) {
               module.clear();
             }
             module.debug('Creating dropdown with specified values', values);
-            module.setup.menu({values: values});
+            module.setup.menu({[[fields.values]]: values});
             $.each(values, function(index, item) {
               if(item.selected == true) {
                 module.debug('Setting initial selection to', item[fields.value]);

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1956,9 +1956,9 @@ $.fn.dropdown = function(parameters) {
           selectValues: function() {
             var
               select = {},
-              oldGroup = []
+              oldGroup = [],
+              values = []
             ;
-            select[fields.values] = [];
             $module
               .find('option')
                 .each(function() {
@@ -1979,14 +1979,14 @@ $.fn.dropdown = function(parameters) {
                   }
                   else {
                     if(group.length !== oldGroup.length || group[0] !== oldGroup[0]) {
-                      select[fields.values].push({
+                      values.push({
                         type: 'header',
                         divider: settings.headerDivider,
                         name: group.attr('label') || ''
                       });
                       oldGroup = group;
                     }
-                    select[fields.values].push({
+                    values.push({
                       name     : name,
                       value    : value,
                       text     : text,
@@ -2001,19 +2001,21 @@ $.fn.dropdown = function(parameters) {
             }
             if(settings.sortSelect) {
               if(settings.sortSelect === true) {
-                select[fields.values].sort(function(a, b) {
+                values.sort(function(a, b) {
                   return a.name.localeCompare(b.name);
                 });
               } else if(settings.sortSelect === 'natural') {
-                select[fields.values].sort(function(a, b) {
+                values.sort(function(a, b) {
                   return (a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
                 });
               } else if($.isFunction(settings.sortSelect)) {
-                select[fields.values].sort(settings.sortSelect);
+                values.sort(settings.sortSelect);
               }
+              select[fields.values] = values;
               module.debug('Retrieved and sorted values from select', select);
             }
             else {
+              select[fields.values] = values;
               module.debug('Retrieved values from select', select);
             }
             return select;

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -412,7 +412,9 @@ $.fn.dropdown = function(parameters) {
             module.refresh();
           },
           menu: function(values) {
-            $menu.html( templates.menu(values, fields,settings.preserveHTML,settings.className));
+            const response = values;
+            response[fields.values] = values.values;
+            $menu.html( templates.menu(response, fields,settings.preserveHTML,settings.className));
             $item    = $menu.find(selector.item);
             $divider = settings.hideDividers ? $item.parent().children(selector.divider) : $();
           },


### PR DESCRIPTION
## Description
When calling `templates.menu()`, the object passed always has a single fixed key `values`.
However, the implementation of `templates.menu()` reads the object with the configurable key `fields.values`.
So if a key other then `values` is configured, this will fail.

```
$("#selectBox").dropdown({
	fields: {
		values: 'valuesX'
	}
});
```


## Testcase
See [JSFiddle](https://jsfiddle.net/wardlootens/04war7mx/3/)
