### PR TITLE
feat(slider): prevent line break in slider label and support bottom aligned label

### DIFF
--- a/src/definitions/modules/slider.less
+++ b/src/definitions/modules/slider.less
@@ -195,8 +195,14 @@
 
   .ui.labeled.slider > .labels .label {
     display: inline-flex;
+    padding: @labelPadding;
     position: absolute;
     transform: translate(-50%, -100%);
+    white-space: nowrap;
+  }
+
+  .ui.bottom.aligned.labeled.slider > .labels .label {
+    transform: translate(-50%, 100%);
   }
   & when (@variationSliderTicked) {
     .ui.labeled.ticked.slider > .labels .label:after {
@@ -207,6 +213,9 @@
       position: absolute;
       top: 100%;
       left: 50%;
+    }
+    .ui.bottom.aligned.labeled.ticked.slider > .labels .label:after {
+      top: -100%;
     }
     .ui.labeled.ticked.slider > .labels .halftick.label:after {
       height: @labelHeight / 2;

--- a/src/themes/default/modules/slider.variables
+++ b/src/themes/default/modules/slider.variables
@@ -57,6 +57,7 @@
 @labelHeight  : @height;
 @labelWidth   : 1px;
 @labelColor   : @background;
+@labelPadding : 0.2em 0;
 
 /* Hover */
 @hoverVarOpacity                 : 0;


### PR DESCRIPTION
## Description
This PR encourages the slider label to appear in one line without breaking the word into new line especially when the last label contains more than one word and break into multiple line which make the label overlaps the slider track in some situations.

This PR also supports to change the slider label position using `bottom aligned` flag in CSS class name which makes the label to be appeared below the slider track.

## Testcase
**Before:** https://jsfiddle.net/qr1hxs3L/

**After:** https://jsfiddle.net/qr1hxs3L/1/

## Screenshots
| Label Before | Label After  |
|---|---|
| ![Broken-Slider-Label](https://user-images.githubusercontent.com/930315/89179786-744a1e00-d5b6-11ea-81d2-e7ca72f93c0a.png) | ![Fix-Slider-Label](https://user-images.githubusercontent.com/930315/89179810-80ce7680-d5b6-11ea-90a8-7c179c4329d4.png) |

#### Top and bottom aligned labels ####
![Sliders](https://user-images.githubusercontent.com/930315/89180021-ed497580-d5b6-11ea-8269-1b056210e55d.png)

## Closes
#1625 
