### PR TITLE
fix(icon): Change two-word aliases into one-word aliases to avoid conflictions

### DIFF
--- a/src/themes/default/elements/icon.overrides
+++ b/src/themes/default/elements/icon.overrides
@@ -206,7 +206,7 @@ i.icon.chalkboard.teacher:before { content: "\f51c"; }
 i.icon.charging.station:before { content: "\f5e7"; }
 i.icon.chart.area:before { content: "\f1fe"; }
 i.icon.chart.bar:before { content: "\f080"; }
-i.icon.chart.line:before { content: "\f201"; }
+i.icon.chartline:before { content: "\f201"; }
 i.icon.chart.pie:before { content: "\f200"; }
 i.icon.check:before { content: "\f00c"; }
 i.icon.check.circle:before { content: "\f058"; }
@@ -1177,7 +1177,7 @@ i.icon.level.down:before { content: "\f3be"; }
 i.icon.level.up:before { content: "\f3bf"; }
 i.icon.lightning:before { content: "\f0e7"; }
 i.icon.like:before { content: "\f004"; }
-i.icon.line.graph:before { content: "\f201"; }
+i.icon.linegraph:before { content: "\f201"; }
 i.icon.linkify:before { content: "\f0c1"; }
 i.icon.lira:before { content: "\f195"; }
 i.icon.list.layout:before { content: "\f00b"; }


### PR DESCRIPTION
## Description
The two-word aliases for `chart line` and `line graph` are renamed into one-word aliases `chartline` and `linegraph` respectively to avoid conflicting with the class name `line` which is used by other FUI components.

## Testcase
**Broken:** https://jsfiddle.net/tqmab8vu/1/

**Fixed:** https://jsfiddle.net/85mw6can/

## Closes
#1619
