### PR TITLE
feat(icon): add the old two classes for linegraph and chartline for c…

### DIFF
--- a/src/themes/default/elements/icon.overrides
+++ b/src/themes/default/elements/icon.overrides
@@ -206,6 +206,7 @@ i.icon.chalkboard.teacher:before { content: "\f51c"; }
 i.icon.charging.station:before { content: "\f5e7"; }
 i.icon.chart.area:before { content: "\f1fe"; }
 i.icon.chart.bar:before { content: "\f080"; }
+i.icon.chart.line:before { content: "\f201"; }
 i.icon.chartline:before { content: "\f201"; }
 i.icon.chart.pie:before { content: "\f200"; }
 i.icon.check:before { content: "\f00c"; }
@@ -1177,6 +1178,7 @@ i.icon.level.down:before { content: "\f3be"; }
 i.icon.level.up:before { content: "\f3bf"; }
 i.icon.lightning:before { content: "\f0e7"; }
 i.icon.like:before { content: "\f004"; }
+i.icon.line.graph:before { content: "\f201"; }
 i.icon.linegraph:before { content: "\f201"; }
 i.icon.linkify:before { content: "\f0c1"; }
 i.icon.lira:before { content: "\f195"; }


### PR DESCRIPTION
## Description
This PR re-adds the two word icon names for `chartline` and `linegraph` as of #1636  to avoid being a breaking change as @prudho mentioned [here](https://github.com/fomantic/create-fomantic-icons/pull/115#issuecomment-671762616) .

The next full font awesome update will happen in 2.9.0 using the fixes from https://github.com/fomantic/create-fomantic-icons/pull/115 Then two word aliases will be completely removed 