### PR TITLE
[Build] Fix issue when "individuals" or "components" has only single element 

### DIFF
--- a/tasks/config/project/config.js
+++ b/tasks/config/project/config.js
@@ -128,18 +128,14 @@ module.exports = {
     }
 
     // takes component object and creates file glob matching selected components
-    config.globs.components = (typeof config.components == 'object')
-      ? (config.components.length > 1)
-        ? '{' + config.components.join(',') + '}'
-        : config.components[0]
+    config.globs.components = (Array.isArray(config.components) && config.components.length >= 1)
+      ? '{' + config.components.join(',') + '}'
       : '{' + defaults.components.join(',') + '}'
     ;
 
     // components that should be built, but excluded from main .css/.js files
-    config.globs.individuals = (typeof config.individuals == 'object')
-      ? (config.individuals.length > 1)
-        ? '{' + config.individuals.join(',') + '}'
-        : config.individuals[0]
+    config.globs.individuals = (Array.isArray(config.individuals) && config.individuals.length >= 1)
+      ? '{' + config.individuals.join(',') + '}'
       : undefined
     ;
 


### PR DESCRIPTION
## Description

It seems that the current logic (below) to create file blob like `{foo,bar,buz}.less` assumes that `config.globs.individuals` is always like `{a,b,c}`, but it does not when `individuals` has only one single element.
https://github.com/fomantic/Fomantic-UI/blob/74458216193cbf22653784a98f58ce57b0fc0244/tasks/build/css.js#L131-L134

After This PR, `config.globs.components` and `config.globs.individuals` are `{a,b,c}` if those arrays has 1 or more elements, so `build/css.js` and `build/javascript.js` works regardless of the number of elements in `individuals`/`components`




## Testcase

I have no idea how to test build tasks.... 
Suggestion is highly appreciated 🙏 

## Closes
#1638