### PR TITLE
[Build] Remove individuals from components so users can specify only individuals

### DIFF
--- a/tasks/config/project/config.js
+++ b/tasks/config/project/config.js
@@ -127,15 +127,22 @@ module.exports = {
       });
     }
 
-    // takes component object and creates file glob matching selected components
-    config.globs.components = (Array.isArray(config.components) && config.components.length >= 1)
-      ? '{' + config.components.join(',') + '}'
-      : '{' + defaults.components.join(',') + '}'
+    const components = (Array.isArray(config.components) && config.components.length >= 1)
+      ? config.components
+      : defaults.components
     ;
+    const individuals =  (Array.isArray(config.individuals) && config.individuals.length >= 1)
+      ? config.individuals
+      : []
+    ;
+    const componentsExceptIndividuals = components.filter((component) => !individuals.includes(component));
+
+    // takes component object and creates file glob matching selected components
+    config.globs.components = '{' + componentsExceptIndividuals.join(',') + '}';
 
     // components that should be built, but excluded from main .css/.js files
-    config.globs.individuals = (Array.isArray(config.individuals) && config.individuals.length >= 1)
-      ? '{' + config.individuals.join(',') + '}'
+    config.globs.individuals = (individuals.length >= 1)
+      ? '{' + individuals.join(',') + '}'
       : undefined
     ;
 


### PR DESCRIPTION
## Description
Implement https://github.com/fomantic/Fomantic-UI/pull/1639#discussion_r468923211

So users no need to remove the items in `individuals` from `components`, or even can omit `components` at all.

Corresponding docs update: https://github.com/fomantic/Fomantic-UI-Docs/pull/224

## Closes
no-issue
