### PR TITLE
[Calendar] Support safari to accept yyyy-mm-dd format using dashes

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -1468,7 +1468,7 @@ $.fn.calendar.settings = {
         return null;
       }
       if(text.match(/^[0-9]{4}[\/\-\.][0-9]{2}[\/\-\.][0-9]{2}$/)){
-        text += ' 00:00:00';
+        text = text.replace(/[\/\-\.]/g,'/') + ' 00:00:00';
       }
       // Reverse date and month in some cases
       text = settings.monthFirst || !text.match(/^[0-9]{2}[\/\-\.]/) ? text : text.replace(/[\/\-\.]/g,'/').replace(/([0-9]+)\/([0-9]+)/,'$2/$1');


### PR DESCRIPTION
## Description
After implementing #1462, a pure given date in `yyyy-mm-dd` format did not work in safari  anymore , because safari does not handle the internal converted date of `yyyy-mm-dd 00:00:00`

This PR now changes the dashes to slashes, so the internal result is  `yyyy/mm/dd 00:00:00`, which is supported in every browser

## Testcase
- Use Safari

### Broken
The given date `2020-08-12` results in `August, 12, 2000`
https://jsfiddle.net/lubber/s82zoc5w/

### Fixed
The given date `2020-08-12` correctly results in `August, 12, 2020` as in every other browser already
https://jsfiddle.net/lubber/s82zoc5w/2/

## Screenshots
#### Broken
![image](https://user-images.githubusercontent.com/18379884/90561172-96d85b80-e1a0-11ea-9191-4782b0e3343b.png)

#### Fixed
![image](https://user-images.githubusercontent.com/18379884/90561103-77d9c980-e1a0-11ea-81e2-9ae0ddb12fc5.png)

## Closes
https://github.com/fomantic/Fomantic-UI/issues/1462#issuecomment-672559777
