### PR TITLE
[Dropdown] optional show a scrollhint on ios devices (or firefox mobile) to indicate more entries

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -608,6 +608,40 @@ select.ui.dropdown {
     border: none !important;
     box-shadow: none !important;
   }
+  & when (@variationDropdownScrollhint) {
+    @supports (-webkit-overflow-scrolling: touch) {
+      /* CSS specific to iOS devices only  */
+      .ui.selection.dropdown .scrollhint.menu:not(.hidden):before {
+        content: '';
+        z-index: @scrollhintZIndex;
+        display: block;
+        position: absolute;
+        opacity: 0;
+        right: 0;
+        top: 0;
+        height: 100%;
+        border-right: @scrollhintRightBorder;
+        border-left: @scrollhintLeftBorder;
+        animation: scrollhint @scrollhintDuration @scrollhintEasing @scrollhintIteration;
+        border-image: linear-gradient(to bottom, @scrollhintStartColor, @scrollhintEndColor) 1 100%;
+      }
+
+      .ui.inverted.selection.dropdown .scrollhint.menu:not(.hidden):before {
+        border-image: linear-gradient(to bottom, @invertedScrollhintStartColor, @invertedScrollhintEndColor) 1 100%;
+      }
+
+      @keyframes scrollhint {
+        0% {
+          opacity: 1;
+          top: 100%;
+        }
+        100% {
+          opacity: 0;
+          top: 0;
+        }
+      }
+    }
+  }
 }
 
 & when (@variationDropdownSearch) {

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -609,36 +609,45 @@ select.ui.dropdown {
     box-shadow: none !important;
   }
   & when (@variationDropdownScrollhint) {
-    @supports (-webkit-overflow-scrolling: touch) {
-      /* CSS specific to iOS devices only  */
+    /* CSS specific to iOS devices only  */
+    @supports (-webkit-touch-callout: none) {
       .ui.selection.dropdown .scrollhint.menu:not(.hidden):before {
-        content: '';
-        z-index: @scrollhintZIndex;
-        display: block;
-        position: absolute;
-        opacity: 0;
-        right: 0;
-        top: 0;
-        height: 100%;
-        border-right: @scrollhintRightBorder;
-        border-left: @scrollhintLeftBorder;
         animation: scrollhint @scrollhintDuration @scrollhintEasing @scrollhintIteration;
-        border-image: linear-gradient(to bottom, @scrollhintStartColor, @scrollhintEndColor) 1 100%;
       }
-
-      .ui.inverted.selection.dropdown .scrollhint.menu:not(.hidden):before {
-        border-image: linear-gradient(to bottom, @invertedScrollhintStartColor, @invertedScrollhintEndColor) 1 100%;
+    }
+    /* CSS specific to Firefox mobile only  */
+    @media (-moz-touch-enabled) {
+      .ui.selection.dropdown .scrollhint.menu:not(.hidden):before {
+        animation: scrollhint @scrollhintDuration @scrollhintEasing @scrollhintIteration;
       }
+    }
 
-      @keyframes scrollhint {
-        0% {
-          opacity: 1;
-          top: 100%;
-        }
-        100% {
-          opacity: 0;
-          top: 0;
-        }
+    .ui.selection.dropdown .scrollhint.menu:not(.hidden):before {
+      content: '';
+      z-index: @scrollhintZIndex;
+      display: block;
+      position: absolute;
+      opacity: 0;
+      right: 0;
+      top: 0;
+      height: 100%;
+      border-right: @scrollhintRightBorder;
+      border-left: @scrollhintLeftBorder;
+      border-image: linear-gradient(to bottom, @scrollhintStartColor, @scrollhintEndColor) 1 100%;
+    }
+
+    .ui.inverted.selection.dropdown .scrollhint.menu:not(.hidden):before {
+      border-image: linear-gradient(to bottom, @invertedScrollhintStartColor, @invertedScrollhintEndColor) 1 100%;
+    }
+
+    @keyframes scrollhint {
+      0% {
+        opacity: 1;
+        top: 100%;
+      }
+      100% {
+        opacity: 0;
+        top: 0;
       }
     }
   }

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -614,36 +614,33 @@ select.ui.dropdown {
       @media (-moz-touch-enabled), (pointer: coarse) {
         .ui.dropdown .scrollhint.menu:not(.hidden):before {
           animation: scrollhint @scrollhintDuration @scrollhintEasing @scrollhintIteration;
+          content: '';
+          z-index: @scrollhintZIndex;
+          display: block;
+          position: absolute;
+          opacity: 0;
+          right: @scrollhintOffsetRight;
+          top: 0;
+          height: 100%;
+          border-right: @scrollhintRightBorder;
+          border-left: @scrollhintLeftBorder;
+          border-image: linear-gradient(to bottom, @scrollhintStartColor, @scrollhintEndColor) 1 100%;
         }
-      }
-    }
 
-    .ui.dropdown .scrollhint.menu:not(.hidden):before {
-      content: '';
-      z-index: @scrollhintZIndex;
-      display: block;
-      position: absolute;
-      opacity: 0;
-      right: @scrollhintOffsetRight;
-      top: 0;
-      height: 100%;
-      border-right: @scrollhintRightBorder;
-      border-left: @scrollhintLeftBorder;
-      border-image: linear-gradient(to bottom, @scrollhintStartColor, @scrollhintEndColor) 1 100%;
-    }
+        .ui.inverted.dropdown .scrollhint.menu:not(.hidden):before {
+          border-image: linear-gradient(to bottom, @invertedScrollhintStartColor, @invertedScrollhintEndColor) 1 100%;
+        }
 
-    .ui.inverted.dropdown .scrollhint.menu:not(.hidden):before {
-      border-image: linear-gradient(to bottom, @invertedScrollhintStartColor, @invertedScrollhintEndColor) 1 100%;
-    }
-
-    @keyframes scrollhint {
-      0% {
-        opacity: 1;
-        top: 100%;
-      }
-      100% {
-        opacity: 0;
-        top: 0;
+        @keyframes scrollhint {
+          0% {
+            opacity: 1;
+            top: 100%;
+          }
+          100% {
+            opacity: 0;
+            top: 0;
+          }
+        }
       }
     }
   }

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -611,24 +611,24 @@ select.ui.dropdown {
   & when (@variationDropdownScrollhint) {
     /* CSS specific to iOS devices only  */
     @supports (-webkit-touch-callout: none) {
-      .ui.selection.dropdown .scrollhint.menu:not(.hidden):before {
+      .ui.dropdown .scrollhint.menu:not(.hidden):before {
         animation: scrollhint @scrollhintDuration @scrollhintEasing @scrollhintIteration;
       }
     }
     /* CSS specific to Firefox mobile only  */
     @media (-moz-touch-enabled) {
-      .ui.selection.dropdown .scrollhint.menu:not(.hidden):before {
+      .ui.dropdown .scrollhint.menu:not(.hidden):before {
         animation: scrollhint @scrollhintDuration @scrollhintEasing @scrollhintIteration;
       }
     }
 
-    .ui.selection.dropdown .scrollhint.menu:not(.hidden):before {
+    .ui.dropdown .scrollhint.menu:not(.hidden):before {
       content: '';
       z-index: @scrollhintZIndex;
       display: block;
       position: absolute;
       opacity: 0;
-      right: 0;
+      right: @scrollhintOffsetRight;
       top: 0;
       height: 100%;
       border-right: @scrollhintRightBorder;
@@ -636,7 +636,7 @@ select.ui.dropdown {
       border-image: linear-gradient(to bottom, @scrollhintStartColor, @scrollhintEndColor) 1 100%;
     }
 
-    .ui.inverted.selection.dropdown .scrollhint.menu:not(.hidden):before {
+    .ui.inverted.dropdown .scrollhint.menu:not(.hidden):before {
       border-image: linear-gradient(to bottom, @invertedScrollhintStartColor, @invertedScrollhintEndColor) 1 100%;
     }
 

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -609,16 +609,12 @@ select.ui.dropdown {
     box-shadow: none !important;
   }
   & when (@variationDropdownScrollhint) {
-    /* CSS specific to iOS devices only  */
-    @supports (-webkit-touch-callout: none) {
-      .ui.dropdown .scrollhint.menu:not(.hidden):before {
-        animation: scrollhint @scrollhintDuration @scrollhintEasing @scrollhintIteration;
-      }
-    }
-    /* CSS specific to Firefox mobile only  */
-    @media (-moz-touch-enabled) {
-      .ui.dropdown .scrollhint.menu:not(.hidden):before {
-        animation: scrollhint @scrollhintDuration @scrollhintEasing @scrollhintIteration;
+    /* CSS specific to iOS devices or firefox mobile only  */
+    @supports (-webkit-touch-callout: none) or (-webkit-overflow-scrolling: touch) or (-moz-appearance:none) {
+      @media (-moz-touch-enabled), (pointer: coarse) {
+        .ui.dropdown .scrollhint.menu:not(.hidden):before {
+          animation: scrollhint @scrollhintDuration @scrollhintEasing @scrollhintIteration;
+        }
       }
     }
 

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -414,6 +414,7 @@
 @variationDropdownFluid: true;
 @variationDropdownFloating: true;
 @variationDropdownPointing: true;
+@variationDropdownScrollhint: true;
 @variationDropdownSizes: @variationAllSizes;
 
 /* Embed */

--- a/src/themes/default/modules/dropdown.variables
+++ b/src/themes/default/modules/dropdown.variables
@@ -375,12 +375,14 @@
 @pointingUpwardArrowBoxShadow: @menuBorderWidth @menuBorderWidth 0 0 @menuBorderColor;
 
 /* Scrollhint */
-@scrollhintRightBorder: 4px solid;
+@scrollhintWidth: 0.25em;
+@scrollhintRightBorder: @scrollhintWidth solid;
 @scrollhintLeftBorder: 0;
 @scrollhintZIndex: 15;
 @scrollhintDuration: 2s;
 @scrollhintEasing: @defaultEasing;
 @scrollhintIteration: 2;
+@scrollhintOffsetRight: @scrollhintWidth;
 @scrollhintStartColor: rgba(0, 0, 0, 0.75);
 @scrollhintEndColor: rgba(0, 0, 0, 0);
 

--- a/src/themes/default/modules/dropdown.variables
+++ b/src/themes/default/modules/dropdown.variables
@@ -374,6 +374,15 @@
 @pointingUpwardMenuBorderRadius: @borderRadius;
 @pointingUpwardArrowBoxShadow: @menuBorderWidth @menuBorderWidth 0 0 @menuBorderColor;
 
+/* Scrollhint */
+@scrollhintRightBorder: 4px solid;
+@scrollhintLeftBorder: 0;
+@scrollhintZIndex: 15;
+@scrollhintDuration: 2s;
+@scrollhintEasing: @defaultEasing;
+@scrollhintIteration: 2;
+@scrollhintStartColor: rgba(0, 0, 0, 0.75);
+@scrollhintEndColor: rgba(0, 0, 0, 0);
 
 /*--------------
     Inverted
@@ -451,3 +460,7 @@
 
 @invertedLabelIconOpacity: 0.6;
 @invertedLabelIconHoverOpacity: 0.8;
+
+/* Scrollhint */
+@invertedScrollhintStartColor: rgba(255, 255, 255, 0.75);
+@invertedScrollhintEndColor: rgba(255, 255, 255, 0);


### PR DESCRIPTION
## Description
IOS devices do not show a scrollbar when the content is not scrolled. This is a design decision by apple and cannot be adjusted via CSS (for example by  `-webkit-scrollbar`)
A similiar behavior is built into firefox mobile (also on Android)

That said if one opens a dropdown it is not clear, if the shown entries are the only available options or if the user has to scroll down to see more, which is confusing and probably leads to wrong selections (because the user did not know of more choices, because of avoided scrolling)

This PR provides the optional `scrollhint` class to be used for the `menu` to show a short animation hint on the right edge (where the usual scrollbar appears) when the dropdown opens to indicate swiping to see more entries

## Testcase
Use an iOS Device or Firefox mobile (also on Android)

### Normal
https://raw.githack.com/lubber-de/fomantic-ui/jsfiddlefullscreen/jsfiddle/#!lubber/2mcak7xr/129/

### using `scrollhint menu`
https://raw.githack.com/lubber-de/fomantic-ui/jsfiddlefullscreen/jsfiddle/#!lubber/2mcak7xr/190/

jsfiddle: https://jsfiddle.net/lubber/2mcak7xr/190/

## Screenshot
|Normal|using `scrollhint menu`|
|-|-|
|![iosnoscrollhint](https://user-images.githubusercontent.com/18379884/90977727-c7751800-e547-11ea-819a-cda6cc6320ec.gif)|![iosscrollhint](https://user-images.githubusercontent.com/18379884/90977728-cba13580-e547-11ea-8997-306f07e58fb6.gif)|

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5197 