### PR TITLE
[Search] Avoid unnecessary double link navigation

### DIFF
--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -239,6 +239,7 @@ $.fn.search = function(parameters) {
               }
               module.hideResults();
               if(href) {
+                event.preventDefault();
                 module.verbose('Opening search link found in result', $link);
                 if(target == '_blank' || event.ctrlKey) {
                   window.open(href);


### PR DESCRIPTION
## Description
Results in search responses which got an URL to be followed when clicked on it, are followed twice: First by the click event handler of a result and second by the native `a` link behavior

## Testcase
- Enter something in the search field so it returns some entries
- Click on one of the results
- Watch console (network tab)

### Broken
Link is followed twice 👎 
https://jsfiddle.net/lubber/nf8321pc/1/

### Fixed
Link is followed once 👍 
https://jsfiddle.net/lubber/nf8321pc/2/

## Screenshots
### Broken
![searchclickdouble](https://user-images.githubusercontent.com/18379884/91070544-25345d80-e637-11ea-963a-1b7dcd098340.gif)

### Fixed
![searchclicksingle](https://user-images.githubusercontent.com/18379884/91070557-29607b00-e637-11ea-964d-c8750ee1140b.gif)

## Closes
#1652 