### PR TITLE
[Site] greyhover and blackhover are declared twice

### DIFF
--- a/src/themes/default/globals/site.variables
+++ b/src/themes/default/globals/site.variables
@@ -1015,8 +1015,6 @@
 @purpleHover              : saturate(darken(@purple, 5), 10, relative);
 @pinkHover                : saturate(darken(@pink, 5), 10, relative);
 @brownHover               : saturate(darken(@brown, 5), 10, relative);
-@greyHover                : saturate(darken(@grey, 5), 10, relative);
-@blackHover               : saturate(darken(@black, 5), 10, relative);
 
 @lightRedHover            : saturate(darken(@lightRed, 10), 10, relative);
 @lightOrangeHover         : saturate(darken(@lightOrange, 10), 10, relative);


### PR DESCRIPTION
## Description
`blackHover` and `greyHover` are declared twice. The first one was obviously a copy/past regression when we centralized the color definitions.
However they don't have any effect because they are redeclared /overridden a second time some LOC later.

Also SUI does not have them declared twice (end with brown), so this PR makes the logic equal to SUI again.

https://github.com/Semantic-Org/Semantic-UI/blob/deb275d2d5fe9a522a0b7bd8b6b6a1c939552718/src/themes/default/globals/site.variables#L752-L754

SUI also just uses the declared versions later on
https://github.com/Semantic-Org/Semantic-UI/blob/deb275d2d5fe9a522a0b7bd8b6b6a1c939552718/src/themes/default/globals/site.variables#L783-L786

## Closes
#1654 