### PR TITLE
[Dropdown] Multiple search button dropdown misaligned, placeholder wraps and search text ghosting

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -681,7 +681,7 @@ select.ui.dropdown {
     color: @selectionTextUnderlayColor !important;
   }
 
-  .ui.search.dropdown.button. > span.sizer {
+  .ui.search.dropdown.button > span.sizer {
     display: none;
   }
 

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -681,6 +681,9 @@ select.ui.dropdown {
     color: @selectionTextUnderlayColor !important;
   }
 
+  .ui.search.dropdown.button. > span.sizer {
+    display: none;
+  }
 
   /* Search Menu */
   .ui.search.dropdown .menu {
@@ -742,7 +745,7 @@ select.ui.dropdown {
   ---------------*/
 
   /* Multiple Selection */
-  .ui.multiple.dropdown {
+  .ui.ui.multiple.dropdown {
     padding: @multipleSelectionPadding;
   }
   .ui.multiple.dropdown .menu {
@@ -824,6 +827,10 @@ select.ui.dropdown {
       margin: @multipleSelectionChildMargin;
       width: @multipleSelectionSearchStartWidth;
       line-height: @multipleSelectionChildLineHeight;
+    }
+
+    .ui.multiple.search.dropdown.button {
+      min-width: @selectionMinWidth;
     }
   }
 }

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -775,6 +775,11 @@ select.ui.dropdown {
     max-width: 100%;
     margin: @multipleSelectionChildMargin;
     line-height: @multipleSelectionChildLineHeight;
+    &.default {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
   }
   .ui.multiple.dropdown > .label ~ input.search {
     margin-left: @multipleSelectionSearchAfterLabelDistance !important;


### PR DESCRIPTION
## Description
This PR fixes

- multiple search button dropdown had wrong padding
- Placeholders in multiple search dropdowns were wrapping
- Search in dropdown buttons had ghosting text

## Testcase
## Broken
https://jsfiddle.net/lubber/47r2v1cf/59

## Fixed
https://jsfiddle.net/lubber/47r2v1cf/60

## Screenshot
### Broken
![multipleghost](https://user-images.githubusercontent.com/18379884/91202815-a3116b00-e702-11ea-9329-b814ae519989.gif)

## Fixed
![multiplenoghost](https://user-images.githubusercontent.com/18379884/91202801-9db42080-e702-11ea-83c6-0d8c812b6d4a.gif)

## Closes
#1623 