### PR TITLE
[Dropdown] "very short" menu height always overriden by normal "short" height because of  wrong specificity order 

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -448,11 +448,11 @@ select.ui.dropdown {
 
   @media only screen and (max-width : @largestMobileScreen) {
     & when (@variationDropdownShort) {
-      .ui.selection.dropdown[class*="very short"] .menu {
-        max-height: @selectionMobileMaxMenuHeight * 0.5;
-      }
       .ui.selection.dropdown.short .menu {
         max-height: @selectionMobileMaxMenuHeight * 0.75;
+      }
+      .ui.selection.dropdown[class*="very short"] .menu {
+        max-height: @selectionMobileMaxMenuHeight * 0.5;
       }
     }
     .ui.selection.dropdown .menu {
@@ -469,11 +469,11 @@ select.ui.dropdown {
   }
   @media only screen and (min-width: @tabletBreakpoint) {
     & when (@variationDropdownShort) {
-      .ui.selection.dropdown[class*="very short"] .menu {
-        max-height: @selectionTabletMaxMenuHeight * 0.5;
-      }
       .ui.selection.dropdown.short .menu {
         max-height: @selectionTabletMaxMenuHeight * 0.75;
+      }
+      .ui.selection.dropdown[class*="very short"] .menu {
+        max-height: @selectionTabletMaxMenuHeight * 0.5;
       }
     }
     .ui.selection.dropdown .menu {
@@ -490,11 +490,11 @@ select.ui.dropdown {
   }
   @media only screen and (min-width: @computerBreakpoint) {
     & when (@variationDropdownShort) {
-      .ui.selection.dropdown[class*="very short"] .menu {
-        max-height: @selectionComputerMaxMenuHeight * 0.5;
-      }
       .ui.selection.dropdown.short .menu {
         max-height: @selectionComputerMaxMenuHeight * 0.75;
+      }
+      .ui.selection.dropdown[class*="very short"] .menu {
+        max-height: @selectionComputerMaxMenuHeight * 0.5;
       }
     }
     .ui.selection.dropdown .menu {
@@ -511,11 +511,11 @@ select.ui.dropdown {
   }
   @media only screen and (min-width: @widescreenMonitorBreakpoint) {
     & when (@variationDropdownShort) {
-      .ui.selection.dropdown[class*="very short"] .menu {
-        max-height: @selectionWidescreenMaxMenuHeight * 0.5;
-      }
       .ui.selection.dropdown.short .menu {
         max-height: @selectionWidescreenMaxMenuHeight * 0.75;
+      }
+      .ui.selection.dropdown[class*="very short"] .menu {
+        max-height: @selectionWidescreenMaxMenuHeight * 0.5;
       }
     }
     .ui.selection.dropdown .menu {


### PR DESCRIPTION
## Description

The `very short`  size variation did not work. It was always overridden by the `short` variation because both share same specificity, thus the declaration order matters.

## Testcase
I used a new "test" and "short test" naming to show the difference 

### Broken
Wrong order: first `very test`, then  `test`
https://jsfiddle.net/lubber/nq4c5eg1/13

### Fixed
Correct order: first `test`, then  `very test`
https://jsfiddle.net/lubber/nq4c5eg1/12

## Screenshot
### Broken
![image](https://user-images.githubusercontent.com/18379884/92166138-6b0fd380-ee38-11ea-9cb5-43450e8c6456.png)

### Fixed
![image](https://user-images.githubusercontent.com/18379884/92166103-5df2e480-ee38-11ea-8028-95662747f439.png)
