### PR TITLE
feat(dropdown): Dropdown formatted with label like input labeled

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -1323,6 +1323,30 @@ select.ui.dropdown {
   }
 }
 
+& when (@variationInputLabeled) {
+  /*--------------------
+          Labeled
+  ---------------------*/
+
+  /* Regular Label on Left */
+  .ui.labeled.input:not([class*="corner labeled"]) .label:first-child + .dropdown {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    border-left-color: transparent;
+  }
+
+  /* Regular Label on Right */
+  .ui[class*="right labeled"].input > .dropdown:not(:last-child) {
+    border-top-right-radius: 0 !important;
+    border-bottom-right-radius: 0 !important;
+    border-right-color: transparent !important;
+  }
+  .ui[class*="right labeled"].input > .dropdown + .label {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+}
+
 /*--------------
      Columnar
 ---------------*/


### PR DESCRIPTION
## Description
Sometimes, we will need to create a stack of dropdown and the label together as described in this [issue](https://github.com/fomantic/Fomantic-UI/issues/1667).

This PR intends to support the dropdown to be formatted with the label at left or right position same as input element stacks with the [label](https://fomantic-ui.com/elements/input.html#labeled) and the [action](https://fomantic-ui.com/elements/input.html#action) button.

## Note
This implementation is not standalone and 100% semantic because, the class name `dropdown` is already used by dropdown module.

At the moment, it only works when the theme has enabled the labeled input variation `@variationInputLabeled` and the dropdown module needs to be the child of `labeled input` element. If we could find any suitable alias for this module, I'll update this PR and implement as standalone extension without depending on the input element.

## Test Case
https://jsfiddle.net/ko2in/ucsyf3nb/

## Screenshot
![DropdownLabeled](https://user-images.githubusercontent.com/930315/92642990-0d332e00-f307-11ea-8f88-e002d45a1bf3.png)

## Closes
#1667
