### PR TITLE
[Dropdown] Allow displayType transition setting to be overriden by dropdown

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -3565,7 +3565,7 @@ $.fn.dropdown = function(parameters) {
               module.set.scrollPosition(module.get.selectedItem(), true);
             }
             if( module.is.hidden($currentMenu) || module.is.animating($currentMenu) ) {
-              var displayType = $module.hasClass('column') ? 'flex' : false;
+              var displayType = $module.hasClass('column') ? 'flex' : settings.displayType;
               if(transition == 'none') {
                 start();
                 $currentMenu.transition({
@@ -3956,6 +3956,7 @@ $.fn.dropdown.settings = {
 
   transition             : 'auto',     // auto transition will slide down or up based on direction
   duration               : 200,        // duration of transition
+  displayType            : false,      // displayType of transition
 
   glyphWidth             : 1.037,      // widest glyph width in em (W is 1.037 em) used to calculate multiselect input width
 

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -2136,6 +2136,9 @@ $.fn.dropdown = function(parameters) {
               ;
             }
             return $selectedItem;
+          },
+          displayType: function() {
+            return $module.hasClass('column') ? 'flex' : settings.displayType;
           }
         },
 
@@ -3565,11 +3568,10 @@ $.fn.dropdown = function(parameters) {
               module.set.scrollPosition(module.get.selectedItem(), true);
             }
             if( module.is.hidden($currentMenu) || module.is.animating($currentMenu) ) {
-              var displayType = $module.hasClass('column') ? 'flex' : settings.displayType;
               if(transition == 'none') {
                 start();
                 $currentMenu.transition({
-                  displayType: displayType
+                  displayType: module.get.displayType()
                 }).transition('show');
                 callback.call(element);
               }
@@ -3582,7 +3584,7 @@ $.fn.dropdown = function(parameters) {
                     duration   : settings.duration,
                     queue      : true,
                     onStart    : start,
-                    displayType: displayType,
+                    displayType: module.get.displayType(),
                     onComplete : function() {
                       callback.call(element);
                     }
@@ -3616,7 +3618,9 @@ $.fn.dropdown = function(parameters) {
 
               if(transition == 'none') {
                 start();
-                $currentMenu.transition('hide');
+                $currentMenu.transition({
+                  displayType: module.get.displayType()
+                }).transition('hide');
                 callback.call(element);
               }
               else if($.fn.transition !== undefined && $module.transition('is supported')) {
@@ -3628,6 +3632,7 @@ $.fn.dropdown = function(parameters) {
                     verbose    : settings.verbose,
                     queue      : false,
                     onStart    : start,
+                    displayType: module.get.displayType(),
                     onComplete : function() {
                       callback.call(element);
                     }


### PR DESCRIPTION
## Description
In situations where a dropdown was inside a right menu (which got a flex setting) the transition module was taking that flex displaytype setting for the dropdown menu. This unfortunately results into a horizontal menu list.
To be able to adjust this, i added the `displayType`, used for the transition, setting to the dropdown module as well. If set, this setting could be used just as in transition to correct the display if needed.

Additionally this setting also had to be provided to the hiding transition, otherwise the wrong flex setting would  be reapplied before hiding the dropdown again.

## Testcase
Click the top right menu button

### Broken
The menu is displayed horizontally
https://jsfiddle.net/lubber/wtvfd7pn/25/

### Fixed
The menu is displayed vertical
https://jsfiddle.net/lubber/wtvfd7pn/24/

## Screenshots
### Broken
![image](https://user-images.githubusercontent.com/18379884/92972209-26acb500-f482-11ea-87b3-0bae5c245770.png)

### Fixed
![image](https://user-images.githubusercontent.com/18379884/92972006-c6b60e80-f481-11ea-8634-7f673c459dda.png)


