### PR TITLE
[Label,Form] Apply the error color not only to the label tag but also with label class

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -495,7 +495,9 @@
     }
 
     .ui.ui.form .fields.@{state} .field label,
+    .ui.ui.form .fields.@{state} .field .ui.label,
     .ui.ui.form .field.@{state} label,
+    .ui.ui.form .field.@{state} .ui.label,
     .ui.ui.form .fields.@{state} .field .input,
     .ui.ui.form .field.@{state} .input {
       color: @c;

--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -468,6 +468,7 @@
     @c: @formStates[@@state][color];
     @bg: @formStates[@@state][background];
     @bdc: @formStates[@@state][borderColor];
+    @lbg: @formStates[@@state][labelBackground];
 
     /* On Form */
     .ui.form.@{state} .@{state}.message:not(:empty) {
@@ -495,12 +496,17 @@
     }
 
     .ui.ui.form .fields.@{state} .field label,
-    .ui.ui.form .fields.@{state} .field .ui.label,
+    .ui.ui.form .fields.@{state} .field .ui.label:not(.corner),
     .ui.ui.form .field.@{state} label,
-    .ui.ui.form .field.@{state} .ui.label,
+    .ui.ui.form .field.@{state} .ui.label:not(.corner),
     .ui.ui.form .fields.@{state} .field .input,
     .ui.ui.form .field.@{state} .input {
       color: @c;
+    }
+
+    .ui.form .fields.@{state} .field .ui.label, 
+    .ui.form .field.@{state} .ui.label {
+      background-color: @lbg;
     }
 
     .ui.form .fields.@{state} .field .corner.label,

--- a/src/themes/default/globals/colors.less
+++ b/src/themes/default/globals/colors.less
@@ -497,6 +497,7 @@
     borderRadius: @inputErrorBorderRadius;
     boxShadow: @inputErrorBoxShadow;
     cornerLabelColor: @white;
+    labelBackground: darken(@formErrorBorder, -8);
 
     dropdownLabelColor: @dropdownErrorLabelColor;
     dropdownLabelBackground: @dropdownErrorLabelBackground;
@@ -524,6 +525,7 @@
     borderRadius: @inputInfoBorderRadius;
     boxShadow: @inputInfoBoxShadow;
     cornerLabelColor: @white;
+    labelBackground: darken(@formInfoBorder, -8);
 
     dropdownLabelColor: @dropdownInfoLabelColor;
     dropdownLabelBackground: @dropdownInfoLabelBackground;
@@ -551,6 +553,7 @@
     borderRadius: @inputSuccessBorderRadius;
     boxShadow: @inputSuccessBoxShadow;
     cornerLabelColor: @white;
+    labelBackground: darken(@formSuccessBorder, -8);
 
     dropdownLabelColor: @dropdownSuccessLabelColor;
     dropdownLabelBackground: @dropdownSuccessLabelBackground;
@@ -578,6 +581,7 @@
     borderRadius: @inputWarningBorderRadius;
     boxShadow: @inputWarningBoxShadow;
     cornerLabelColor: @white;
+    labelBackground: darken(@formWarningBorder, -8);
 
     dropdownLabelColor: @dropdownWarningLabelColor;
     dropdownLabelBackground: @dropdownWarningLabelBackground;


### PR DESCRIPTION
## Description
When the form with error state contain the labels, these labels will be styled as red color, but only they're used as HTML label element.

Now, any element with `label` class will have the same style as label element, and produces more consistent design flow.

## Testcase
**Before:** https://jsfiddle.net/ko2in/sdca1hjt/2/

**After:** https://jsfiddle.net/ko2in/sdca1hjt/4/

## Screenshot
Before | After
----------|---------
![LabelStyle-Before](https://user-images.githubusercontent.com/930315/92995625-21f00b80-f52b-11ea-94e4-60480f63df3d.png) | ![LabelStyle-After](https://user-images.githubusercontent.com/930315/92995632-2caaa080-f52b-11ea-9f60-247fef1f9b52.png)

