### PR TITLE
[Chore] Update google fonts api to v2

### DIFF
--- a/src/theme.less
+++ b/src/theme.less
@@ -61,7 +61,7 @@
 -------------------*/
 
 .loadFonts() when (@importGoogleFonts) {
-  @import (css) url('@{googleProtocol}fonts.googleapis.com/css?family=@{googleFontRequest}');
+  @import (css) url('@{googleProtocol}fonts.googleapis.com/css2?family=@{googleFontRequest}');
 }
 
 /*------------------

--- a/src/themes/default/globals/site.variables
+++ b/src/themes/default/globals/site.variables
@@ -15,7 +15,7 @@
 
 @googleFontName    : @fontName;
 @importGoogleFonts : true;
-@googleFontSizes   : '400,700,400italic,700italic';
+@googleFontSizes   : 'ital,wght@0,400;0,700;1,400;1,700';
 @googleSubset      : 'latin';
 @googleFontDisplay : 'swap';
 


### PR DESCRIPTION
## Description
This PR updates the import for the Lato font via google font api to [v2](https://developers.google.com/fonts/docs/css2)

## Testcase
#### Old
https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic&subset=latin&display=swap

#### New
https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,400;0,700;1,400;1,700&subset=latin&display=swap

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6973