### PR TITLE
fix(dropdown) - forceSelection trigger event with null addition

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1942,15 +1942,16 @@ $.fn.dropdown = function(parameters) {
                 $choice.find(selector.menu).remove();
                 $choice.find(selector.menuIcon).remove();
               }
-              else if(settings.allowAdditions && settings.forceSelection) {
-                return;
+              if($choice.data(metadata.text) !== undefined) {
+                return $choice.data(metadata.text);
               }
-              return ($choice.data(metadata.text) !== undefined)
-                ? $choice.data(metadata.text)
-                : (preserveHTML)
-                  ? $choice.html().trim()
-                  : $choice.text().trim()
-              ;
+              else {
+                if($choice.length == 0 && settings.allowAdditions && settings.forceSelection){
+                  return;
+                }
+
+                return (preserveHTML) ? $choice.html().trim() : $choice.text().trim();
+              }
             }
           },
           choiceValue: function($choice, choiceText) {

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1942,6 +1942,9 @@ $.fn.dropdown = function(parameters) {
                 $choice.find(selector.menu).remove();
                 $choice.find(selector.menuIcon).remove();
               }
+              else if(settings.allowAdditions && settings.forceSelection) {
+                return;
+              }
               return ($choice.data(metadata.text) !== undefined)
                 ? $choice.data(metadata.text)
                 : (preserveHTML)

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1942,16 +1942,12 @@ $.fn.dropdown = function(parameters) {
                 $choice.find(selector.menu).remove();
                 $choice.find(selector.menuIcon).remove();
               }
-              if($choice.data(metadata.text) !== undefined) {
-                return $choice.data(metadata.text);
-              }
-              else {
-                if($choice.length == 0 && settings.allowAdditions && settings.forceSelection){
-                  return;
-                }
-
-                return (preserveHTML) ? $choice.html().trim() : $choice.text().trim();
-              }
+              return ($choice.data(metadata.text) !== undefined)
+                ? $choice.data(metadata.text)
+                : (preserveHTML)
+                  ? $choice.html() && $choice.html().trim()
+                  : $choice.text() && $choice.text().trim()
+              ;
             }
           },
           choiceValue: function($choice, choiceText) {


### PR DESCRIPTION
## Description
Hi!
This fix is very simple,  when `allowAdditions` is handled by click event, `forceSelection` triggers event click again, but with `allowAdditions` removed can't find the item.
As far as I know I can't know if the event calling this method is the original click or `forceSelection` trigger, so what I did is: if there's no element and `allowAdditions` and `forceSelection` is set to true return `null`.

## Testcase
- Add a non existing value to the dropdown
- Watch console

## Broken
A JS error occurs `Cannot read property 'trim' of undefined`
http://jsfiddle.net/kamalkemo/bwhsrvdf/

## Fixed
No error anymore
http://jsfiddle.net/lubber/sqpc9d1y/

## Closes
#1679