### PR TITLE
[Dropdown] Add `preventChangeTrigger` parameter to the `set selected` behavior

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -2693,7 +2693,7 @@ $.fn.dropdown = function(parameters) {
             module.clear();
             module.set.selected(value, $selectedItem);
           },
-          selected: function(value, $selectedItem) {
+          selected: function(value, $selectedItem, preventChangeTrigger) {
             var
               isMultiple = module.is.multiple()
             ;
@@ -2756,7 +2756,7 @@ $.fn.dropdown = function(parameters) {
                     module.save.remoteData(selectedText, selectedValue);
                   }
                   module.set.text(selectedText);
-                  module.set.value(selectedValue, selectedText, $selected);
+                  module.set.value(selectedValue, selectedText, $selected, preventChangeTrigger);
                   $selected
                     .addClass(className.active)
                     .addClass(className.selected)


### PR DESCRIPTION
## Description
This PR simply add the ability to prevent the `onChange` event trigerring when the `set selected` behavior is used. Until now, the only way to not trigger the `onChange` was to use the `set value` behavior, which is not IMHO the right stuff to call when you want to programmatically select a value.
