### PR TITLE
[Slider] - With step 0, divides by 0

### DIFF
--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -577,7 +577,7 @@ $.fn.slider = function(parameters) {
             return settings.step;
           },
           numLabels: function() {
-            var value = Math.round((module.get.max() - module.get.min()) / module.get.step());
+            var value = Math.round((module.get.max() - module.get.min()) / (module.get.step() === 0 ? 1 : module.get.step()));
             module.debug('Determined that there should be ' + value + ' labels');
             return value;
           },


### PR DESCRIPTION
## Description
<!-- Describe what you fixed/changed in great detail (required). -->
When step is 0, this division returns `Infinity`, so later on function `gapRatio` while loop is infinite.
Now is checking if step is 0 to change for 1 else return step.

## Testcase
* Add an slider
* Resize window
* Window is freezed

## Broken
https://jsfiddle.net/mthrcf5n/3/

--> Simply move JSFiddle's grid divider or resize your browser window

## Fixed
<!--
  If possible create an example of your change via a JSFiddle. 

  How to create an example:
   1. Open the following JSFiddle - https://jsfiddle.net/31d6y7mn
   2. Click "Fork" at the top
   3. Add the minimum required HTML, CSS and JavaScript which shows your change
   4. Click "Save" at the top
   5. Copy the URL of your fiddle and link it here
-->
It should have a normal behavior now
https://jsfiddle.net/TheJltres/p4zte923/3/

## Screenshot (if possible)
![1684](https://user-images.githubusercontent.com/23702867/94198891-4a2b2300-feb8-11ea-972f-c2f26947a7ce.gif)

## Closes
#1684 
