### PR TITLE
[Slider] No minimum step for label generator

### DIFF
--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -589,7 +589,7 @@ $.fn.slider = function(parameters) {
 
             switch (settings.labelType) {
               case settings.labelTypes.number:
-                return Math.round(((value * module.get.step()) + module.get.min()) * precision ) / precision;
+                return Math.round(((value * (module.get.step() === 0 ? 1 : module.get.step())) + module.get.min()) * precision ) / precision;
               case settings.labelTypes.letter:
                 return alphabet[(value) % 26];
               default:

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -205,28 +205,26 @@ $.fn.slider = function(parameters) {
             });
           },
           autoLabel: function() {
-            if(module.get.step() != 0) {
-              $labels = $module.find('.labels');
-              if($labels.length != 0) {
-                $labels.empty();
-              }
-              else {
-                $labels = $module.append('<ul class="auto labels"></ul>').find('.labels');
-              }
-              for(var i = 0, len = module.get.numLabels(); i <= len; i++) {
-                var
-                  labelText = module.get.label(i),
-                  $label = (labelText !== "") 
-                    ? !(i % module.get.gapRatio())
-                      ? $('<li class="label">' + labelText + '</li>') 
-                      : $('<li class="halftick label"></li>')
-                    : null,
-                  ratio  = i / len
-                ;
-                if($label) {
-                  module.update.labelPosition(ratio, $label);
-                  $labels.append($label);
-                }
+            $labels = $module.find('.labels');
+            if($labels.length != 0) {
+              $labels.empty();
+            }
+            else {
+              $labels = $module.append('<ul class="auto labels"></ul>').find('.labels');
+            }
+            for(var i = 0, len = module.get.numLabels(); i <= len; i++) {
+              var
+                labelText = module.get.label(i),
+                $label = (labelText !== "")
+                  ? !(i % module.get.gapRatio())
+                    ? $('<li class="label">' + labelText + '</li>')
+                    : $('<li class="halftick label"></li>')
+                  : null,
+                ratio  = i / len
+              ;
+              if($label) {
+                module.update.labelPosition(ratio, $label);
+                $labels.append($label);
               }
             }
           }


### PR DESCRIPTION
## Description
Here was set a minimum step of 0, i think for the same reason of #1684, if you remove this step it handles `atoLabel` for all kind of steps.

**This fix needs #1686**

PD. Sorry @ko2in I could not do it with fewer line changes 🤣 

## Testcase
<!--
  If possible create an example of your change via a JSFiddle. 

  How to create an example:
   1. Open the following JSFiddle - https://jsfiddle.net/31d6y7mn
   2. Click "Fork" at the top
   3. Add the minimum required HTML, CSS and JavaScript which shows your change
   4. Click "Save" at the top
   5. Copy the URL of your fiddle and link it here
-->
https://jsfiddle.net/TheJltres/z43vub60/1/

## Screenshot (if possible)
![1685](https://user-images.githubusercontent.com/23702867/94288283-8792bd80-ff57-11ea-83dd-4ef8f10bfd78.gif)


## Closes
#1685 
