### PR TITLE
[Progress] limitValues setting limits values to 100 instead of percentages

### DIFF
--- a/src/definitions/modules/progress.js
+++ b/src/definitions/modules/progress.js
@@ -537,7 +537,7 @@ $.fn.progress = function(parameters) {
               });
               module.percent = roundedPercents;
               if (hasTotal) {
-                module.value = roundedPercents.map(function (percent) {
+                module.value = percents.map(function (percent) {
                   return (autoPrecision > 0)
                     ? Math.round((percent / 100) * module.total * (10 * autoPrecision)) / (10 * autoPrecision)
                     : Math.round((percent / 100) * module.total * 10) / 10

--- a/src/definitions/modules/progress.js
+++ b/src/definitions/modules/progress.js
@@ -546,7 +546,6 @@ $.fn.progress = function(parameters) {
               }
               module.set.barWidth(percents);
               module.set.labelInterval();
-              module.set.labels();
             }
             settings.onChange.call(element, percents, module.value, module.total);
           },

--- a/src/definitions/modules/progress.js
+++ b/src/definitions/modules/progress.js
@@ -500,10 +500,14 @@ $.fn.progress = function(parameters) {
           },
           percent: function(percents) {
             percents = module.helper.forceArray(percents).map(function(percent) {
-              return (typeof percent == 'string')
+              percent = (typeof percent == 'string')
                 ? +(percent.replace('%', ''))
                 : percent
                 ;
+              return (settings.limitValues)
+                  ? Math.max(0, Math.min(100, percent))
+                  : percent
+              ;
             });
             var hasTotal = module.has.total();
             var totalPercent = module.helper.sum(percents);
@@ -539,11 +543,6 @@ $.fn.progress = function(parameters) {
                     : Math.round((percent / 100) * module.total * 10) / 10
                     ;
                 });
-                if (settings.limitValues) {
-                  module.value = module.value.map(function (value) {
-                    return Math.max(0, Math.min(100, value));
-                  });
-                }
               }
               module.set.barWidth(percents);
               module.set.labelInterval();


### PR DESCRIPTION
## Description
The `limitValues` setting limits the values between 0 and 100. Instead it should limit the calculated precentages instead and calculate the actual values afterwards.

## Testcase
Click on the + icon. It should increase the progress
### Broken
It reduces the value and even by clicking many times on the + button the value is stuck
https://jsfiddle.net/lubber/q01tfzeb/6/

### Fixed
All fine
https://jsfiddle.net/lubber/q01tfzeb/12/

## Closes
#1689 
