### PR TITLE
[slider]: onChange is triggered without moving slider

### DIFF
--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -88,6 +88,7 @@ $.fn.slider = function(parameters) {
         precision,
         isTouch,
         gapRatio = 1,
+        previousValue,
 
         initialPosition,
         initialLoad,
@@ -331,7 +332,13 @@ $.fn.slider = function(parameters) {
               } else {
                 $currThumb = module.determine.closestThumb(newPos);
               }
+              if (previousValue === undefined) {
+                previousValue = module.get.currentThumbValue();
+              }
+            } else if (previousValue === undefined) {
+                previousValue = module.get.value();
             }
+
             if(!module.is.disabled()) {
               module.bind.slidingEvents();
             }
@@ -379,6 +386,9 @@ $.fn.slider = function(parameters) {
             var value = module.determine.valueFromEvent(event);
             module.set.value(value);
             module.unbind.slidingEvents();
+            if (previousValue !== undefined) {
+              previousValue = undefined;
+            }
           },
           keydown: function(event, first) {
             if(settings.preventCrossover && module.is.range() && module.thumbVal === module.secondThumbVal) {
@@ -854,10 +864,17 @@ $.fn.slider = function(parameters) {
 
         set: {
           value: function(newValue) {
+            var toReset = previousValue === undefined;
+            previousValue = previousValue === undefined ? module.get.value() : previousValue;
             module.update.value(newValue, function(value, thumbVal, secondThumbVal) {
               if (!initialLoad || settings.fireOnInit){
-                settings.onChange.call(element, value, thumbVal, secondThumbVal);
+                if (newValue !== previousValue) {
+                  settings.onChange.call(element, value, thumbVal, secondThumbVal);
+                }
                 settings.onMove.call(element, value, thumbVal, secondThumbVal);
+              }
+              if (toReset) {
+                previousValue = undefined;
               }
             });
           },
@@ -865,8 +882,10 @@ $.fn.slider = function(parameters) {
             if(module.is.range()) {
               var
                 min = module.get.min(),
-                max = module.get.max()
+                max = module.get.max(),
+                toReset = previousValue === undefined
               ;
+              previousValue = previousValue === undefined ? module.get.value() : previousValue;
               if (first <= min) {
                 first = min;
               } else if(first >= max){
@@ -883,8 +902,13 @@ $.fn.slider = function(parameters) {
               module.update.position(module.thumbVal, $thumb);
               module.update.position(module.secondThumbVal, $secondThumb);
               if (!initialLoad || settings.fireOnInit) {
-                settings.onChange.call(element, value, module.thumbVal, module.secondThumbVal);
+                if (value !== previousValue) {
+                  settings.onChange.call(element, value, module.thumbVal, module.secondThumbVal);
+                }
                 settings.onMove.call(element, value, module.thumbVal, module.secondThumbVal);
+              }
+              if (toReset) {
+                previousValue = undefined;
               }
             } else {
               module.error(error.notrange);


### PR DESCRIPTION
##  Description

Store previous value to skip onChange trigger if no change is found in value.

I've assumed here that `onChange` is to behave differently than `onMove`, let me know if this assumption is incorrect and there are changes needed.
 
Added a new variable `previousValue` and compare it with new value before triggering `onChange` and `onMove`. 
If new changes are found then trigger both or else trigger only `onMove`.

## Testcases
Fiddle: https://jsfiddle.net/MrL1605/5vp4u38g/16/
- Testcase 1:
  Sliding the slider and going back to same position should trigger `onMove` on every position and should not trigger `onChange`.
- Testcase 2:
  Simply clicking on standard slider tab should not trigger `onChange`, but `onMove` should be triggered. (standard and range)
- Testcase 3:
  If a standard slider is already at `x` position, calling the behaviour to set value `x` should trigger `onMove` and not `onChange`.
- Testcase 4:
  If a range slider has positions set to `a1` and `b1`, calling the behaviour to set range as `a2` to `b2`, 
  - if the abs difference `a1` and `b1` is different from abs difference of `a2` and `b2`, then this should trigger both `onMove` and `onChange`.
  - if the abs difference `a1` and `b1` is same as abs difference of `a2` and `b2`, then this should trigger only `onMove` and not `onChange`.

## Screenshot (if possible)
No CSS changes

## Closes
Closes #1382 
