### PR TITLE
[Form Validation] Set optional field behavior

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1165,6 +1165,17 @@ $.fn.form = function(parameters) {
                 }
               }
             });
+          },
+          optional: function(identifier, bool) {
+            bool = (bool !== undefined)
+              ? bool
+              : true
+            ;
+            $.each(validation, function(fieldName, field) {
+              if (identifier == fieldName || identifier == field.identifier) {
+                field.optional = bool;
+              }
+            });
           }
         },
 

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1167,10 +1167,7 @@ $.fn.form = function(parameters) {
             });
           },
           optional: function(identifier, bool) {
-            bool = (bool !== undefined)
-              ? bool
-              : true
-            ;
+            bool = (bool !== false);
             $.each(validation, function(fieldName, field) {
               if (identifier == fieldName || identifier == field.identifier) {
                 field.optional = bool;


### PR DESCRIPTION

## Description
Adds the possibility to use `$('.ui.form').form('set optional', fieldName, bool);` to set or unset a field as optional for validation.

## Testcase
https://jsfiddle.net/giandrop/gbwunp7j/14/

## Closes
#1500 
