### PR TITLE
[Card] Images in horizontal cards are stretched on latest chrome when inside css table layout

### DIFF
--- a/src/definitions/views/card.less
+++ b/src/definitions/views/card.less
@@ -457,7 +457,6 @@
     display: -webkit-flex;
     display: flex;
     width: 100%;
-    height: 100%;
     border-radius: @defaultBorderRadius 0 0 @defaultBorderRadius;
   }
   .ui.horizontal.cards > .card > .image:last-child > img,


### PR DESCRIPTION
## Description
Since chrome 85, images inside horizontal cards are stretched when their parent node has `display: table` set (for example inside a `compact segment` or inside a `toast-box`)
This is triggered because horizontal card images have a fixed 100% height set. By leaving the height to `auto` as for all other card variants, the images shown correctly again.

Even if this _could_ be an error in the latest chrome (it's also in chrome 86 beta and 87 dev) i don't think we should set the height to 100% anyway (just because non equal size images would definately be stretched.

## Testcase
#### Broken
https://jsfiddle.net/lubber/orvshx8z/14/

#### Fixed
https://jsfiddle.net/lubber/orvshx8z/16/

## Screenshot
#### Broken
![image](https://user-images.githubusercontent.com/18379884/95679777-5e1f9600-0bd5-11eb-8103-d168a77cf65a.png)

#### Fixed
![image](https://user-images.githubusercontent.com/18379884/95679792-798aa100-0bd5-11eb-9a1c-2046742c8442.png)

