### PR TITLE
[Progress] Support right aligned progress bar

### DIFF
--- a/src/definitions/modules/progress.less
+++ b/src/definitions/modules/progress.less
@@ -24,7 +24,7 @@
 
 .ui.progress {
   position: relative;
-  display: block;
+  display: flex;
   max-width: 100%;
   border: @border;
   margin: @margin;
@@ -89,7 +89,6 @@
 
 & when (@variationProgressRightAligned) {
   .ui.right.aligned.progress {
-    display: flex;
     justify-content: flex-end;
     & .bar > .progress {
       left: @progressRightAlignedLeft;
@@ -240,12 +239,6 @@
   }
 }
 
-& when (@variationProgressMultiple) {
-  /* Multiple */
-  .ui.multiple.progress {
-    display: flex;
-  }
-}
 
 /*******************************
              States
@@ -413,7 +406,6 @@
   }
   .ui.progress.attached,
   .ui.progress.attached .bar {
-    display: block;
     height: @attachedHeight;
     padding: 0;
     overflow: hidden;

--- a/src/definitions/modules/progress.less
+++ b/src/definitions/modules/progress.less
@@ -87,6 +87,17 @@
   text-align: @progressTextAlign;
 }
 
+& when (@variationProgressRightAligned) {
+  .ui.right.aligned.progress {
+    display: flex;
+    justify-content: flex-end;
+    & .bar > .progress {
+      left: @progressRightAlignedLeft;
+      right: @progressRightAlignedRight;
+    }
+  }
+}
+
 /* Label */
 .ui.progress > .label {
   position: absolute;
@@ -316,6 +327,12 @@
     animation: progress-active @activePulseDuration @defaultEasing infinite;
     transform-origin: left;
   }
+  & when (@variationProgressRightAligned) {
+    .ui.active.right.aligned.progress .bar::after {
+      transform-origin: right;
+    }
+  }
+
   @keyframes progress-active {
     0% {
       opacity: @activePulseMaxOpacity;

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -464,6 +464,7 @@
 @variationProgressActive: true;
 @variationProgressAttached: true;
 @variationProgressSpeeds: true;
+@variationProgressRightAligned: true;
 @variationProgressSizes: @variationAllSizes;
 
 /* Rating */

--- a/src/themes/default/modules/progress.variables
+++ b/src/themes/default/modules/progress.variables
@@ -44,6 +44,8 @@
 @progressTextShadow: none;
 @progressFontWeight: @bold;
 @progressTextAlign: left;
+@progressRightAlignedRight: @progressLeft;
+@progressRightAlignedLeft: @progressRight;
 
 /* Label */
 @labelWidth: 100%;


### PR DESCRIPTION
## Description
This PR allows to display the progress bar aligned to the right growing to the left by using `ui right aligned progress`

## Testcase
https://jsfiddle.net/lubber/zrx39u1b/15/

## Screenshot
![rightprogress](https://user-images.githubusercontent.com/18379884/95687721-afe01480-0c05-11eb-8ad8-755c97e16d03.gif)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/7017