### PR TITLE
[Calendar]: Support single digit months and days at parsing time

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -1467,11 +1467,11 @@ $.fn.calendar.settings = {
       if (text.length === 0) {
         return null;
       }
-      if(text.match(/^[0-9]{4}[\/\-\.][0-9]{2}[\/\-\.][0-9]{2}$/)){
+      if(text.match(/^[0-9]{4}[\/\-\.][0-9]{1,2}[\/\-\.][0-9]{1,2}$/)){
         text = text.replace(/[\/\-\.]/g,'/') + ' 00:00:00';
       }
       // Reverse date and month in some cases
-      text = settings.monthFirst || !text.match(/^[0-9]{2}[\/\-\.]/) ? text : text.replace(/[\/\-\.]/g,'/').replace(/([0-9]+)\/([0-9]+)/,'$2/$1');
+      text = settings.monthFirst || !text.match(/^[0-9]{1,2}[\/\-\.]/) ? text : text.replace(/[\/\-\.]/g,'/').replace(/([0-9]+)\/([0-9]+)/,'$2/$1');
       var textDate = new Date(text);
       var numberOnly = text.match(/^[0-9]+$/) !== null;
       if(!numberOnly && !isNaN(textDate.getDate())) {


### PR DESCRIPTION
## Description
This PR allows for single digits as month/day when trying to parse them to correctly handle the `monthFirst` setting
In addtion it also supports single digits as of `2020-5-1` now

## Testcase
- Have a calendar with `monthFirst: false`
- Try to enter `1-5-2020`
- You expect `1 May, 2020` as the result

#### Broken
You get `5 January, 2020`
https://jsfiddle.net/ko2in/gn801bzj/

#### Fixed
You get `1 May, 2020` as expected 
https://jsfiddle.net/lubber/67d2hsrw/

## Closes
https://github.com/fomantic/Fomantic-UI/issues/829#issuecomment-708378939