### PR TITLE
[Header] Icon content was not aligned

### DIFF
--- a/src/definitions/elements/header.less
+++ b/src/definitions/elements/header.less
@@ -234,7 +234,7 @@
   .ui.icon.header .corner.icon {
     font-size: @cornerIconHeaderSize;
   }
-  .ui.icon.header .content {
+  .ui.ui.icon.header .content {
     display: block;
     padding: 0;
   }

--- a/src/definitions/elements/header.less
+++ b/src/definitions/elements/header.less
@@ -111,7 +111,7 @@
 }
 
 /* After Icon */
-.ui.header > i.icon + .content {
+.ui.header:not(.centered):not(.aligned) > i.icon + .content {
   padding-left: @iconMargin;
   display: table-cell;
   vertical-align: @contentIconAlignment;
@@ -234,7 +234,7 @@
   .ui.icon.header .corner.icon {
     font-size: @cornerIconHeaderSize;
   }
-  .ui.ui.icon.header .content {
+  .ui.icon.header .content {
     display: block;
     padding: 0;
   }


### PR DESCRIPTION
## Description
The specificity has changed for icons by #1593 . This had an impact when using an `aligned icon header` to not correctly be aligned anymore because of the wrong display setting.
This PR adjusts the specificity again

## Testcase
https://jsfiddle.net/lubber/j294u6mx/7/

## Screenshot
### Broken
![image](https://user-images.githubusercontent.com/18379884/96190036-d40f5e80-0f41-11eb-8aa0-f01fb2c41f50.png)

### Fixed
![image](https://user-images.githubusercontent.com/18379884/96190008-c9ed6000-0f41-11eb-8df8-320f50064436.png)

## Closes
#1708 
 