### PR TITLE
[Form] Option errorfocus to auto focus the first error field on form validation

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1209,6 +1209,9 @@ $.fn.form = function(parameters) {
               if(event && $module.data('moduleApi') !== undefined) {
                 event.stopImmediatePropagation();
               }
+              if(settings.errorFocus) {
+                $group.filter('.' + className.error).first().find(selector.field).focus();
+              }
               if(ignoreCallbacks !== true) {
                 return settings.onFailure.call(element, formErrors, values);
               }
@@ -1514,6 +1517,7 @@ $.fn.form.settings = {
 
   autoCheckRequired : false,
   preventLeaving    : false,
+  errorFocus        : false,
   dateHandling      : 'date', // 'date', 'input', 'formatter'
 
   onValid           : function() {},

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1210,7 +1210,22 @@ $.fn.form = function(parameters) {
                 event.stopImmediatePropagation();
               }
               if(settings.errorFocus) {
-                $group.filter('.' + className.error).first().find(selector.field).focus();
+                var focusElement, hasTabIndex = true;
+                if (typeof settings.errorFocus === 'string') {
+                  focusElement = $(settings.errorFocus);
+                  hasTabIndex = focusElement.is('[tabindex]');
+                  // to be able to focus/scroll into non input elements we need a tabindex
+                  if (!hasTabIndex) {
+                    focusElement.attr('tabindex',-1);
+                  }
+                } else {
+                  focusElement = $group.filter('.' + className.error).first().find(selector.field);
+                }
+                focusElement.focus();
+                // only remove tabindex if it was dynamically created above
+                if (!hasTabIndex){
+                  focusElement.removeAttr('tabindex');
+                }
               }
               if(ignoreCallbacks !== true) {
                 return settings.onFailure.call(element, formErrors, values);


### PR DESCRIPTION
## Description
This PR adds a new option `errorFocus` (default `false` to stay backward compatible).
When set to `true`, the first found error field will be focussed ready to immediatly change the values.
When set to a string, it will be used as a dom selector to be able to focus anything else (most probably the error message box)

Until now the user always had to click into the related field before

## Testcase
### Before
https://jsfiddle.net/lubber/r91wax23/1/

### After
https://jsfiddle.net/lubber/r91wax23/2/

## Screenshots
|Before|After|
|-|-|
|![errorfocusbad](https://user-images.githubusercontent.com/18379884/96262144-aec23500-0fc1-11eb-8a35-31b08ec95342.gif)|![errorfocusgood](https://user-images.githubusercontent.com/18379884/96262156-b41f7f80-0fc1-11eb-9e54-25fe5922b280.gif)|

## Closes
#1659 

