### PR TITLE
[Dropdown] Menu did not show up on mobile when search and api was used (api was also called twice)

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -569,6 +569,7 @@ $.fn.dropdown = function(parameters) {
               module.unbind.intent();
           }
           iconClicked = false;
+          focused = false;
         },
 
         hideOthers: function() {
@@ -784,6 +785,7 @@ $.fn.dropdown = function(parameters) {
                     ;
                   });
                 }
+                module.focusSearch(true);
                 afterFiltered();
               });
             }
@@ -1127,7 +1129,7 @@ $.fn.dropdown = function(parameters) {
               if(module.is.multiple()) {
                 module.remove.activeLabel();
               }
-              if(!module.is.active() && (settings.showOnFocus || (event.type !== 'focus' && event.type !== 'focusin'))) {
+              if(!focused && !module.is.active() && (settings.showOnFocus || (event.type !== 'focus' && event.type !== 'focusin'))) {
                 focused = true;
                 module.search();
               }


### PR DESCRIPTION
## Description
When a `search` dropdown was used, loading remote content via `apiSettings`, the menu did not show up on mobile devices.
This was due to the lost search focus which happened when the menu nodes were recreated after the api returned the dropdown items. Mobile devices triggered a blur of the search field, while desktop browsers did not. Blurring the search field however led to not showing the dropdown menu anymore. 

This PR also fixes that the API was called twice the first time one clicked on the search field (while it was only triggered once when clicking on the dropdown icon)

## Testcase
### Broken
- Dropdown menu not shown on mobile devices
https://fomantic-ui.com/jsfiddle/#!lubber/t6az41op/1/

- Watch console: The responseAsync callback is fired twice.
https://jsfiddle.net/edanL3gf/

### Fixed
- Dropdown appears on mobile as expected
https://fomantic-ui.com/jsfiddle/#!lubber/t6az41op/2/

- Watch console: The responseAsync callback is only fired once 
https://jsfiddle.net/lubber/64gobhjx/

## Screenshots
|Broken|Fixed|
|-|-|
|![brokensearchmobile](https://user-images.githubusercontent.com/18379884/97116722-5c8abd80-16ff-11eb-8599-ef79e7b2d7de.gif)|![fixedsearchmobile](https://user-images.githubusercontent.com/18379884/97116728-61e80800-16ff-11eb-8f5b-81538c1957cd.gif)|

## Closes
#1472 
#1718 