### PR TITLE
[Slider] Fix bottom aligned labels for size variations

### DIFF
--- a/src/definitions/modules/slider.less
+++ b/src/definitions/modules/slider.less
@@ -202,6 +202,7 @@
   }
 
   .ui.bottom.aligned.labeled.slider > .labels .label {
+    bottom: 0;
     transform: translate(-50%, 100%);
   }
   & when (@variationSliderTicked) {
@@ -215,7 +216,8 @@
       left: 50%;
     }
     .ui.bottom.aligned.labeled.ticked.slider > .labels .label:after {
-      top: -100%;
+      top: auto;
+      bottom: 100%;
     }
     .ui.labeled.ticked.slider > .labels .halftick.label:after {
       height: @labelHeight / 2;


### PR DESCRIPTION
## Description
#1631 introduced the ability to put labels below a slider instead of above it, but using `bottom aligned` together with the size variations (small/large/big) results in messed up spacing.

## Testcase
Before: https://jsfiddle.net/ghL7p089/
After: https://jsfiddle.net/ghL7p089/1/

## Closes
https://github.com/fomantic/Fomantic-UI/pull/1631#issuecomment-715079996
