### PR TITLE
[Calendar] Show active and eventdates on enabled adjacent days

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -377,6 +377,7 @@ $.fn.calendar = function(parameters) {
                   cell.data(metadata.date, cellDate);
                   var adjacent = isDay && cellDate.getMonth() !== ((month + 12) % 12);
                   var disabled = (!settings.selectAdjacentDays && adjacent) || !module.helper.isDateInRange(cellDate, mode) || settings.isDisabled(cellDate, mode) || module.helper.isDisabled(cellDate, mode) || !module.helper.isEnabled(cellDate, mode);
+                  var eventDate;
                   if (disabled) {
                     var disabledDate = module.helper.findDayAsObject(cellDate, mode, settings.disabledDates);
                     if (disabledDate !== null && disabledDate[metadata.message]) {
@@ -390,7 +391,7 @@ $.fn.calendar = function(parameters) {
                       }
                     }
                   } else {
-                    var eventDate = module.helper.findDayAsObject(cellDate, mode, settings.eventDates);
+                    eventDate = module.helper.findDayAsObject(cellDate, mode, settings.eventDates);
                     if (eventDate !== null) {
                       cell.addClass(eventDate[metadata.class] || settings.eventClass);
                       if (eventDate[metadata.message]) {
@@ -407,9 +408,9 @@ $.fn.calendar = function(parameters) {
                   }
                   var active = module.helper.dateEqual(cellDate, date, mode);
                   var isToday = module.helper.dateEqual(cellDate, today, mode);
-                  cell.toggleClass(className.adjacentCell, adjacent);
+                  cell.toggleClass(className.adjacentCell, adjacent && !eventDate);
                   cell.toggleClass(className.disabledCell, disabled);
-                  cell.toggleClass(className.activeCell, active && !adjacent);
+                  cell.toggleClass(className.activeCell, active && !(adjacent && disabled));
                   if (!isHour && !isMinute) {
                     cell.toggleClass(className.todayCell, !adjacent && isToday);
                   }

--- a/src/definitions/modules/calendar.less
+++ b/src/definitions/modules/calendar.less
@@ -127,7 +127,7 @@
   color: @disabledTextColor;
 }
 
-.ui.calendar .ui.table tr .adjacent:not(.disabled) {
+.ui.calendar .ui.table tr .adjacent:not(.disabled):not(.active) {
   color: @adjacentTextColor;
   background: @adjacentBackground;
 }
@@ -166,7 +166,7 @@
     color: @invertedDisabledTextColor;
   }
 
-  .ui.inverted.calendar .ui.inverted.table tr .adjacent:not(.disabled) {
+  .ui.inverted.calendar .ui.inverted.table tr .adjacent:not(.disabled):not(.active) {
     color: @adjacentInvertedTextColor;
     background: @adjacentInvertedBackground;
   }


### PR DESCRIPTION
## Description
When selection of adjacent days is enabled by `selectAdjacentDays:true`. those days should respect possible existing eventdates classes as well as active selected days

## Testcase
- The first of November should be shown as eventdate in the adjacent days area of october
- A selection of the third of November inside the adjacent days area of October should be shown

### Broken
https://jsfiddle.net/lubber/c4s9dLm0/20/

### Fixed
https://jsfiddle.net/lubber/c4s9dLm0/21/


## Screenshot
### Broken
![image](https://user-images.githubusercontent.com/18379884/97761805-fc34bb00-1b06-11eb-8007-2a7fb71afc1e.png)
![image](https://user-images.githubusercontent.com/18379884/97761817-0656b980-1b07-11eb-9774-2c8a630d9a13.png)

### Fixed
![image](https://user-images.githubusercontent.com/18379884/97761839-153d6c00-1b07-11eb-9c5d-beebc747172a.png)
![image](https://user-images.githubusercontent.com/18379884/97761858-225a5b00-1b07-11eb-9fae-7ffabcfd47b6.png)

## Closes
#1734 