### PR TITLE
[Icon] Labels in icon groups where shown italic

### DIFF
--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -289,6 +289,7 @@ i.icon,
 i.icons {
   font-size: @medium;
   line-height: @lineHeight;
+  font-style: normal;
 }
 & when not (@variationIconSizes = false) {
   each(@variationIconSizes, {


### PR DESCRIPTION
## Description
When making use of a `floating label` inside an icon group, the label text is shown italic (because icon groups use the `i` tag

## Testcase
https://jsfiddle.net/lubber/786vh0Lt/3/

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/97804460-6311bb80-1c50-11eb-9bda-7e044657e288.png)
