### PR TITLE
[Grid] stackable grid had wrong width inside popup

### DIFF
--- a/src/definitions/collections/grid.less
+++ b/src/definitions/collections/grid.less
@@ -1659,7 +1659,7 @@ each(@colors, {
   --------------------*/
 
   @media only screen and (max-width: @largestMobileScreen) {
-    .ui.stackable.grid {
+    .ui.ui.ui.ui.stackable.grid {
       width: auto;
       margin-left: 0 !important;
       margin-right: 0 !important;


### PR DESCRIPTION
## Description
A `stackable grid` inside a popup did not have enough specificity to adjust the width on mobile views

## Testcase
- Click on the red bar to show the popup 
- Adjust screen to mobile size
- Watch the blue background
- Remove the CSS to see issue
https://jsfiddle.net/lubber/fv1hg0jm/5/

## Screenshot
![gridinsidepopup](https://user-images.githubusercontent.com/18379884/97815896-a93b3f00-1c91-11eb-9be0-f88894f99a9c.gif)

