### PR TITLE
fix(chore): use url encoded semicolons so gulp-concat doesnt break

### DIFF
--- a/src/themes/default/globals/site.variables
+++ b/src/themes/default/globals/site.variables
@@ -15,7 +15,7 @@
 
 @googleFontName    : @fontName;
 @importGoogleFonts : true;
-@googleFontSizes   : 'ital,wght@0,400;0,700;1,400;1,700';
+@googleFontSizes   : 'ital,wght@0,400%3B0,700%3B1,400%3B1,700';
 @googleSubset      : 'latin';
 @googleFontDisplay : 'swap';
 


### PR DESCRIPTION
## Description
This PR tries to solve the issue that `gulp-concat-css` doesn't find the google path because of the semicolons
This issue does only occur when building inside a node_modules folder. using `npx gulp build` inside a forked git repo folder is /was still working while having semicolons inside the google path

## Closes (hopefully)
#1738 
