### PR TITLE
[Calendar] Dont draw complete adjacent rows

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -358,8 +358,9 @@ $.fn.calendar = function(parameters) {
 
               var tbody = $('<tbody/>').appendTo(table);
               i = isYear ? Math.ceil(year / 10) * 10 - 9 : isDay ? 1 - firstMonthDayColumn : 0;
+              rowsLoop:
               for (r = 0; r < rows; r++) {
-                row = $('<tr/>').appendTo(tbody);
+                row = $('<tr/>');
                 if(isDay && settings.showWeekNumbers){
                     cell = $('<th/>').appendTo(row);
                     cell.text(module.get.weekOfYear(year,month,i+1-settings.firstDayOfWeek));
@@ -376,6 +377,9 @@ $.fn.calendar = function(parameters) {
                   cell.text(cellText);
                   cell.data(metadata.date, cellDate);
                   var adjacent = isDay && cellDate.getMonth() !== ((month + 12) % 12);
+                  if(adjacent && c === 0 && r > 0) {
+                    break rowsLoop;
+                  }
                   var disabled = (!settings.selectAdjacentDays && adjacent) || !module.helper.isDateInRange(cellDate, mode) || settings.isDisabled(cellDate, mode) || module.helper.isDisabled(cellDate, mode) || !module.helper.isEnabled(cellDate, mode);
                   var eventDate;
                   if (disabled) {
@@ -431,6 +435,7 @@ $.fn.calendar = function(parameters) {
                     module.set.focusDate(cellDate, false, false);
                   }
                 }
+                row.appendTo(tbody);
               }
 
               if (settings.today) {


### PR DESCRIPTION
## Description
Whenever the first of a month is shown within the first 5 columns of a calendar, then, according to the months amount of days, a full adjacent row is added to the calendar, which is unnecessary.

This PR skips the last row on rendertime if it would consists adjacent days only, making sure the calendar concentrates as much on the current month

## Testcase

#### Current
https://jsfiddle.net/lubber/0m192y5b/1/

#### Enhanced
https://jsfiddle.net/lubber/0m192y5b/2/

## Screenshot

|Current|Enhanced|
|-|-|
|![calendarfixedrows](https://user-images.githubusercontent.com/18379884/98036518-783a4600-1e1a-11eb-9826-fb8bb29464be.gif)|![calendardynamicrows](https://user-images.githubusercontent.com/18379884/98036546-82f4db00-1e1a-11eb-8571-1e9c716cd77d.gif)|


