### PR TITLE
[Icon] Make colored icon selector more specific

### DIFF
--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -265,15 +265,15 @@ each(@colors, {
   @c: @colors[@@color][color];
   @l: @colors[@@color][light];
 
-  i.@{color}.icon.icon.icon.icon {
+  i.@{color}.icon.icon.icon.icon.icon {
     color: @c;
   }
   & when (@variationIconInverted) {
-    i.inverted.@{color}.icon.icon.icon.icon {
+    i.inverted.@{color}.icon.icon.icon.icon.icon {
       color: @l;
     }
-    i.inverted.bordered.@{color}.icon.icon.icon.icon,
-    i.inverted.circular.@{color}.icon.icon.icon.icon {
+    i.inverted.bordered.@{color}.icon.icon.icon.icon.icon,
+    i.inverted.circular.@{color}.icon.icon.icon.icon.icon {
       background-color: @c;
       color: @white;
     }


### PR DESCRIPTION
<!--
 Please read our Contributing Guide and Code of Conduct before you
 submit a pull request.
  
 Contributing Guide: https://github.com/fomantic/Fomantic-UI/blob/master/CONTRIBUTING.md
 Code of Conduct: https://github.com/fomantic/Fomantic-UI/blob/master/CODE_OF_CONDUCT.md

 ----

 Please use the following pull request title format:
 "[<scope>] <summary of what you fixed/changed>"
-->

## Description

Adds one more `.icon` to the icon color definition to make it work in nested lists.


## Testcase
<!--
  If possible create an example of your change via a JSFiddle. 

  How to create an example:
   1. Open the following JSFiddle - https://jsfiddle.net/31d6y7mn
   2. Click "Fork" at the top
   3. Add the minimum required HTML, CSS and JavaScript which shows your change
   4. Click "Save" at the top
   5. Copy the URL of your fiddle and link it here
-->
https://jsfiddle.net/medc42zu/2/

## Closes
<!--
  List all the issues this pull request closes (only if it does).
-->
#1748
