### PR TITLE
[Slider] support control over change trigger when setting a value or range

### DIFF
--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -861,11 +861,12 @@ $.fn.slider = function(parameters) {
         },
 
         set: {
-          value: function(newValue) {
+          value: function(newValue, fireChange) {
+            fireChange = fireChange !== false;
             var toReset = previousValue === undefined;
             previousValue = previousValue === undefined ? module.get.value() : previousValue;
             module.update.value(newValue, function(value, thumbVal, secondThumbVal) {
-              if (!initialLoad || settings.fireOnInit){
+              if ((!initialLoad || settings.fireOnInit) && fireChange){
                 if (newValue !== previousValue) {
                   settings.onChange.call(element, value, thumbVal, secondThumbVal);
                 }
@@ -876,7 +877,8 @@ $.fn.slider = function(parameters) {
               }
             });
           },
-          rangeValue: function(first, second) {
+          rangeValue: function(first, second, fireChange) {
+            fireChange = fireChange !== false;
             if(module.is.range()) {
               var
                 min = module.get.min(),
@@ -899,7 +901,7 @@ $.fn.slider = function(parameters) {
               value = Math.abs(module.thumbVal - module.secondThumbVal);
               module.update.position(module.thumbVal, $thumb);
               module.update.position(module.secondThumbVal, $secondThumb);
-              if (!initialLoad || settings.fireOnInit) {
+              if ((!initialLoad || settings.fireOnInit) && fireChange) {
                 if (value !== previousValue) {
                   settings.onChange.call(element, value, module.thumbVal, module.secondThumbVal);
                 }


### PR DESCRIPTION
## Description
This PR adds a new option to the `set value` or `set rangeValue` behavior to optionally avoid the `onChange` callback

The change is backward compatible, because when the new parameter is omitted, it behaves like before (triggering the callback)

`.slider('set value',10,false)`

## Testcase

## Before
The onChange callback is triggered immediatly
`.slider('set value',10)`
https://jsfiddle.net/lubber/pwfd81rL/2/

## After
The onChange callback is not triggered
`.slider('set value',10,false)`
https://jsfiddle.net/lubber/pwfd81rL/3/

## Closes
#1750 