### PR TITLE
[Icons] allow corner icons and icon groups to be bordered

### DIFF
--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -273,7 +273,9 @@ each(@colors, {
       color: @l;
     }
     i.inverted.bordered.@{color}.icon.icon.icon.icon.icon,
-    i.inverted.circular.@{color}.icon.icon.icon.icon.icon {
+    i.inverted.circular.@{color}.icon.icon.icon.icon.icon,
+    i.inverted.bordered.@{color}.icons,
+    i.inverted.circular.@{color}.icons {
       background-color: @c;
       color: @white;
     }

--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -372,4 +372,49 @@ i.icons {
   }
 }
 
+& when ((@variationIconGroups) or (@variationIconCorner)) and (@variationIconBordered) {
+  i.bordered.icons {
+    width: @borderedSize;
+    height: @borderedSize;
+    box-shadow: @borderedShadow;
+  }
+  i.bordered.icons i.icon:first-child {
+    position: absolute;
+    transform: translateX(-50%) translateY(-50%);
+  }
+
+  & when (@variationIconCorner) {
+    i.bordered.icons .corner.icon {
+      top: auto;
+      left: auto;
+      right: .8em;
+      bottom: .8em;
+    }
+    i.bordered.icons .icon.corner[class*="top right"] {
+      top: .8em;
+      left: auto;
+      right: .8em;
+      bottom: auto;
+    }
+    i.bordered.icons .icon.corner[class*="top left"] {
+      top: .8em;
+      left: .8em;
+      right: auto;
+      bottom: auto;
+    }
+    i.bordered.icons .icon.corner[class*="bottom left"] {
+      top: auto;
+      left: .8em;
+      right: auto;
+      bottom: .8em;
+    }
+    i.bordered.icons .icon.corner[class*="bottom right"] {
+      top: auto;
+      left: auto;
+      right: .8em;
+      bottom: .8em;
+    }
+  }
+}
+
 .loadUIOverrides();

--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -372,47 +372,78 @@ i.icons {
   }
 }
 
-& when ((@variationIconGroups) or (@variationIconCorner)) and (@variationIconBordered) {
-  i.bordered.icons {
+& when ((@variationIconGroups) or (@variationIconCorner))
+   and ((@variationIconBordered) or (@variationIconCircular)) {
+  /*************************************************
+     Bordered/circular with corner or group icons
+  *************************************************/
+  i.bordered.icons,
+  i.circular.icons {
     width: @borderedSize;
     height: @borderedSize;
     box-shadow: @borderedShadow;
+    vertical-align: middle;
   }
-  i.bordered.icons i.icon:first-child {
+  i.circular.icons {
+    border-radius: 500em !important;
+  }
+  i.bordered.icons i.icon:first-child,
+  i.circular.icons i.icon:first-child {
     position: absolute;
     transform: translateX(-50%) translateY(-50%);
   }
 
+  & when (@variationIconInverted) {
+    /* Inverted Icon */
+    i.circular.inverted.icons,
+    i.bordered.inverted.icons {
+      border: none;
+      box-shadow: none;
+    }
+
+    i.inverted.bordered.icons,
+    i.inverted.circular.icons {
+      background-color: @black;
+      color: @white;
+    }
+  }
+
   & when (@variationIconCorner) {
-    i.bordered.icons .corner.icon {
+    /* Corner Icon */
+    i.bordered.icons .corner.icon,
+    i.circular.icons .corner.icon {
       top: auto;
       left: auto;
-      right: .8em;
-      bottom: .8em;
+      right: @borderedGroupCornerOffset;
+      bottom: @borderedGroupCornerOffset;
     }
-    i.bordered.icons .icon.corner[class*="top right"] {
-      top: .8em;
+    i.bordered.icons .icon.corner[class*="top right"],
+    i.circular.icons .icon.corner[class*="top right"] {
+      top: @borderedGroupCornerOffset;
       left: auto;
-      right: .8em;
+      right: @borderedGroupCornerOffset;
       bottom: auto;
     }
-    i.bordered.icons .icon.corner[class*="top left"] {
-      top: .8em;
-      left: .8em;
+    i.bordered.icons .icon.corner[class*="top left"],
+    i.circular.icons .icon.corner[class*="top left"] {
+      top: @borderedGroupCornerOffset;
+      left: @borderedGroupCornerOffset;
       right: auto;
       bottom: auto;
     }
-    i.bordered.icons .icon.corner[class*="bottom left"] {
+    i.bordered.icons .icon.corner[class*="bottom left"],
+    i.circular.icons .icon.corner[class*="bottom left"] {
       top: auto;
-      left: .8em;
+      left: @borderedGroupCornerOffset;
       right: auto;
-      bottom: .8em;
+      bottom: @borderedGroupCornerOffset;
     }
-    i.bordered.icons .icon.corner[class*="bottom right"] {
+    i.bordered.icons .icon.corner[class*="bottom right"],
+    i.circular.icons .icon.corner[class*="bottom right"] {
       top: auto;
       left: auto;
-      right: .8em;
-      bottom: .8em;
+      right: @borderedGroupCornerOffset;
+      bottom: @borderedGroupCornerOffset;
     }
   }
 }

--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -397,14 +397,10 @@ i.icons {
 
   & when (@variationIconInverted) {
     /* Inverted Icon */
-    i.circular.inverted.icons,
-    i.bordered.inverted.icons {
+    i.bordered.inverted.icons,
+    i.circular.inverted.icons {
       border: none;
       box-shadow: none;
-    }
-
-    i.inverted.bordered.icons,
-    i.inverted.circular.icons {
       background-color: @black;
       color: @white;
     }

--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -408,8 +408,10 @@ i.icons {
 
   & when (@variationIconCorner) {
     /* Corner Icon */
-    i.bordered.icons .corner.icon,
-    i.circular.icons .corner.icon {
+    i.bordered.icons .icon.corner,
+    i.circular.icons .icon.corner,
+    i.bordered.icons .icon.corner[class*="bottom right"],
+    i.circular.icons .icon.corner[class*="bottom right"] {
       top: auto;
       left: auto;
       right: @borderedGroupCornerOffset;
@@ -434,13 +436,6 @@ i.icons {
       top: auto;
       left: @borderedGroupCornerOffset;
       right: auto;
-      bottom: @borderedGroupCornerOffset;
-    }
-    i.bordered.icons .icon.corner[class*="bottom right"],
-    i.circular.icons .icon.corner[class*="bottom right"] {
-      top: auto;
-      left: auto;
-      right: @borderedGroupCornerOffset;
       bottom: @borderedGroupCornerOffset;
     }
   }

--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -387,7 +387,7 @@ i.icons {
     vertical-align: middle;
   }
   i.circular.icons {
-    border-radius: 500em !important;
+    border-radius: 500em;
   }
   i.bordered.icons i.icon:first-child,
   i.circular.icons i.icon:first-child {

--- a/src/themes/default/elements/icon.variables
+++ b/src/themes/default/elements/icon.variables
@@ -85,6 +85,8 @@
    @cornerIconStroke  @cornerIconStroke 0 @black
 ;
 
+@borderedGroupCornerOffset: 1.15em;
+
 @mini: 0.4em;
 @tiny: 0.5em;
 @small: 0.75em;


### PR DESCRIPTION
<!--
 Please read our Contributing Guide and Code of Conduct before you
 submit a pull request.
  
 Contributing Guide: https://github.com/fomantic/Fomantic-UI/blob/master/CONTRIBUTING.md
 Code of Conduct: https://github.com/fomantic/Fomantic-UI/blob/master/CODE_OF_CONDUCT.md

 ----

 Please use the following pull request title format:
 "[<scope>] <summary of what you fixed/changed>"
-->

## Description
I added functionality to make an icon group bordered.

## Testcase
```html
<p>
    <i class="huge bordered icons">
        <i class="book icon"></i>
        <i class="corner pen icon"></i>
    </i>
    <i class="huge bordered icons">
        <i class="book icon"></i>
        <i class="user icon"></i>
    </i>
    <i class="huge bordered icons">
        <i class="big red dont icon"></i>
        <i class="black user icon"></i>
    </i>
</p>
<p>
    <i class="huge bordered icons">
        <i class="book icon"></i>
        <i class="corner pen top left icon"></i>
    </i>
    <i class="huge bordered icons">
        <i class="book icon"></i>
        <i class="corner pen top right icon"></i>
    </i>
    <br>
    <i class="huge bordered icons">
        <i class="book icon"></i>
        <i class="corner pen bottom left icon"></i>
    </i>
    <i class="huge bordered icons">
        <i class="book icon"></i>
        <i class="corner pen bottom right icon"></i>
    </i>
</p>
```

## Screenshot (if possible)
![image](https://user-images.githubusercontent.com/3358782/98416617-aec4ca80-207f-11eb-8256-57166edc9554.png)


## Closes
#1753 