### PR TITLE
fix(chore): Fetch correct milestones for nightly beta build

### DIFF
--- a/scripts/nightly-version.js
+++ b/scripts/nightly-version.js
@@ -18,7 +18,7 @@ const npmPackage = 'fomantic-ui'
 const getGitHubVersion = async function () {
   return fetch(`${ghBase}/repos/${repoUrlPath}/milestones`)
     .then(r => r.json())
-    .then(milestones => milestones.filter(m => m.title.indexOf('x') === -1)[0].title)
+    .then(milestones => milestones.filter(m => m.title.indexOf('x') === -1).map(m => m.title).sort()[0])
 }
 
 const getCurrentNpmVersion = async function () {


### PR DESCRIPTION
## Description
The current nightly build script is expecting only one available numeric semver milestone to be available, because it only filters milestones which have a "x" inside their version.

While i was preparing issues to 2.9.0 by creating new milestones, the nightly build is fetching the wrong milestone and does not build (correctly) anymore

This PR now sorts all existing milestones ((still leaving out those including an x) to make sure the next upcoming version will be catched

## Testcase
Watch the console
### Wrong
 It will identify 2.9.0 as next nightly build version
https://jsfiddle.net/lubber/hru65zet/7/

### Correct
 It will identify 2.8.8 as next nightly build version
https://jsfiddle.net/lubber/hru65zet/5/
