### PR TITLE
[Table] Allow pointer events for the first header cell in definition table

### DIFF
--- a/src/definitions/collections/table.less
+++ b/src/definitions/collections/table.less
@@ -334,6 +334,10 @@
     -moz-transform: scale(1);
   }
 
+  .ui.definition.table > thead:not(.full-width) > tr > th:first-child:not(:empty) {
+    pointer-events: auto;
+  }
+
   .ui.definition.table > tfoot:not(.full-width) > tr > th:first-child {
     pointer-events: none;
     background: @definitionFooterBackground;


### PR DESCRIPTION
## Description
The first header cell of definition table disables the pointer event which causes the problem when the cell contains the content that are needed the pointer event such as dropdown, input field or the content from title attribute is unable to be seen.

This PR changes the behavior of pointer event to become available if there is content inside the cell.

## Testcase
Put the mouse cursor over the header `Foo title` and `subtitle` in the first cell.

**Before (Tooltip disappear):** https://jsfiddle.net/ko2in/furswynh/2/
**Now (Tooltip appears):** https://jsfiddle.net/ko2in/furswynh/3/

## Closes
#1756
