### PR TITLE
[Card] Fix the top border thickness of horizontal card

### DIFF
--- a/src/definitions/views/card.less
+++ b/src/definitions/views/card.less
@@ -464,6 +464,7 @@
     border-radius: 0 @defaultBorderRadius @defaultBorderRadius 0;
   }
   .ui.horizontal.cards > .card > .content, .ui.horizontal.card > .content {
+    border-top: none;
     flex-basis: 1px;
   }
   .ui.horizontal.cards > .card > .extra, .ui.horizontal.card > .extra {


### PR DESCRIPTION
## Description
The content element of the card has top border and the card also has box shadow which makes the card border thicker when 
the card representing the content horizontally.

This PR removes the top border from the card content if it's inside the horizontal card.

## Testcase
**Before:** https://jsfiddle.net/ko2in/9fyxu08L/

**After:** https://jsfiddle.net/ko2in/82ykuofc/

## Screenshot
**Before:**
![Card_Fomantic_UI_Before](https://user-images.githubusercontent.com/930315/98869282-ec6e8c80-249f-11eb-9dc9-d2d71754cbe0.png)

**After:**
![Card_Fomantic_UI_After](https://user-images.githubusercontent.com/930315/98869295-f0021380-249f-11eb-8baa-f3a43989d5f2.png)

## Closes
None
