### PR TITLE
[Card]: Inverted header links were not styled properly

### DIFF
--- a/src/definitions/views/card.less
+++ b/src/definitions/views/card.less
@@ -928,6 +928,13 @@ each(@colors,{
   .ui.inverted.card > .content > .header {
     color: @invertedHeaderColor;
   }
+  .ui.inverted.cards > .card > .content > a.header,
+  .ui.inverted.card > .content > a.header {
+    color: @invertedHeaderLinkColor;
+    &:hover {
+      color: @invertedHeaderLinkHoverColor;
+    }
+  }
 
   /* Description */
   .ui.inverted.cards > .card > .content > .description,

--- a/src/themes/default/views/card.variables
+++ b/src/themes/default/views/card.variables
@@ -227,6 +227,8 @@
 @invertedBackground: @black;
 @invertedContentDivider: @borderWidth solid rgba(255, 255, 255, 0.15);
 @invertedHeaderColor: @invertedTextColor;
+@invertedHeaderLinkColor: @invertedTextColor;
+@invertedHeaderLinkHoverColor: @linkHoverColor;
 @invertedDescriptionColor: @invertedMutedTextColor;
 @invertedMetaColor: @invertedLightTextColor;
 @invertedMetaLinkColor: @invertedLightTextColor;


### PR DESCRIPTION
## Description
When header link was inside an inverted cards group (not inside a single card!), it was not styled properly.
This PR now adds the same logic as for single card making link header visible again

## Testcase
#### Before
https://jsfiddle.net/lubber/t8asvzdk/12/
#### After
https://jsfiddle.net/lubber/t8asvzdk/13/
## Screenshot
|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/98971950-1c567800-2512-11eb-8e8e-8b7dc5eb2971.png)|![image](https://user-images.githubusercontent.com/18379884/98971807-ef09ca00-2511-11eb-9904-61ba0f312aba.png)|
