### PR TITLE
[Segment] Prevent user selection on disabled and loading segments

### DIFF
--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -491,6 +491,8 @@
   .ui.disabled.segment {
     opacity: @disabledOpacity;
     color: @disabledTextColor;
+    pointer-events: none;
+    user-select: none;
   }
 }
 
@@ -503,7 +505,7 @@
     position: relative;
     cursor: default;
     pointer-events: none;
-    text-shadow: none !important;
+    user-select: none;
     transition: all 0s linear;
   }
   .ui.loading.segment:before {


### PR DESCRIPTION
## Description
In `disabled` or `loading` segments, selection of text via mouse or even clicking on links was still possible
I also removed the unnecessary text-shadow setting

## Testcase
Try to select the header inside the two segments with your mouse or click in the link, it should not work
Remove the custom CSS part to see the issue
https://jsfiddle.net/lubber/dz30etxj/26/  