### PR TITLE
feat(dropdown): support icon groups margin

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -267,6 +267,7 @@
 ---------------*/
 
 /* Icons / Flags / Labels / Image */
+.ui.dropdown > .text > i.icons,
 .ui.dropdown > .text > i.icon,
 .ui.dropdown > .text > .label,
 .ui.dropdown > .text > .flag,
@@ -274,6 +275,7 @@
 .ui.dropdown > .text > .image {
   margin-top: @textLineHeightOffset;
 }
+.ui.dropdown .menu > .item > i.icons,
 .ui.dropdown .menu > .item > i.icon,
 .ui.dropdown .menu > .item > .label,
 .ui.dropdown .menu > .item > .flag,
@@ -282,11 +284,13 @@
   margin-top: @itemLineHeightOffset;
 }
 
+.ui.dropdown > .text > i.icons,
 .ui.dropdown > .text > i.icon,
 .ui.dropdown > .text > .label,
 .ui.dropdown > .text > .flag,
 .ui.dropdown > .text > img,
 .ui.dropdown > .text > .image,
+.ui.dropdown .menu > .item > i.icons,
 .ui.dropdown .menu > .item > i.icon,
 .ui.dropdown .menu > .item > .label,
 .ui.dropdown .menu > .item > .flag,


### PR DESCRIPTION
## Description
icon groups were not respected to add the same margins inside dropdown menus as for single icons

## Testcase

### Broken
https://jsfiddle.net/lubber/3qw8ck2o/
### Fixed
https://jsfiddle.net/lubber/3qw8ck2o/2/

## Screenshots
### Broken
![image](https://user-images.githubusercontent.com/18379884/99107513-40838900-25e6-11eb-94e8-5add0ee108eb.png)

### Fixed
> The visible margin difference to the first entry is because of the wider used single icon but the margin itself is the same

![image](https://user-images.githubusercontent.com/18379884/99107537-4da07800-25e6-11eb-896b-c8412bd8f977.png)

## Closes
#1765 