### PR TITLE
[Dropdown] multiselect values encoding, label cannot be removed, quotes missing in select dropdown

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -3179,8 +3179,9 @@ $.fn.dropdown = function(parameters) {
           },
           label: function(value, shouldAnimate) {
             var
+              escapedValue  = module.escape.value(value),
               $labels       = $module.find(selector.label),
-              $removedLabel = $labels.filter('[data-' + metadata.value + '="' + module.escape.string(settings.ignoreCase ? value.toLowerCase() : value) +'"]')
+              $removedLabel = $labels.filter('[data-' + metadata.value + '="' + module.escape.string(settings.ignoreCase ? escapedValue.toLowerCase() : escapedValue) +'"]')
             ;
             module.verbose('Removing label', $removedLabel);
             $removedLabel.remove();

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1930,7 +1930,7 @@ $.fn.dropdown = function(parameters) {
               : value
             ;
           },
-          values: function() {
+          values: function(raw) {
             var
               value = module.get.value()
             ;
@@ -1939,7 +1939,7 @@ $.fn.dropdown = function(parameters) {
             }
             return ( !module.has.selectInput() && module.is.multiple() )
               ? (typeof value == 'string') // delimited string
-                ? module.escape.htmlEntities(value).split(settings.delimiter)
+                ? (raw ? value : module.escape.htmlEntities(value)).split(settings.delimiter)
                 : ''
               : value
             ;
@@ -2970,7 +2970,7 @@ $.fn.dropdown = function(parameters) {
           },
           value: function(addedValue, addedText, $selectedItem) {
             var
-              currentValue = module.get.values(),
+              currentValue = module.get.values(true),
               newValue
             ;
             if(module.has.value(addedValue)) {

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -3329,7 +3329,7 @@ $.fn.dropdown = function(parameters) {
           },
           valueMatchingCase: function(value) {
             var
-              values   = module.get.values(),
+              values   = module.get.values(true),
               hasValue = Array.isArray(values)
                ? values && ($.inArray(value, values) !== -1)
                : (values == value)
@@ -3341,7 +3341,7 @@ $.fn.dropdown = function(parameters) {
           },
           valueIgnoringCase: function(value) {
             var
-              values   = module.get.values(),
+              values   = module.get.values(true),
               hasValue = false
             ;
             if(!Array.isArray(values)) {

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -4167,8 +4167,8 @@ $.fn.dropdown.settings = {
 
 /* Templates */
 $.fn.dropdown.settings.templates = {
-  deQuote: function(string) {
-      return String(string).replace(/"/g,"");
+  deQuote: function(string, encode) {
+      return String(string).replace(/"/g,encode ? "&quot;" : "");
   },
   escape: function(string, preserveHTML) {
     if (preserveHTML){
@@ -4232,13 +4232,13 @@ $.fn.dropdown.settings.templates = {
       if( itemType === 'item' ) {
         var
           maybeText = (option[fields.text])
-            ? ' data-text="' + deQuote(option[fields.text]) + '"'
+            ? ' data-text="' + deQuote(option[fields.text],true) + '"'
             : '',
           maybeDisabled = (option[fields.disabled])
             ? className.disabled+' '
             : ''
         ;
-        html += '<div class="'+ maybeDisabled + (option[fields.class] ? deQuote(option[fields.class]) : className.item)+'" data-value="' + deQuote(option[fields.value]) + '"' + maybeText + '>';
+        html += '<div class="'+ maybeDisabled + (option[fields.class] ? deQuote(option[fields.class]) : className.item)+'" data-value="' + deQuote(option[fields.value],true) + '"' + maybeText + '>';
         if(option[fields.image]) {
           html += '<img class="'+(option[fields.imageClass] ? deQuote(option[fields.imageClass]) : className.image)+'" src="' + deQuote(option[fields.image]) + '">';
         }


### PR DESCRIPTION
## Description
When a multiple dropdown (non select) was used and selected data has characters like `&` or `'` set, there were stored entity encoded (returning into false positives when comparing later to their original values). Even worse this was only done for all previous selected values, the current to be added value was kept raw already. dropdowns using select tags do not store the selected data in an input field, so the issue does not happen there.

Original data should be kept, as it is already the case for dropdown made out of select tags. Also SUI does not do this.

Additionally this PR fixes a situation when a value has double quotes which led to a js error when trying to remove that label .
Double quotes in select menus are now also kept encoded instead of being removed to have the same behavior for select/non select dropdowns

> Double quotes are always encoded (when text needs to be kept) or removed (everywhere else where they dont make sense like classnames) for security reasons, because all internal templates use them for HTML generation

## Testcase
- Try to select the entries with a & or '
- Watch the hidden inputs content after every selection in the elements console
- Try to remove the `Item 3" inches` label in the first dropdown

### Wrong
- While selecting each previous value gets encoded making it different to the original value
- Trying to remove the `Item 3" inches` label results in a console syntax error 
- The second dropdown, made out of a select, does not show the `"` inside the Item 3 label anymore
https://jsfiddle.net/lubber/fL56791d/13/

### Correct
- Identical selected values
-  `Item 3" inches` label can be removed
- Item 3 shows the `"`
https://jsfiddle.net/lubber/fL56791d/15/



## Screenshots
To see the difference look at the elements console for the hidden input tag holding the selected data. Each time a selected value is added the previous values are encoded.
The second dropdown is made out of a selected tag which works fine already

### Wrong
![image](https://user-images.githubusercontent.com/18379884/99183393-ad5c6780-273b-11eb-95d0-3b6974b0f8c7.png)
![image](https://user-images.githubusercontent.com/18379884/99185524-af79f280-274a-11eb-8165-ed7779f6e1a0.png)

### Correct
![image](https://user-images.githubusercontent.com/18379884/99185492-86f1f880-274a-11eb-82c1-2c135c7f73ea.png)
![image](https://user-images.githubusercontent.com/18379884/99185473-6e81de00-274a-11eb-8dce-c14d0d67d7be.png)

## Closes
#1373 

