### PR TITLE
feat(modal): dynamic modal content

### DIFF
--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -101,7 +101,7 @@ $.fn.modal = function(parameters) {
           }
           $module.addClass(settings.class);
           if (settings.title !== '') {
-            $module.find(selector.title).html(module.helpers.escape(settings.title, settings.preserveHTML));
+            $module.find(selector.title).html(module.helpers.escape(settings.title, settings.preserveHTML)).addClass(settings.classTitle);
           }
           if (settings.content !== '') {
             $module.find(selector.content).html(module.helpers.escape(settings.content, settings.preserveHTML)).addClass(settings.classContent);
@@ -1250,6 +1250,7 @@ $.fn.modal.settings = {
   content      : '',
   class        : '',
   classContent : '',
+  classTitle   : '',
   closeIcon    : false,
   actions      : false,
   preserveHTML : true,

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -58,7 +58,7 @@ $.fn.modal = function(parameters) {
         selector        = settings.selector,
         className       = settings.className,
         namespace       = settings.namespace,
-        fields           = settings.fields,
+        fields          = settings.fields,
         error           = settings.error,
 
         eventNamespace  = '.' + namespace,
@@ -94,10 +94,12 @@ $.fn.modal = function(parameters) {
         initialize: function() {
           if(!$module.hasClass('modal')) {
             module.create.modal();
-            settings.onHidden = function(){
-              module.destroy();
-              $module.remove();
-            };
+            if(!$.isFunction(settings.onHidden)) {
+              settings.onHidden = function () {
+                module.destroy();
+                $module.remove();
+              };
+            }
           }
           $module.addClass(settings.class);
           if (settings.title !== '') {
@@ -550,7 +552,9 @@ $.fn.modal = function(parameters) {
                         $previousModal.find(selector.dimmer).removeClass('active');
                       }
                     }
-                    settings.onHidden.call(element);
+                    if($.isFunction(settings.onHidden)) {
+                      settings.onHidden.call(element);
+                    }
                     module.remove.dimmerStyles();
                     module.restore.focus();
                     callback();
@@ -1273,7 +1277,7 @@ $.fn.modal.settings = {
   onHide     : function(){ return true; },
 
   // called after hide animation
-  onHidden   : function(){},
+  onHidden   : false,
 
   // called after approve selector match
   onApprove  : function(){ return true; },

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -170,6 +170,7 @@ $.fn.modal = function(parameters) {
             if (module.has.configActions()) {
               $('<div/>', {class: 'actions'}).appendTo($module);
             }
+            $context.append($module);
           },
           dimmer: function() {
             var

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -107,7 +107,7 @@ $.fn.modal = function(parameters) {
             $module.find(selector.content).html(module.helpers.escape(settings.content, settings.preserveHTML)).addClass(settings.classContent);
           }
           if(module.has.configActions()){
-            var $actions = $module.find(selector.actions);
+            var $actions = $module.find(selector.actions).addClass(settings.classActions);
             settings.actions.forEach(function (el) {
               var icon = el[fields.icon] ? '<i class="' + module.helpers.deQuote(el[fields.icon]) + ' icon"></i>' : '',
                   text = module.helpers.escape(el[fields.text] || '', settings.preserveHTML),
@@ -1249,8 +1249,9 @@ $.fn.modal.settings = {
   title        : '',
   content      : '',
   class        : '',
-  classContent : '',
   classTitle   : '',
+  classContent : '',
+  classActions : '',
   closeIcon    : false,
   actions      : false,
   preserveHTML : true,


### PR DESCRIPTION
## Description
This PR adds the same dynamic functionality like toast to create a modal just out of properties or reuse a DOM node modal as a template with its content being dynamically set via js properties.
Everything is optional and backward compatible 🙂 
Most of the code is copied /adopted from the toast component so the usage is equal.

This goes along with @prudho fui-alert plugin approach (#1716) which could be more simplified then

### Create a temporary modal just by JS properties
By providing new properties to the modal module and targeting to body you create temporary modals without the need to create markup on your own. The modal is temporary and will be removed from the DOM once closed.

```javascript
$('body').modal({
  title: 'Important Notice',
  class: 'mini',
  closeIcon: true,
  content: 'You will be logged out in 5 Minutes',
  actions: [{
    	text: 'Alright, got it',
        class: 'green'
  }]
}).modal('show');
```
### Reuse an existing modal
Also, you can still prepare a modal markup in your domtree as usual, but set the related content via js properties to reuse the general style
```javascript
$('.ui.modal').modal({
  title: 'Chat rules',
  content: '<div>You can put HTML content right here</div>',
  class: 'inverted fullscreen',
  classContent: 'scrolling',
  actions: [{
    	text: 'That is awesome',
        class: 'green',
        icon: 'exclamation',
        click: function() {
            // do something. return false to prevent closing the modal
        }
  }]
}).modal('show');
```

## Testcase
https://jsfiddle.net/lubber/eo8bdyp3/48/

## Screenshot
![dynamicmodal](https://user-images.githubusercontent.com/18379884/99649599-b0fe3000-2a54-11eb-8a79-4d77ba28fc94.gif)

## Closes
#1407 