### PR TITLE
fix(calendar): return null instead of undefined in sanitizer

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -1074,14 +1074,11 @@ $.fn.calendar = function(parameters) {
             return null;
           },
           sanitiseDate: function (date) {
-            if (!date) {
-              return undefined;
-            }
             if (!(date instanceof Date)) {
               date = parser.date('' + date, settings);
             }
-            if (!date || date === null || isNaN(date.getTime())) {
-              return undefined;
+            if (!date || isNaN(date.getTime())) {
+              return null;
             }
             return date;
           },


### PR DESCRIPTION
## Description
The date sanitizer returns `undefined` when the date argument is not a valid date object or date string which doesn't allow to reset the date value especially for min and max date by passing `null` value via `set minDate` and `set MaxDate`.

This PR makes the `sanitiseDate` method to return `null` if the value of date argument is not valid date object or date string.

## Testcase
**Unable to reset min date and max date:** https://jsfiddle.net/cr7myt25/2/

**Enable to reset min date and max date:** https://jsfiddle.net/ko2in/8ym30fju/8/

## Closes
#1776
