### PR TITLE
fix(dropdown): calculate correct height of current menu if it contains child menu

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -3295,7 +3295,7 @@ $.fn.dropdown = function(parameters) {
             return ($menu.length > 0);
           },
           subMenu: function($currentMenu) {
-            return $currentMenu.find(selector.menu).length > 0;
+            return ($currentMenu || $menu).find(selector.menu).length > 0;
           },
           message: function() {
             return ($menu.children(selector.message).length !== 0);

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -3527,7 +3527,7 @@ $.fn.dropdown = function(parameters) {
               calculations.menu.offset.top += calculations.context.scrollTop;
             }
             if(module.has.subMenu()) {
-              calculations.menu.height += $menu.find(selector.menu).first().outerHeight();
+              calculations.menu.height += $currentMenu.find(selector.menu).first().outerHeight();
             }
             onScreen = {
               above : (calculations.context.scrollTop) <= calculations.menu.offset.top - calculations.context.offset.top - calculations.menu.height,

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -3294,8 +3294,8 @@ $.fn.dropdown = function(parameters) {
           menu: function() {
             return ($menu.length > 0);
           },
-          subMenu: function() {
-            return $menu.find(selector.menu).length > 0;
+          subMenu: function($currentMenu) {
+            return $currentMenu.find(selector.menu).length > 0;
           },
           message: function() {
             return ($menu.children(selector.message).length !== 0);
@@ -3526,7 +3526,7 @@ $.fn.dropdown = function(parameters) {
             if(module.is.verticallyScrollableContext()) {
               calculations.menu.offset.top += calculations.context.scrollTop;
             }
-            if(module.has.subMenu()) {
+            if(module.has.subMenu($currentMenu)) {
               calculations.menu.height += $currentMenu.find(selector.menu).first().outerHeight();
             }
             onScreen = {

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -3294,6 +3294,9 @@ $.fn.dropdown = function(parameters) {
           menu: function() {
             return ($menu.length > 0);
           },
+          subMenu: function() {
+            return $menu.find(selector.menu).length > 0;
+          },
           message: function() {
             return ($menu.children(selector.message).length !== 0);
           },
@@ -3522,6 +3525,9 @@ $.fn.dropdown = function(parameters) {
             };
             if(module.is.verticallyScrollableContext()) {
               calculations.menu.offset.top += calculations.context.scrollTop;
+            }
+            if(module.has.subMenu()) {
+              calculations.menu.height += $menu.find(selector.menu).first().outerHeight();
             }
             onScreen = {
               above : (calculations.context.scrollTop) <= calculations.menu.offset.top - calculations.context.offset.top - calculations.menu.height,


### PR DESCRIPTION
## Description
When the menu contain the child menu, the calculation of menu height is incorrect while evaluating to open upward or downard.

It's because the child menu is hidden when the current menu is in the transition of being open and it doesn't occupy any space in the current menu and the height of the current menu is incorrectly calculated without the height of child menu which let the menu opens upward or downward incorrectly.

This PR checks if the current menu has the child menu and adds the child menu height to the current menu height to give correct assumption whether the menu fits in the screen upward or downward.

![Dropdown](https://user-images.githubusercontent.com/930315/100156761-dd440180-2ed7-11eb-8374-6a7de90e4c48.gif)

## Testcase

Open the fiddle and adjust the page where the dropdown is not fit to open downward. Click the button to open dropdown. The dropdown should open upward.
- Bug: https://jsfiddle.net/ko2in/k6Lwzhjf/
- Fixed: https://jsfiddle.net/ko2in/c28t6wkx/3/

## Screenshot
**Incorrect:**
![Dropdown-Downward](https://user-images.githubusercontent.com/930315/100156466-5db63280-2ed7-11eb-8dd1-f7c9c672dedc.gif)

**Correct:**
![Dropdown-Upward](https://user-images.githubusercontent.com/930315/100156473-6149b980-2ed7-11eb-9a86-e783383b0b53.gif)

## Closes
#1711
