### PR TITLE
fix(table): missing comma lead into wrong selector

### DIFF
--- a/src/definitions/collections/table.less
+++ b/src/definitions/collections/table.less
@@ -1116,7 +1116,7 @@ each(@colors, {
     .ui.inverted.definition.table > thead:not(.full-width) > tr > th:first-child {
       background: @definitionPageBackground;
     }
-    .ui.inverted.definition.table > tbody > tr > td:first-child
+    .ui.inverted.definition.table > tbody > tr > td:first-child,
     .ui.inverted.definition.table > tfoot > tr > td:first-child,
     .ui.inverted.definition.table > tr > td:first-child {
       background: @invertedDefinitionColumnBackground;


### PR DESCRIPTION
## Description

This PR fixes a missing comma, which otherwise led into a wrong selector generation

Thanks to @ivantcholakov for finding this typo! 🙂 👍 

## Closes
https://github.com/fomantic/Fomantic-UI/commit/c0483997eaf3e378abcaef1cf6b25bdfd1d33ffb#r44990281