### PR TITLE
[Nag] Refactored: no jquery cookie plugin dependency, colors, sizes, fixes

### DIFF
--- a/src/definitions/modules/nag.js
+++ b/src/definitions/modules/nag.js
@@ -58,14 +58,14 @@ $.fn.nag = function(parameters) {
 
         element         = this,
         instance        = $module.data(moduleNamespace),
-
+        storage,
         module
       ;
       module = {
 
         initialize: function() {
           module.verbose('Initializing element');
-
+          storage = module.get.storage();
           $module
             .on('click' + eventNamespace, selector.close, module.dismiss)
             .data(moduleNamespace, module)
@@ -110,9 +110,9 @@ $.fn.nag = function(parameters) {
 
         hide: function() {
           module.debug('Showing nag', settings.animation.hide);
-          if(settings.animation.show == 'fade') {
+          if(settings.animation.hide == 'fade') {
             $module
-              .fadeIn(settings.duration, settings.easing)
+              .fadeOut(settings.duration, settings.easing)
             ;
           }
           else {
@@ -155,18 +155,83 @@ $.fn.nag = function(parameters) {
         },
 
         get: {
+          expirationDate: function(expires) {
+            if (typeof expires === 'number') {
+              expires = new Date(Date.now() + expires * 864e5);
+            }
+            if(expires instanceof Date && expires.getTime() ){
+              return expires.toUTCString();
+            } else {
+              module.error(error.expiresFormat);
+            }
+          },
+          storage: function(){
+            if(settings.storageMethod === 'localstorage' && window.localStorage !== undefined) {
+              module.debug('Using local storage');
+              return window.localStorage;
+            }
+            else if(settings.storageMethod === 'sessionstorage' && window.sessionStorage !== undefined) {
+              module.debug('Using session storage');
+              return window.sessionStorage;
+            }
+            else if("cookie" in document) {
+              module.debug('Using cookie');
+              return {
+                setItem: function(key, value, options) {
+                  // RFC6265 compliant encoding
+                  key   = encodeURIComponent(key)
+                      .replace(/%(2[346B]|5E|60|7C)/g, decodeURIComponent)
+                      .replace(/[()]/g, escape);
+                  value = encodeURIComponent(value)
+                      .replace(/%(2[346BF]|3[AC-F]|40|5[BDE]|60|7[BCD])/g, decodeURIComponent)
+
+                  var cookieOptions = '';
+                  for (var option in options) {
+                    if (options.hasOwnProperty(option)) {
+                      cookieOptions += '; ' + option;
+                      if (typeof options[option] === 'string') {
+                        cookieOptions += '=' + options[option].split(';')[0];
+                      }
+                    }
+                  }
+                  document.cookie = key + '=' + value + cookieOptions;
+                },
+                getItem: function(key) {
+                  var cookies = document.cookie.split('; ');
+                  for (var i = 0, il = cookies.length; i < il; i++) {
+                    var parts    = cookies[i].split('='),
+                        foundKey = parts[0].replace(/(%[\dA-F]{2})+/gi, decodeURIComponent);
+                    if (key === foundKey) {
+                      return parts[1] || '';
+                    }
+                  }
+                },
+                removeItem: function(key, options) {
+                  storage.setItem(key,'',options);
+                }
+              };
+            } else {
+              module.error(error.noStorage);
+            }
+          },
           storageOptions: function() {
             var
               options = {}
             ;
             if(settings.expires) {
-              options.expires = settings.expires;
+              options.expires = module.get.expirationDate(settings.expires);
             }
             if(settings.domain) {
               options.domain = settings.domain;
             }
             if(settings.path) {
               options.path = settings.path;
+            }
+            if(settings.secure) {
+              options.secure = settings.secure;
+            }
+            if(settings.samesite) {
+              options.samesite = settings.samesite;
             }
             return options;
           }
@@ -181,39 +246,30 @@ $.fn.nag = function(parameters) {
             var
               options = module.get.storageOptions()
             ;
-            if(settings.storageMethod == 'localstorage' && window.localStorage !== undefined) {
-              window.localStorage.setItem(key, value);
-              module.debug('Value stored using local storage', key, value);
+            if(storage === window.localStorage && options.expires) {
+              module.debug('Storing expiration value in localStorage', key, options.expires);
+              storage.setItem(key + settings.expirationKey, options.expires );
             }
-            else if(settings.storageMethod == 'sessionstorage' && window.sessionStorage !== undefined) {
-              window.sessionStorage.setItem(key, value);
-              module.debug('Value stored using session storage', key, value);
+            module.debug('Value stored', key, value);
+            try {
+              storage.setItem(key, value, options);
             }
-            else if($.cookie !== undefined) {
-              $.cookie(key, value, options);
-              module.debug('Value stored using cookie', key, value, options);
-            }
-            else {
-              module.error(error.noCookieStorage);
-              return;
+            catch(e) {
+              module.error(error.setItem, e);
             }
           },
-          get: function(key, value) {
+          get: function(key) {
             var
               storedValue
             ;
-            if(settings.storageMethod == 'localstorage' && window.localStorage !== undefined) {
-              storedValue = window.localStorage.getItem(key);
-            }
-            else if(settings.storageMethod == 'sessionstorage' && window.sessionStorage !== undefined) {
-              storedValue = window.sessionStorage.getItem(key);
-            }
-            // get by cookie
-            else if($.cookie !== undefined) {
-              storedValue = $.cookie(key);
-            }
-            else {
-              module.error(error.noCookieStorage);
+            storedValue = storage.getItem(key);
+            if(storage === window.localStorage) {
+              var expiration = storage.getItem(key + settings.expirationKey);
+              if(expiration !== null && expiration !== undefined && new Date(expiration) < new Date()) {
+                module.debug('Value in localStorage has expired. Deleting key', key);
+                module.storage.remove(key);
+                storedValue = null;
+              }
             }
             if(storedValue == 'undefined' || storedValue == 'null' || storedValue === undefined || storedValue === null) {
               storedValue = undefined;
@@ -224,19 +280,11 @@ $.fn.nag = function(parameters) {
             var
               options = module.get.storageOptions()
             ;
-            if(settings.storageMethod == 'localstorage' && window.localStorage !== undefined) {
-              window.localStorage.removeItem(key);
+            options.expires = module.get.expirationDate(-1);
+            if(storage === window.localStorage) {
+              storage.removeItem(key + settings.expirationKey);
             }
-            else if(settings.storageMethod == 'sessionstorage' && window.sessionStorage !== undefined) {
-              window.sessionStorage.removeItem(key);
-            }
-            // store by cookie
-            else if($.cookie !== undefined) {
-              $.removeCookie(key, options);
-            }
-            else {
-              module.error(error.noStorage);
-            }
+            storage.removeItem(key, options);
           }
         },
 
@@ -450,8 +498,12 @@ $.fn.nag.settings = {
   detachable    : false,
 
   expires       : 30,
+
+// cookie storage only options
   domain        : false,
   path          : '/',
+  secure        : false,
+  samesite      : false,
 
   // type of storage to use
   storageMethod : 'cookie',
@@ -460,10 +512,14 @@ $.fn.nag.settings = {
   key           : 'nag',
   value         : 'dismiss',
 
+// Key suffix to support expiration in localstorage
+  expirationKey : 'ExpirationDate',
+
   error: {
-    noCookieStorage : '$.cookie is not included. A storage solution is required.',
-    noStorage       : 'Neither $.cookie or store is defined. A storage solution is required for storing state',
-    method          : 'The method you called is not defined.'
+    noStorage       : 'Unsupported storage method',
+    method          : 'The method you called is not defined.',
+    setItem         : 'Unexpected error while setting value',
+    expiresFormat   : '"expires" must be a number of days or a Date Object'
   },
 
   className     : {
@@ -472,7 +528,7 @@ $.fn.nag.settings = {
   },
 
   selector      : {
-    close : '.close.icon'
+    close : '> .close.icon'
   },
 
   speed         : 500,

--- a/src/definitions/modules/nag.js
+++ b/src/definitions/modules/nag.js
@@ -183,7 +183,7 @@ $.fn.nag = function(parameters) {
                       .replace(/%(2[346B]|5E|60|7C)/g, decodeURIComponent)
                       .replace(/[()]/g, escape);
                   value = encodeURIComponent(value)
-                      .replace(/%(2[346BF]|3[AC-F]|40|5[BDE]|60|7[BCD])/g, decodeURIComponent)
+                      .replace(/%(2[346BF]|3[AC-F]|40|5[BDE]|60|7[BCD])/g, decodeURIComponent);
 
                   var cookieOptions = '';
                   for (var option in options) {

--- a/src/definitions/modules/nag.less
+++ b/src/definitions/modules/nag.less
@@ -86,7 +86,7 @@ a.ui.nag {
   opacity: @nagHoverOpacity;
 }
 
-.ui.nag .close:hover {
+.ui.nag > .close:hover {
   opacity: @closeHoverOpacity;
 }
 
@@ -95,64 +95,116 @@ a.ui.nag {
            Variations
 *******************************/
 
+& when(@variationNagOverlay) {
+  /*--------------
+       Static
+  ---------------*/
 
-/*--------------
-     Static
----------------*/
-
-.ui.overlay.nag {
-  position: absolute;
-  display: block;
+  .ui.overlay.nag {
+    position: absolute;
+    display: block;
+  }
 }
 
+& when(@variationNagFixed) {
 /*--------------
      Fixed
 ---------------*/
 
-.ui.fixed.nag {
-  position: fixed;
+  .ui.fixed.nag {
+    position: fixed;
+  }
 }
-
 /*--------------
      Bottom
 ---------------*/
+& when(@variationNagBottom) {
+  .ui.bottom.nags,
+  .ui.bottom.nag {
+    border-radius: @bottomBorderRadius;
+    top: auto;
+    bottom: @bottom;
+  }
+}
 
-.ui.bottom.nags,
-.ui.bottom.nag {
-  border-radius: @bottomBorderRadius;
-  top: auto;
-  bottom: @bottom;
+& when(@variationNagInverted) {
+/*--------------
+     Inverted
+---------------*/
+
+  .ui.inverted.nags .nag,
+  .ui.inverted.nag {
+    background-color: @invertedBackground;
+    color: @darkTextColor;
+  }
+  .ui.inverted.nags .nag > .close,
+  .ui.inverted.nag > .close {
+    color: @invertedCloseColor;
+  }
+  .ui.inverted.nags .nag > .title,
+  .ui.inverted.nag > .title {
+    color: @invertedTitleColor;
+  }
+}
+
+& when not (@variationNagSizes = false) {
+/*-------------------
+        Sizes
+--------------------*/
+  each(@variationNagSizes, {
+    @s: @@value;
+    @sr: "@{value}Raw";
+    .ui.@{value}.nag,
+    .ui.@{value}.nags .nag {
+      font-size: @s;
+      & when (@@sr > 1.4) {
+        line-height: 1;
+      }
+    }
+  })
 }
 
 /*--------------
-     White
----------------*/
+     Colors
+-------------- */
 
-.ui.inverted.nags .nag,
-.ui.inverted.nag {
-  background-color: @invertedBackground;
-  color: @darkTextColor;
-}
-.ui.inverted.nags .nag .close,
-.ui.inverted.nags .nag .title,
-.ui.inverted.nag .close,
-.ui.inverted.nag .title {
-  color: @lightTextColor;
-}
+each(@colors, {
+  @color: replace(@key, '@', '');
+  @c: @colors[@@color][color];
+  @l: @colors[@@color][light];
+  @isVeryDark: @colors[@@color][isVeryDark];
 
+  .ui.@{color}.nag {
+    background-color: @c;
+    & when (@isVeryDark) {
+      color: @invertedTextColor;
+    }
+  }
+  & when (@variationNagInverted) {
+    .ui.inverted.@{color}.nag {
+      background-color: @l;
+      & .title when (@isVeryDark) {
+        color: @titleColor;
+      }
+    }
+  }
+})
 
+& when (@variationNagGroups) {
 /*******************************
            Groups
 *******************************/
 
-.ui.nags .nag {
-  border-radius: @groupedBorderRadius !important;
+  .ui.nags .nag {
+    border-radius: @groupedBorderRadius;
+  }
+  .ui.nags:not(.bottom) .nag:last-child {
+    border-radius: @topBorderRadius;
+  }
+  & when(@variationNagBottom) {
+    .ui.bottom.nags .nag:first-child {
+      border-radius: @bottomBorderRadius;
+    }
+  }
 }
-.ui.nags .nag:last-child {
-  border-radius: @topBorderRadius;
-}
-.ui.bottom.nags .nag:last-child {
-  border-radius: @bottomBorderRadius;
-}
-
 .loadUIOverrides();

--- a/src/definitions/modules/nag.less
+++ b/src/definitions/modules/nag.less
@@ -115,10 +115,10 @@ a.ui.nag {
     position: fixed;
   }
 }
+& when(@variationNagBottom) {
 /*--------------
      Bottom
 ---------------*/
-& when(@variationNagBottom) {
   .ui.bottom.nags,
   .ui.bottom.nag {
     border-radius: @bottomBorderRadius;

--- a/src/definitions/modules/nag.less
+++ b/src/definitions/modules/nag.less
@@ -74,7 +74,9 @@ a.ui.nag {
   transition: @closeTransition;
 }
 
-
+.ui.nag:not(.overlay):not(.fixed) {
+  border-radius: @borderRadius;
+}
 
 /*******************************
              States
@@ -99,7 +101,7 @@ a.ui.nag {
   /*--------------
        Static
   ---------------*/
-
+  .ui.overlay.nags,
   .ui.overlay.nag {
     position: absolute;
     display: block;
@@ -110,7 +112,7 @@ a.ui.nag {
 /*--------------
      Fixed
 ---------------*/
-
+  .ui.fixed.nags,
   .ui.fixed.nag {
     position: fixed;
   }
@@ -194,8 +196,12 @@ each(@colors, {
 /*******************************
            Groups
 *******************************/
-
-  .ui.nags .nag {
+  .ui.nags {
+    top: @top;
+    left: 0;
+    width: @width;
+  }
+  .ui.ui.nags .nag {
     border-radius: @groupedBorderRadius;
   }
   .ui.nags:not(.bottom) .nag:last-child {
@@ -205,6 +211,12 @@ each(@colors, {
     .ui.bottom.nags .nag:first-child {
       border-radius: @bottomBorderRadius;
     }
+  }
+  .ui.nags:not(.fixed):not(.overlay) .nag:first-child {
+    border-radius: @bottomBorderRadius;
+  }
+  .ui.nags:not(.fixed):not(.overlay) .nag:only-child {
+    border-radius: @borderRadius;
   }
 }
 .loadUIOverrides();

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -435,6 +435,14 @@
 @variationModalCloseInside: true;
 @variationModalSizes: @variationAllSizes;
 
+/* Nag */
+@variationNagInverted: true;
+@variationNagBottom: true;
+@variationNagOverlay: true;
+@variationNagFixed: true;
+@variationNagGroups: true;
+@variationNagSizes: @variationAllSizes;
+
 /* Popup */
 @variationPopupInverted: true;
 @variationPopupTooltip: true;

--- a/src/themes/default/modules/nag.variables
+++ b/src/themes/default/modules/nag.variables
@@ -11,7 +11,7 @@
 @zIndex: 999;
 @margin: 0;
 
-@background: #555555;
+@background: #777777;
 @opacity: 0.95;
 @minHeight: 0;
 @padding: 0.75em 1em;
@@ -65,6 +65,8 @@
 
 /* Inverted */
 @invertedBackground: @darkWhite;
+@invertedTitleColor: @mutedTextColor;
+@invertedCloseColor: @mutedTextColor;
 
 /*--------------
       Plural


### PR DESCRIPTION
## Description

This PR finishes the `nag` module. It was hidden from the docs, because there were still bugs inside and not completely done (but already used in several projects). I refactored some code and added usual features so this module can be officially supported again (I'll do another PR for the docs then) 

### What has been improved?

- Removed the dependency of the jquery cookie plugin. Cookie storage method is now natively supported inside the module. Now every storage method also got the same api for easier abstraction
- Added expiration functionality for localstorage method as well 
- Added color support
- Added sizing support
- fixed grouping (wrong border radius)
- fixed animation (wrong direction)
- slightly fixed text colors for better contrast
- fully backward compatible to existing code

## Testcase
https://jsfiddle.net/lubber/p67wLyb0/41/

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/102422520-44e8fa80-4007-11eb-95bd-fa75cbc641e8.png)
![image](https://user-images.githubusercontent.com/18379884/102422469-284cc280-4007-11eb-8c92-861fcd819a61.png)

## Closes
https://github.com/Semantic-Org/Semantic-UI/pull/2905
https://github.com/Semantic-Org/Semantic-UI/pull/6505
https://github.com/Semantic-Org/Semantic-UI/issues/211#issuecomment-227877711
https://github.com/Semantic-Org/Semantic-UI/issues/211#issuecomment-140584891
