### PR TITLE
[Form]: Support range values for decimal and number validation, add max/minValue and display range in default prompt

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -559,8 +559,8 @@ $.fn.form = function(parameters) {
               parts = ancillary.split('..', 2);
               if(!rule.prompt) {
                 suffixPrompt = (
-                    parts[0] === '' ? settings.prompt.maxValue.replace(/\{ruleValue\}/,'{max}') :
-                    parts[1] === '' ? settings.prompt.minValue.replace(/\{ruleValue\}/,'{min}') :
+                    parts[0] === '' ? settings.prompt.maxValue.replace(/\{ruleValue\}/g,'{max}') :
+                    parts[1] === '' ? settings.prompt.minValue.replace(/\{ruleValue\}/g,'{min}') :
                     settings.prompt.range
                 );
                 prompt += suffixPrompt.replace(/\{name\}/g, ' ' + settings.text.and);

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1732,8 +1732,16 @@ $.fn.form.settings = {
 
     // is valid integer or matches range
     integer: function(value, range) {
+      return $.fn.form.settings.rules.range(value, range, 'integer');
+    },
+    range: function(value, range, regExp) {
+      if(typeof regExp == "string") {
+        regExp = $.fn.form.settings.regExp[regExp];
+      }
+      if(!(regExp instanceof RegExp)) {
+        regExp = $.fn.form.settings.regExp.integer;
+      }
       var
-        intRegExp = $.fn.form.settings.regExp.integer,
         min,
         max,
         parts
@@ -1742,34 +1750,34 @@ $.fn.form.settings = {
         // do nothing
       }
       else if(range.indexOf('..') == -1) {
-        if(intRegExp.test(range)) {
+        if(regExp.test(range)) {
           min = max = range - 0;
         }
       }
       else {
         parts = range.split('..', 2);
-        if(intRegExp.test(parts[0])) {
+        if(regExp.test(parts[0])) {
           min = parts[0] - 0;
         }
-        if(intRegExp.test(parts[1])) {
+        if(regExp.test(parts[1])) {
           max = parts[1] - 0;
         }
       }
       return (
-        intRegExp.test(value) &&
+        regExp.test(value) &&
         (min === undefined || value >= min) &&
         (max === undefined || value <= max)
       );
     },
 
     // is valid number (with decimal)
-    decimal: function(value) {
-      return $.fn.form.settings.regExp.decimal.test(value);
+    decimal: function(value, range) {
+      return $.fn.form.settings.rules.range(value, range, 'decimal');
     },
 
     // is valid number
-    number: function(value) {
-      return $.fn.form.settings.regExp.number.test(value);
+    number: function(value, range) {
+      return $.fn.form.settings.rules.range(value, range, 'number');
     },
 
     // is value (case insensitive)

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -551,8 +551,23 @@ $.fn.form = function(parameters) {
               requiresValue = (prompt.search('{value}') !== -1),
               requiresName  = (prompt.search('{name}') !== -1),
               $label,
-              name
+              name,
+              parts,
+              suffixPrompt
             ;
+            if(ancillary && ancillary.indexOf('..') >= 0) {
+              parts = ancillary.split('..', 2);
+              if(!rule.prompt) {
+                suffixPrompt = (
+                    parts[0] === '' ? settings.prompt.maxValue.replace(/\{ruleValue\}/,'{max}') :
+                    parts[1] === '' ? settings.prompt.minValue.replace(/\{ruleValue\}/,'{min}') :
+                    settings.prompt.range
+                );
+                prompt += suffixPrompt.replace(/\{name\}/g, ' ' + settings.text.and);
+              }
+              prompt = prompt.replace(/\{min\}/g, parts[0]);
+              prompt = prompt.replace(/\{max\}/g, parts[1]);
+            }
             if(requiresValue) {
               prompt = prompt.replace(/\{value\}/g, $field.val());
             }
@@ -1561,12 +1576,16 @@ $.fn.form.settings = {
   },
 
   text: {
+    and              : 'and',
     unspecifiedRule  : 'Please enter a valid value',
     unspecifiedField : 'This field',
     leavingMessage   : 'There are unsaved changes on this page which will be discarded if you continue.'
   },
 
   prompt: {
+    range                : '{name} must be in a range from {min} to {max}',
+    maxValue             : '{name} must have a maximum value of {ruleValue}',
+    minValue             : '{name} must have a minimum value of {ruleValue}',
     empty                : '{name} must have a value',
     checked              : '{name} must be checked',
     email                : '{name} must be a valid e-mail',
@@ -1729,7 +1748,12 @@ $.fn.form.settings = {
       }
       return value.match( new RegExp(regExp, flags) );
     },
-
+    minValue: function(value, range) {
+      return $.fn.form.settings.rules.range(value, range+'..', 'number');
+    },
+    maxValue: function(value, range) {
+      return $.fn.form.settings.rules.range(value, '..'+range, 'number');
+    },
     // is valid integer or matches range
     integer: function(value, range) {
       return $.fn.form.settings.rules.range(value, range, 'integer');


### PR DESCRIPTION
## Description
It was not possible to allow for an optional range check for the decimal or number validator. This was only supported for integer values.
This PR now 

- supports decimal and number validators to supply a range by making the check for a range value a separate `range` validator so it can be reused.
- adds 2 new validators `maxValue` and `minValue` accordingly
- displays the range values in the default error prompt as well if no prompt is given 


### Before
```javascript
rules: [
  {
    type   : 'decimal'
  }
]
```

### After
```javascript
rules: [
  {
    type   : 'decimal[0.5..1.9]'
  }
]
rules: [
  {
    type   : 'minValue[50]'
  }
]
rules: [
  {
    type   : 'maxValue[10]'
  }
]
```

## Testcase
https://jsfiddle.net/lubber/g3nte1m6/14/

## Screenshot
### Before
![image](https://user-images.githubusercontent.com/18379884/102489991-8c56a180-406e-11eb-9b0e-9dd6b021ad16.png)

### After
![image](https://user-images.githubusercontent.com/18379884/102489959-7e088580-406e-11eb-9119-676e4c525692.png)
![image](https://user-images.githubusercontent.com/18379884/102490441-1e5eaa00-406f-11eb-8fe0-51967e2196d4.png)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5496
