### PR TITLE
[Input / Form] Firefox has different placeholder opacity by default

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -377,6 +377,7 @@
 }
 .ui.form ::-moz-placeholder {
   color: @inputPlaceholderColor;
+  opacity: 1;
 }
 
 .ui.form :focus::-webkit-input-placeholder {

--- a/src/definitions/elements/input.less
+++ b/src/definitions/elements/input.less
@@ -67,6 +67,7 @@
 }
 .ui.input > input::-moz-placeholder {
   color: @placeholderColor;
+  opacity: 1;
 }
 .ui.input > input:-ms-input-placeholder {
   color: @placeholderColor;


### PR DESCRIPTION
## Description
[Firefox does not set the default placeholder to 100% opacity](https://developer.mozilla.org/en-US/docs/Web/CSS/::placeholder#Opaque_text)

This results into a visual difference when an input field is shown next to a dropdown, whereas the placeholder opacity is 100%, while firefox defaults it around 54%

## Testcase
Open in Firefox to see the difference: The normal input fields placeholders have a lower opacity than the dropdown placeholder

### Before
https://jsfiddle.net/lubber/eh8v6y35/2/

### After
https://jsfiddle.net/lubber/eh8v6y35/4/

## Screenshots

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/102506740-b6ff2500-4083-11eb-99f3-1606545c0d3d.png)|![image](https://user-images.githubusercontent.com/18379884/102506669-a77fdc00-4083-11eb-8fd0-886c1b66402f.png)|

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/4937
