### PR TITLE
[Message] Support icon groups

### DIFF
--- a/src/definitions/collections/message.less
+++ b/src/definitions/collections/message.less
@@ -107,6 +107,7 @@
 
 
 /* Icon */
+.ui.message > .icons,
 .ui.message > i.icon {
   margin-right: @iconDistance;
 }
@@ -225,6 +226,7 @@
     width: 100%;
     align-items: center;
   }
+  .ui.icon.message > .icons,
   .ui.icon.message > i.icon:not(.close) {
     display: block;
     flex: 0 0 auto;
@@ -240,11 +242,11 @@
     vertical-align: @iconVerticalAlign;
   }
 
-
+  .ui.icon.message > .icons + .content,
   .ui.icon.message > i.icon:not(.close) + .content {
     padding-left: @iconContentDistance;
   }
-  .ui.icon.message > i.circular.icon {
+  .ui.icon.message > i.circular {
     width: 1em;
   }
 }


### PR DESCRIPTION
## Description
Usage of icon groups were not supported for `icon message`.

## Testcase
## Before
http://jsfiddle.net/lubber/0ht8y135/15/

## After
http://jsfiddle.net/lubber/0ht8y135/13/

## Screenshot

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/102527770-e6229000-409d-11eb-9534-e70ca53bcd97.png)|![image](https://user-images.githubusercontent.com/18379884/102527722-d440ed00-409d-11eb-8e86-d1481a281d67.png)|

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/2553