### PR TITLE
[Header] Support icon groups

### DIFF
--- a/src/definitions/elements/header.less
+++ b/src/definitions/elements/header.less
@@ -72,8 +72,8 @@
 }
 
 /* With Text Node */
-.ui.header > .icons:only-child,
-.ui.header > i.icon:only-child {
+.ui.header:not(.icon) > .icons:only-child,
+.ui.header:not(.icon) > i.icon:only-child {
   display: inline-block;
   padding: 0;
   margin-right: @iconMargin;

--- a/src/definitions/elements/header.less
+++ b/src/definitions/elements/header.less
@@ -62,6 +62,7 @@
       Icon
 ---------------*/
 
+.ui.header > .icons,
 .ui.header > i.icon {
   display: table-cell;
   opacity: @iconOpacity;
@@ -71,6 +72,7 @@
 }
 
 /* With Text Node */
+.ui.header > .icons:only-child,
 .ui.header > i.icon:only-child {
   display: inline-block;
   padding: 0;
@@ -111,6 +113,7 @@
 }
 
 /* After Icon */
+.ui.header:not(.centered):not(.aligned) > .icons + .content,
 .ui.header:not(.centered):not(.aligned) > i.icon + .content {
   padding-left: @iconMargin;
   display: table-cell;
@@ -220,6 +223,7 @@
   .ui.icon.header:first-child {
     margin-top: @iconHeaderFirstMargin;
   }
+  .ui.icon.header > .icons,
   .ui.icon.header > i.icon {
     float: none;
     display: block;
@@ -238,13 +242,14 @@
     display: block;
     padding: 0;
   }
-  .ui.icon.header > i.circular.icon {
+  .ui.icon.header > i.circular {
     font-size: @circularHeaderIconSize;
   }
-  .ui.icon.header > i.square.icon {
+  .ui.icon.header > i.square {
     font-size: @squareHeaderIconSize;
   }
   & when (@variationHeaderBlock) {
+    .ui.block.icon.header > .icons,
     .ui.block.icon.header > i.icon {
       margin-bottom: 0;
     }


### PR DESCRIPTION
## Description
Icon groups were not supported in headers

## Testcase
### Before
https://jsfiddle.net/lubber/4kwhux5t/12/

### After
https://jsfiddle.net/lubber/4kwhux5t/21/

## Screenshot

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/102535891-22a7b900-40a9-11eb-83bd-7df579574dd0.png)|![image](https://user-images.githubusercontent.com/18379884/102538989-5a186480-40ad-11eb-86e8-d4a2352d2689.png)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/2553
