### PR TITLE
[Message] centered and right aligned variant

### DIFF
--- a/src/definitions/collections/message.less
+++ b/src/definitions/collections/message.less
@@ -169,6 +169,12 @@
 /*******************************
             Variations
 *******************************/
+& when (@variationMessageCentered) {
+  .ui.centered.message,
+  .ui.center.aligned.message {
+    text-align: center;
+  }
+}
 
 & when (@variationMessageCompact) {
   /*--------------

--- a/src/definitions/collections/message.less
+++ b/src/definitions/collections/message.less
@@ -183,6 +183,11 @@
     }
   }
 }
+& when (@variationMessageRightAligned) {
+  .ui.right.aligned.message {
+    text-align: right;
+  }
+}
 
 & when (@variationMessageCompact) {
   /*--------------

--- a/src/definitions/collections/message.less
+++ b/src/definitions/collections/message.less
@@ -174,6 +174,7 @@
   .ui.center.aligned.message {
     text-align: center;
     justify-content: center;
+    & > .icons + .content,
     & > i.icon + .content {
       flex: 0 0 auto;
     }

--- a/src/definitions/collections/message.less
+++ b/src/definitions/collections/message.less
@@ -173,6 +173,10 @@
   .ui.centered.message,
   .ui.center.aligned.message {
     text-align: center;
+    justify-content: center;
+    & > i.icon + .content {
+      flex: 0 0 auto;
+    }
   }
 }
 

--- a/src/definitions/collections/message.less
+++ b/src/definitions/collections/message.less
@@ -107,9 +107,12 @@
 
 
 /* Icon */
-.ui.message > .icons,
-.ui.message > i.icon {
+.ui.icon.message > .icons,
+.ui.icon.message > i.icon {
   margin-right: @iconDistance;
+  &:last-child {
+    margin: 0 0 0 @iconDistance;
+  }
 }
 
 /* Close Icon */
@@ -175,8 +178,7 @@
   .ui.center.aligned.message {
     text-align: center;
     justify-content: center;
-    & > .icons + .content,
-    & > i.icon + .content {
+    & > .content {
       flex: 0 0 auto;
     }
   }

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -274,6 +274,7 @@
 @variationMessageIcon: true;
 @variationMessageFloating: true;
 @variationMessageConsequences: true;
+@variationMessageCentered: true;
 @variationMessageSizes: @variationAllSizes;
 
 /* Table */

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -275,6 +275,7 @@
 @variationMessageFloating: true;
 @variationMessageConsequences: true;
 @variationMessageCentered: true;
+@variationMessageRightAligned: true;
 @variationMessageSizes: @variationAllSizes;
 
 /* Table */


### PR DESCRIPTION
## Description
This PR adds a `centered` or `center aligned` as well as a `right aligned` variant to the `message` component just like many other components already support.

## Testcase
https://jsfiddle.net/lubber/03qx4gr5/39/

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/102623968-9dbdad80-4143-11eb-91a0-a0f40b146d78.png)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5049