### PR TITLE
[Dropdown / Form] Item text with descriptions gets wrong state class

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -622,7 +622,7 @@
     .ui.form .fields.@{state} .field .ui.dropdown,
     .ui.form .fields.@{state} .field .ui.dropdown .item,
     .ui.form .field.@{state} .ui.dropdown,
-    .ui.form .field.@{state} .ui.dropdown .text,
+    .ui.form .field.@{state} .ui.dropdown > .text,
     .ui.form .field.@{state} .ui.dropdown .item {
       background: @bg;
       color: @c;


### PR DESCRIPTION
## Description
When a dropdown item has got a description, every added state class like `error` also styles such extra items by accident

Original fix by @awgv 

## Testcase
http://jsfiddle.net/lubber/w8ugyc6d/2/

## Screenshot
![dropdownerrortext](https://user-images.githubusercontent.com/18379884/102613098-321f1480-4132-11eb-93e4-67b25e383030.gif)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5207
https://github.com/Semantic-Org/Semantic-UI-React/issues/1462

