### PR TITLE
[Checkbox, Dropdown] Support and fix read only variant

### DIFF
--- a/src/definitions/modules/checkbox.less
+++ b/src/definitions/modules/checkbox.less
@@ -349,14 +349,16 @@
   color: @checkboxActiveFocusCheckColor;
 }
 
+& when (@variationCheckboxReadonly) {
+  /*--------------
+      Read-Only
+  ---------------*/
 
-/*--------------
-    Read-Only
----------------*/
-
-.ui.read-only.checkbox,
-.ui.read-only.checkbox label {
-  cursor: default;
+  .ui.read-only.checkbox,
+  .ui.read-only.checkbox label {
+    cursor: default;
+    pointer-events: none;
+  }
 }
 
 & when (@variationCheckboxDisabled) {
@@ -366,7 +368,7 @@
 
   .ui.disabled.checkbox label,
   .ui.checkbox input[disabled] ~ label {
-    cursor: default !important;
+    cursor: default;
     opacity: @disabledCheckboxOpacity;
     color: @disabledCheckboxLabelColor;
     pointer-events: none;

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -1135,6 +1135,16 @@ select.ui.dropdown {
   }
 }
 
+& when (@variationDropdownReadonly) {
+  /*--------------------
+          Read-Only
+  ----------------------*/
+
+  .ui.read-only.dropdown {
+    cursor: default;
+    pointer-events: none;
+  }
+}
 
 /*******************************
            Variations

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -376,6 +376,7 @@
 /* Checkbox */
 @variationCheckboxBox: false;   //.box (instead of label) is an ancient fragment of sui v1 and not even documented in v2.x anymore
 @variationCheckboxDisabled: true;
+@variationCheckboxReadonly: true;
 @variationCheckboxInverted: true;
 @variationCheckboxRadio: true;
 @variationCheckboxSlider: true;
@@ -399,6 +400,7 @@
 /* Dropdown */
 @variationDropdownInverted: true;
 @variationDropdownDisabled: true;
+@variationDropdownReadonly: true;
 @variationDropdownLabel: true;
 @variationDropdownButton: true;
 @variationDropdownSelection: true;


### PR DESCRIPTION
## Description
The `read-only checkbox` still changed their cursor on hover confusing the user one could still change it.
While doing it i added support for `read-only` to the dropdown component as well

- Removed cursor changes for `read-only checkbox`
- Added "read-only" variant to `dropdown` similar to the existing variant for `checkbox`

## Testcase
https://jsfiddle.net/lubber/s25L87ud/5/

## Screenshot
|Before|After|
|-|-|
|![readonlywrong](https://user-images.githubusercontent.com/18379884/102715872-70563880-42d8-11eb-896e-9a0d646c5b40.gif)|![readonlyfix](https://user-images.githubusercontent.com/18379884/102715879-751aec80-42d8-11eb-9790-cda81aa6f15b.gif)|

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5482

