### PR TITLE
[Dropdown] Clearable inline support

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -359,7 +359,7 @@ $.fn.dropdown = function(parameters) {
             if( !module.has.menu() ) {
               module.create.menu();
             }
-            if ( module.is.selection() && module.is.clearable() && !module.has.clearItem() ) {
+            if ( module.is.clearable() && !module.has.clearItem() ) {
               module.verbose('Adding clear icon');
               $clear = $('<i />')
                 .addClass('remove icon')

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -808,7 +808,7 @@ select.ui.dropdown {
     margin-left: @clearableIconMargin;
   }
   .ui.dropdown:not(.selection) > .remove.icon {
-    margin-top: -@clearableIconMargin;
+    margin-top: -@clearableIconMarginTop;
   }
 }
 

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -87,6 +87,7 @@
 .ui.dropdown:not(.labeled) > .dropdown.icon {
   position: relative;
   width: auto;
+  min-width: @dropdownIconMinWidth;
   font-size: @dropdownIconSize;
   margin: @dropdownIconMargin;
 }
@@ -771,29 +772,44 @@ select.ui.dropdown {
   }
 }
 
-/* Clearable Selection */
-.ui.dropdown > .remove.icon {
-  cursor: pointer;
-  font-size: @dropdownIconSize;
-  margin: @selectionIconMargin;
-  padding: @selectionIconPadding;
-  right: 3em;
-  top: @selectionVerticalPadding;
-  position: absolute;
-  opacity: 0.6;
-  z-index: @selectionIconZIndex;
-}
+& when (@variationDropdownClear) {
+  /* Clearable Selection */
+  .ui.dropdown > .remove.icon {
+    cursor: pointer;
+    font-size: @dropdownIconSize;
+    margin: @selectionIconMargin;
+    padding: @selectionIconPadding;
+    right: @clearableIconPosition;
+    top: @selectionVerticalPadding;
+    position: absolute;
+    opacity: @clearableIconOpacity;
+    z-index: @selectionIconZIndex;
+  }
+  .ui.selection.dropdown > .remove.icon {
+    right: @clearableIconSelectionPosition;
+  }
+  .ui.inline.dropdown > .remove.icon {
+    right: @clearableIconInlinePosition;
+  }
 
-.ui.clearable.dropdown .text,
-.ui.clearable.dropdown a:last-of-type {
-  margin-right: 1.5em;
-}
+  .ui.clearable.dropdown .text,
+  .ui.clearable.dropdown a:last-of-type {
+    margin-right: @clearableTextMargin;
+  }
 
-.ui.dropdown select.noselection ~ .remove.icon,
-.ui.dropdown input[value=''] ~ .remove.icon,
-.ui.dropdown input:not([value]) ~ .remove.icon,
-.ui.dropdown.loading > .remove.icon {
-  display: none;
+  .ui.dropdown select.noselection ~ .remove.icon,
+  .ui.dropdown input[value=''] ~ .remove.icon,
+  .ui.dropdown input:not([value]) ~ .remove.icon,
+  .ui.dropdown.loading > .remove.icon {
+    display: none;
+  }
+
+  .ui.dropdown:not(.selection) > .remove.icon ~ .dropdown.icon {
+    margin-left: @clearableIconMargin;
+  }
+  .ui.dropdown:not(.selection) > .remove.icon {
+    margin-top: -@clearableIconMargin;
+  }
 }
 
 & when (@variationDropdownMultiple) {
@@ -1111,11 +1127,12 @@ select.ui.dropdown {
 /*--------------------
         Clear
 ----------------------*/
-
+  .ui.dropdown > .remove.icon,
   .ui.dropdown > .clear.dropdown.icon {
     opacity: @clearableIconOpacity;
     transition: opacity @defaultDuration @defaultEasing;
   }
+  .ui.dropdown > .remove.icon:hover,
   .ui.dropdown > .clear.dropdown.icon:hover {
     opacity: @clearableIconActiveOpacity;
   }

--- a/src/themes/default/modules/dropdown.variables
+++ b/src/themes/default/modules/dropdown.variables
@@ -315,6 +315,7 @@
 @clearableIconActiveOpacity: 1;
 @clearableTextMargin: 1.5em;
 @clearableIconMargin: 1.5em;
+@clearableIconMarginTop: 1.35em;
 @clearableIconPosition: 2em;
 @clearableIconSelectionPosition: 3em;
 @clearableIconInlinePosition: 2.2em;

--- a/src/themes/default/modules/dropdown.variables
+++ b/src/themes/default/modules/dropdown.variables
@@ -21,6 +21,7 @@
 /* Icon */
 @dropdownIconSize: @relative12px;
 @dropdownIconMargin: 0 0 0 1em;
+@dropdownIconMinWidth: 1em;
 
 /* Current Text */
 @textTransition: none;
@@ -310,8 +311,13 @@
 @selectedColor: @selectedTextColor;
 
 /* Clearable */
-@clearableIconOpacity: 0.8;
+@clearableIconOpacity: 0.6;
 @clearableIconActiveOpacity: 1;
+@clearableTextMargin: 1.5em;
+@clearableIconMargin: 1.5em;
+@clearableIconPosition: 2em;
+@clearableIconSelectionPosition: 3em;
+@clearableIconInlinePosition: 2.2em;
 
 /*-------------------
       Variations


### PR DESCRIPTION
## Description
Inline (or no selection) dropdowns did not support `clearable` (while SUI does and even the FUI docs mention it)

## Testcase
Remove CSS to see the issues
https://jsfiddle.net/lubber/hemuypkc/8/

## Screenshot
|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/102779186-174bda80-4394-11eb-8092-abc0254f1a23.png)|![image](https://user-images.githubusercontent.com/18379884/102820709-fd32ec00-43d5-11eb-9de1-b0561001598a.png)|


## Closes
#924 
https://github.com/Semantic-Org/Semantic-UI/issues/5800 (loading / min-width fix)