### PR TITLE
[Form] Simplify Blur validation and respect revalidate:false

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -444,15 +444,11 @@ $.fn.form = function(parameters) {
                 $fieldGroup     = $field.closest($group),
                 validationRules = module.get.validation($field)
               ;
-              if( $fieldGroup.hasClass(className.error) ) {
+              if(validationRules && (settings.on == 'blur' || ( $fieldGroup.hasClass(className.error) && settings.revalidate) )) {
                 module.debug('Revalidating field', $field, validationRules);
-                if(validationRules) {
-                  module.validate.field( validationRules );
-                }
-              }
-              else if(settings.on == 'blur') {
-                if(validationRules) {
-                  module.validate.field( validationRules );
+                module.validate.field( validationRules );
+                if(!settings.inline) {
+                  module.validate.form(false,true);
                 }
               }
             },
@@ -465,7 +461,7 @@ $.fn.form = function(parameters) {
               if(validationRules && (settings.on == 'change' || ( $fieldGroup.hasClass(className.error) && settings.revalidate) )) {
                 clearTimeout(module.timer);
                 module.timer = setTimeout(function() {
-                  module.debug('Revalidating field', $field,  module.get.validation($field));
+                  module.debug('Revalidating field', $field, validationRules);
                   module.validate.field( validationRules );
                   if(!settings.inline) {
                     module.validate.form(false,true);


### PR DESCRIPTION
## Description
The validation triggered by change and blur are similar. However, the code was unneccesary different.
Additionally the blur validation did not respect a possible given `revalidate:false` resulting in revalidating error fields all the time when the field blurs (even if one only wants revalidation on submit)

It also fixes not showing/updating the error messages on blur as change does

## Testcase
- Click on "submit" to invalidate the fields
- Enter something in the first input field. It does not immediatly revalidate while typing, because `revalidate:false` prevents that (which is correct)
- Now blur the field by pressing tab or click somewhere outside the field

### Broken
The field gets revalidated
http://jsfiddle.net/lubber/g8n9c6kb/4/

### Fixed
The field does not get validated as expected
http://jsfiddle.net/lubber/g8n9c6kb/5/

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/4889
https://github.com/Semantic-Org/Semantic-UI/issues/3574
https://github.com/Semantic-Org/Semantic-UI/issues/4475
