### PR TITLE
[Form] Refresh on instance rather than module to fetch dom changes

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -631,7 +631,7 @@ $.fn.form = function(parameters) {
             instance = $module.data(moduleNamespace);
 
             // refresh selector cache
-            module.refresh();
+            (instance || module).refresh();
           },
           field: function(identifier) {
             module.verbose('Finding field with identifier', identifier);


### PR DESCRIPTION
## Description
When a form gets initialized it is refreshing the field selectors.
This is fine as long as there is only one call to the same form. Whenever a later bahavior call like `get values` takes place on the same form and the form fields have changed, the previous stored instance is not getting refresh (because only the "new" module is)

The[ original issue in the SUI repo](https://github.com/Semantic-Org/Semantic-UI/issues/5703) had a very good detailed explanation and jsfiddle example (thanks @cueedee) and the solution which i adopted in a similar way.

## Testcase
- A form gets initialized 
- another field input is added to the DOM
- the existing form is called again with the behavior "get values"
- It is expected that also the new field is affected
- Focus on the textarea at `4` to see the difference
### Before
- It isn't, only the first prior to initialization time existing field is recognized
https://jsfiddle.net/lubber/s9p4moyx/2/

### After
- It is!, also the newly added input field is recognized 🙂 
https://jsfiddle.net/lubber/s9p4moyx/3/

## Screenshot
|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/102902183-eb515780-446e-11eb-9203-646f7e88df51.png)|![image](https://user-images.githubusercontent.com/18379884/102902152-dc6aa500-446e-11eb-8319-c1bf316235dc.png)|

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5703

