### PR TITLE
fix(build): use current year and implement version in header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fomantic-ui",
-  "version": "2.8.7",
+  "version": "2.8.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fomantic-ui",
-  "version": "2.8.7",
+  "version": "2.8.8",
   "description": "Fomantic empowers designers and developers by creating a shared vocabulary for UI.",
   "keywords": [
     "fomantic-ui",

--- a/tasks/config/project/release.js
+++ b/tasks/config/project/release.js
@@ -49,12 +49,12 @@ module.exports = {
   url        : 'http://fomantic-ui.com/',
 
   banner: ''
-    + ' /*' + '\n'
+    + '/*' + '\n'
     + ' * # <%= title %> - <%= version %>' + '\n'
     + ' * <%= repository %>' + '\n'
     + ' * <%= url %>' + '\n'
     + ' *' + '\n'
-    + ' * Copyright 2014 Contributors' + '\n'
+    + ' * Copyright <%= year %> Contributors' + '\n'
     + ' * Released under the MIT license' + '\n'
     + ' * http://opensource.org/licenses/MIT' + '\n'
     + ' *' + '\n'

--- a/tasks/config/tasks.js
+++ b/tasks/config/tasks.js
@@ -51,7 +51,7 @@ module.exports = {
 
       // add version to first comment
       license: {
-        in  : /(^\/\*[\s\S]+)(# Semantic UI )([\s\S]+?\*\/)/,
+        in  : /(^\/\*[\s\S]+)(# Fomantic-UI )([\s\S]+?\*\/)/,
         out : '$1$2' + release.version + ' $3'
       },
 
@@ -87,6 +87,7 @@ module.exports = {
 
     /* Comment Banners */
     header: {
+      year       : (new Date()).getFullYear(),
       title      : release.title,
       version    : release.version,
       repository : release.repository,


### PR DESCRIPTION
## Description
This PR adjust some build settings. It...
- prepares for the next 2.8.8 release by updating the version number in `package.json`. For 2.8.7 this was done after the NPM upload, so the 2.8.7 release had the 2.8.6 header.
- fixes inclusion of the version number in the comment headers of each file (was omitted since a few versions)
- fixes to adjust the year in the comment header to the year of release (was a hardcoded 2014 before)

## Screenshot
### Before

#### {component}.css/js (missing version number in compiled css/js)
```
/*!
 * # Fomantic-UI - Accordion
 * http://github.com/fomantic/Fomantic-UI/
 *
 *
 * Released under the MIT license
 * http://opensource.org/licenses/MIT
 *
 */
```
#### semantic(.min).js/css (hardcoded 2014 in copyright)
```
 /*
 * # Fomantic UI - 2.8.6
 * https://github.com/fomantic/Fomantic-UI
 * http://fomantic-ui.com/
 *
 * Copyright 2014 Contributors
 * Released under the MIT license
 * http://opensource.org/licenses/MIT
 *
 */
```

### After
{component}.css/js (version included)
```
/*!
 * # Fomantic-UI 2.8.8 - Accordion
 * http://github.com/fomantic/Fomantic-UI/
 *
 *
 * Released under the MIT license
 * http://opensource.org/licenses/MIT
 *
 */
```
semantic(.min).js/css (year according to time of build)
```
/*
 * # Fomantic UI - 2.8.8
 * https://github.com/fomantic/Fomantic-UI
 * http://fomantic-ui.com/
 *
 * Copyright 2020 Contributors
 * Released under the MIT license
 * http://opensource.org/licenses/MIT
 *
 */
```
