### PR TITLE
fix(build): upgrade css minify and remove specialcomments in concat build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1143,9 +1143,9 @@
       }
     },
     "clean-css": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
-      "integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
+      "integrity": "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==",
       "requires": {
         "source-map": "~0.6.0"
       },
@@ -2773,23 +2773,22 @@
       }
     },
     "gulp-clean-css": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/gulp-clean-css/-/gulp-clean-css-3.10.0.tgz",
-      "integrity": "sha512-7Isf9Y690o/Q5MVjEylH1H7L8WeZ89woW7DnhD5unTintOdZb67KdOayRgp9trUFo+f9UyJtuatV42e/+kghPg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/gulp-clean-css/-/gulp-clean-css-4.3.0.tgz",
+      "integrity": "sha512-mGyeT3qqFXTy61j0zOIciS4MkYziF2U594t2Vs9rUnpkEHqfu6aDITMp8xOvZcvdX61Uz3y1mVERRYmjzQF5fg==",
       "requires": {
-        "clean-css": "4.2.1",
+        "clean-css": "4.2.3",
         "plugin-error": "1.0.1",
-        "through2": "2.0.3",
+        "through2": "3.0.1",
         "vinyl-sourcemaps-apply": "0.2.1"
       },
       "dependencies": {
         "through2": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
           "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
+            "readable-stream": "2 || 3"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "gulp": "^4.0.0",
     "gulp-autoprefixer": "^6.0.0",
     "gulp-chmod": "^2.0.0",
-    "gulp-clean-css": "^3.10.0",
+    "gulp-clean-css": "^4.3.0",
     "gulp-clone": "^2.0.1",
     "gulp-concat": "^2.6.1",
     "gulp-concat-css": "^3.1.0",

--- a/tasks/config/tasks.js
+++ b/tasks/config/tasks.js
@@ -143,10 +143,11 @@ module.exports = {
 
     /* Minified CSS Concat */
     minify: {
-      processImport       : false,
-      restructuring       : false,
-      keepSpecialComments : 1,
-      roundingPrecision   : -1,
+      level: {
+        1: {
+          inline          : false
+        }
+      }
     },
 
     /* Minified JS Settings */
@@ -159,10 +160,12 @@ module.exports = {
 
     /* Minified Concat CSS Settings */
     concatMinify: {
-      processImport       : false,
-      restructuring       : false,
-      keepSpecialComments : false,
-      roundingPrecision   : -1,
+      level: {
+        1: {
+          inline          : false,
+          specialComments : false
+        }
+      }
     },
 
     /* Minified Concat JS */


### PR DESCRIPTION
## Description
This PR upgrades gulp-clean-css (respectively clean-css) to the latest version.
Now the removement of special header comments in the concatenated minified css file `semantic.min.css` is properly done and works
Before, the minified concatenated css file still contained every special `/*! ... */` header from each single .css file which increased the minified css file significantly.

> #### Note for reviewers in case you wonder, why i removed nearly all previous options for the minify plugin
> Just because those previous values are default now in clean-css 4.2 (gulp-clean-css 4.3 depends in clean-css 4.2 ... don't get confused)🙂 

## Testcase
`npm install && npx gulp build`
The created `dist/semantic.min.css` does only contain one single comment header, but not every header from each concatenated single css file anymore

## Screenshot
|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/103016145-e90bfd80-4541-11eb-9402-b58a3749d6ff.png)|![image](https://user-images.githubusercontent.com/18379884/103016184-f923dd00-4541-11eb-8d13-ddbcdfa0beeb.png)|

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6930