### PR TITLE
[Form] Support shouldtrim option per fieldrule

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1327,7 +1327,7 @@ $.fn.form = function(parameters) {
                 // cast to string avoiding encoding special values
                 value = (value === undefined || value === '' || value === null)
                     ? ''
-                    : (settings.shouldTrim) ? String(value + '').trim() : String(value + '')
+                    : (settings.shouldTrim && rule.shouldTrim !== false) || rule.shouldTrim ? String(value + '').trim() : String(value + '')
                 ;
                 return ruleFunction.call(field, value, ancillary, $module);
               }


### PR DESCRIPTION
## Description
This PR adds support to use the form wide `shouldTrim` setting individually per field rule 

## Testcase
Enter "    dog" (leading spaces) into the field. Although the global `shouldTrim` setting is set to false, the field still validates, because `shouldTrim:true` is set to the fieldrule itself
https://jsfiddle.net/lubber/6349nfh0/1/

## Closes
#1278 