### PR TITLE
[Modal] bodyfixed selector did not work with existing padding values

### DIFF
--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -680,7 +680,12 @@ $.fn.modal = function(parameters) {
           bodyMargin: function() {
             var position = module.can.leftBodyScrollbar() ? 'left':'right';
             $body.css('margin-'+position, initialBodyMargin);
-            $body.find(selector.bodyFixed.replace('right',position)).css('padding-'+position, initialBodyMargin);
+            $body.find(selector.bodyFixed.replace('right',position)).each(function(){
+              var el = $(this),
+                  attribute = el.css('position') === 'fixed' ? 'padding-'+position : position
+              ;
+              el.css(attribute, '');
+            });
           }
         },
 
@@ -898,7 +903,12 @@ $.fn.modal = function(parameters) {
             if(settings.detachable || module.can.fit()) {
               $body.css('margin-'+position, tempBodyMargin + 'px');
             }
-            $body.find(selector.bodyFixed.replace('right',position)).css('padding-'+position, tempBodyMargin + 'px');
+            $body.find(selector.bodyFixed.replace('right',position)).each(function(){
+              var el = $(this),
+                  attribute = el.css('position') === 'fixed' ? 'padding-'+position : position
+              ;
+              el.css(attribute, 'calc(' + el.css(attribute) + ' + ' + tempBodyMargin + 'px)');
+            });
           },
           clickaway: function() {
             if (!settings.detachable) {
@@ -1294,7 +1304,7 @@ $.fn.modal.settings = {
     deny     : '.actions .negative, .actions .deny, .actions .cancel',
     modal    : '.ui.modal',
     dimmer   : '> .ui.dimmer',
-    bodyFixed: '> .ui.fixed.menu, > .ui.right.toast-container, > .ui.right.sidebar'
+    bodyFixed: '> .ui.fixed.menu, > .ui.right.toast-container, > .ui.right.sidebar, > .ui.fixed.nag, > .ui.fixed.nag > .close'
   },
   error : {
     dimmer    : 'UI Dimmer, a required component is not included in this page',


### PR DESCRIPTION
## Description
When a modal opens and the screen ist large, so there exists a scrollbar, selected fixed elements on the screen are adjusted so they dont move while the screen is shown/closed.

- The `fixed nag` element was missing to be supported
- existing values for `padding` were not taken into account. For all previous selectors (toast-container, menu, sidebar) this was not a problem, because they haven't had a padding by default. But the new `nag` selector actually has a padding of 1em.
- In case a non fixed selector was used, the `padding` was the wrong approach (for example the `close` icon inside the `nag`)
- When the modal hides, the previously set values for padding were overridden by 0. Whenever there was a default padding before, this would not work anymore. I now completely removed the inline style instead.

## Testcase
Watch the right side of the bottom nag next to the scrollbar
The whole nag including the close icon moves to the right when the modal opens

### Broken
https://jsfiddle.net/lubber/43ndykwq/26/

### Fixed
https://jsfiddle.net/lubber/43ndykwq/28/

## Screenshot
|Broken|Fixed|
|-|-|
|![nagmodalbroken](https://user-images.githubusercontent.com/18379884/103150465-c31a6f00-4774-11eb-8578-29aed1ce6dec.gif)|![nagmodalfixed](https://user-images.githubusercontent.com/18379884/103150468-c877b980-4774-11eb-9fa3-f4993e9af07e.gif)|



