### PR TITLE
fix(progress): adjust center position

### DIFF
--- a/src/definitions/modules/progress.less
+++ b/src/definitions/modules/progress.less
@@ -501,6 +501,7 @@ each(@colors, {
   .ui.progress .bar .centered.progress {
     text-align: center;
     position: relative;
+    right: 0;
   }
   .ui.indeterminate.progress .bar::before {
     content: '';


### PR DESCRIPTION
## Description

`centered progress` was missing a slight adjustment to really display the text centered

## Testcase
Remove CSS to see the issue
https://jsfiddle.net/lubber/w5bkzr3h/2/

## Screenshot
|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/103408003-0b64d300-4b61-11eb-8c85-2d745e0c2541.png)![image](https://user-images.githubusercontent.com/18379884/103408013-13247780-4b61-11eb-8637-afa616c92c93.png)|![image](https://user-images.githubusercontent.com/18379884/103407976-eff9c800-4b60-11eb-9a66-498ab82bc00f.png)![image](https://user-images.githubusercontent.com/18379884/103407990-fb4cf380-4b60-11eb-8087-19b82f1dbf1f.png)|

