### PR TITLE
fix(form): inverted state forms colors

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -686,6 +686,13 @@
     .ui.form .field.@{state} .checkbox .box:after {
       color: @c;
     }
+
+    & when (@variationFormInverted) {
+      .ui.inverted.form .fields.@{state} .field label,
+      .ui.inverted.form .@{state}.field label {
+        color: @lbg;
+      }
+    }
   })
 }
 

--- a/src/definitions/collections/message.less
+++ b/src/definitions/collections/message.less
@@ -296,6 +296,7 @@
       boxShadow      : @positiveBoxShadow;
       boxFloatShadow : @positiveBoxFloatingShadow;
       text           : @positiveTextColor;
+      invertedText   : @positiveBorderColor;
     };
     @negative: {
       background     : @negativeBackgroundColor;
@@ -303,6 +304,7 @@
       boxShadow      : @negativeBoxShadow;
       boxFloatShadow : @negativeBoxFloatingShadow;
       text           : @negativeTextColor;
+      invertedText   : @negativeBorderColor;
     };
     @info: {
       background     : @infoBackgroundColor;
@@ -310,6 +312,7 @@
       boxShadow      : @infoBoxShadow;
       boxFloatShadow : @infoBoxFloatingShadow;
       text           : @infoTextColor;
+      invertedText   : @formInfoLabelBackground;
     };
     @warning: {
       background     : @warningBackgroundColor;
@@ -317,6 +320,7 @@
       boxShadow      : @warningBoxShadow;
       boxFloatShadow : @warningBoxFloatingShadow;
       text           : @warningTextColor;
+      invertedText   : @formWarningLabelBackground;
     };
     @error: {
       background     : @errorBackgroundColor;
@@ -324,6 +328,7 @@
       boxShadow      : @errorBoxShadow;
       boxFloatShadow : @errorBoxFloatingShadow;
       text           : @errorTextColor;
+      invertedText   : @formErrorLabelBackground;
     };
     @success: {
       background     : @successBackgroundColor;
@@ -331,6 +336,7 @@
       boxShadow      : @successBoxShadow;
       boxFloatShadow : @successBoxFloatingShadow;
       text           : @successTextColor;
+      invertedText   : @formSuccessLabelBackground;
     };
   }
 
@@ -343,6 +349,7 @@
     @bs: @consequences[@@color][boxShadow];
     @bfs: @consequences[@@color][boxFloatShadow];
     @t: @consequences[@@color][text];
+    @it: @consequences[@@color][invertedText];
 
     .ui.@{color}.message {
       background-color: @bg;
@@ -360,6 +367,12 @@
     }
     .ui.@{color}.message .header {
       color: @hd;
+    }
+    & when (@variationMessageInverted) {
+      .ui.inverted.@{color}.message,
+      .ui.inverted.@{color}.message .header {
+        color: @it;
+      }
     }
   })
 }

--- a/src/themes/default/globals/colors.less
+++ b/src/themes/default/globals/colors.less
@@ -497,7 +497,7 @@
     borderRadius: @inputErrorBorderRadius;
     boxShadow: @inputErrorBoxShadow;
     cornerLabelColor: @white;
-    labelBackground: darken(@formErrorBorder, -8);
+    labelBackground: @formErrorLabelBackground;
 
     dropdownLabelColor: @dropdownErrorLabelColor;
     dropdownLabelBackground: @dropdownErrorLabelBackground;
@@ -525,7 +525,7 @@
     borderRadius: @inputInfoBorderRadius;
     boxShadow: @inputInfoBoxShadow;
     cornerLabelColor: @white;
-    labelBackground: darken(@formInfoBorder, -8);
+    labelBackground: @formInfoLabelBackground;
 
     dropdownLabelColor: @dropdownInfoLabelColor;
     dropdownLabelBackground: @dropdownInfoLabelBackground;
@@ -553,7 +553,7 @@
     borderRadius: @inputSuccessBorderRadius;
     boxShadow: @inputSuccessBoxShadow;
     cornerLabelColor: @white;
-    labelBackground: darken(@formSuccessBorder, -8);
+    labelBackground: @formSuccessLabelBackground;
 
     dropdownLabelColor: @dropdownSuccessLabelColor;
     dropdownLabelBackground: @dropdownSuccessLabelBackground;
@@ -581,7 +581,7 @@
     borderRadius: @inputWarningBorderRadius;
     boxShadow: @inputWarningBoxShadow;
     cornerLabelColor: @white;
-    labelBackground: darken(@formWarningBorder, -8);
+    labelBackground: @formWarningLabelBackground;
 
     dropdownLabelColor: @dropdownWarningLabelColor;
     dropdownLabelBackground: @dropdownWarningLabelBackground;

--- a/src/themes/default/globals/site.variables
+++ b/src/themes/default/globals/site.variables
@@ -1346,24 +1346,28 @@
 @formErrorColor: @negativeTextColor;
 @formErrorBorder: @negativeBorderColor;
 @formErrorBackground: @negativeBackgroundColor;
+@formErrorLabelBackground: darken(@formErrorBorder, -8);
 @transparentFormErrorColor: @formErrorColor;
 @transparentFormErrorBackground: @formErrorBackground;
 
 @formInfoColor: @infoTextColor;
 @formInfoBorder: @infoBorderColor;
 @formInfoBackground: @infoBackgroundColor;
+@formInfoLabelBackground: darken(@formInfoBorder, -8);
 @transparentFormInfoColor: @formInfoColor;
 @transparentFormInfoBackground: @formInfoBackground;
 
 @formSuccessColor: @positiveTextColor;
 @formSuccessBorder: @positiveBorderColor;
 @formSuccessBackground: @positiveBackgroundColor;
+@formSuccessLabelBackground: darken(@formSuccessBorder, -8);
 @transparentFormSuccessColor: @formSuccessColor;
 @transparentFormSuccessBackground: @formSuccessBackground;
 
 @formWarningColor: @warningTextColor;
 @formWarningBorder: @warningBorderColor;
 @formWarningBackground: @warningBackgroundColor;
+@formWarningLabelBackground: darken(@formWarningBorder, -8);
 @transparentFormWarningColor: @formWarningColor;
 @transparentFormWarningBackground: @formWarningBackground;
 


### PR DESCRIPTION
## Description
The state colors in `inverted form` and `inverted message` were too dark for field label and message text
I adjusted them so they now match a error field input label to make it readable and consistent

## Testcase
https://jsfiddle.net/lubber/hczb1rg2/52/

## Screenshot

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/103707098-5726da80-4fae-11eb-8987-061ee0aa4fac.png)|![image](https://user-images.githubusercontent.com/18379884/103707054-41191a00-4fae-11eb-93ed-5591ed169ef0.png)|
