### PR TITLE
fix(form): refresh module on re-initializaion

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -91,6 +91,7 @@ $.fn.form = function(parameters) {
           else {
             if(instance !== undefined) {
               instance.invoke('destroy');
+              module.refresh();
             }
             module.verbose('Initializing form validation', $module, settings);
             module.bindEvents();


### PR DESCRIPTION
## Description
This PR fixes a regression from #1811 whereas the fields are not refreshed anymore when a form gets initialized a second/multiple times

## Testcase
Watch the last section of the testcase

### Broken
https://jsfiddle.net/lubber/s9p4moyx/10/

### Fixed
https://jsfiddle.net/lubber/s9p4moyx/11/

## Screenshot
|Broken|Fixed|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/103755390-0cd54600-500e-11eb-9c8a-16a720dc27e0.png)|![image](https://user-images.githubusercontent.com/18379884/103755417-19f23500-500e-11eb-8501-c5eadaf3c478.png)|

## Closes
https://github.com/fomantic/Fomantic-UI/pull/1811#issuecomment-755162533