### PR TITLE
fix(toast): attached toast margin and border

### DIFF
--- a/src/definitions/modules/toast.less
+++ b/src/definitions/modules/toast.less
@@ -38,6 +38,10 @@
       margin: 0;
       width: 100%;
       border-radius: 0;
+      & > .ui.toast,
+      > .ui.message {
+        margin-left: 0;
+      }
       & when (@variationToastFloating) {
         &.floating,
         &.hoverfloating:hover {

--- a/src/definitions/modules/toast.less
+++ b/src/definitions/modules/toast.less
@@ -28,7 +28,6 @@
   &.ui.attached when (@variationToastAttached) {
     width: 100%;
     left: 0;
-    margin-top: -@toastAttachedMargin;
     & .vertical.attached when (@variationToastVertical) {
       border-radius: 0;
     }
@@ -36,10 +35,15 @@
       border-radius: 0;
     }
     & .toast-box {
-      margin-top: -@toastAttachedMargin;
-      margin-bottom: 0;
+      margin: 0;
       width: 100%;
       border-radius: 0;
+      & when (@variationToastFloating) {
+        &.floating,
+        &.hoverfloating:hover {
+          border: none;
+        }
+      }
       & > .vertical > .content when (@variationToastVertical) {
         flex: 1;
       }

--- a/src/themes/default/modules/toast.variables
+++ b/src/themes/default/modules/toast.variables
@@ -18,7 +18,6 @@
 @toastTextColor: @invertedTextColor;
 @toastInvertedTextColor: @textColor;
 @toastNeutralTextColor: @textColor;
-@toastAttachedMargin: 1px;
 
 /* Mobile */
 @mobileToastBreakpoint: 420px;


### PR DESCRIPTION
## Description
an `attached` positioned toast container still showed an 1px background on the right of the toast

## Testcase
https://jsfiddle.net/lubber/9vkoqp8m/21/

## Screenshot
Look closely to the very right of the toast. You can see a 1px background green color
|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/104102335-00671c80-529e-11eb-927e-edf7cf0ce5f8.png)|![image](https://user-images.githubusercontent.com/18379884/104102179-efb6a680-529d-11eb-93f1-e88aa020d0bd.png)|
