### PR TITLE
feat(dropdown) adds onSearch callback for when searching in the dropdown

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -297,6 +297,12 @@ $.fn.dropdown = function(parameters) {
             : module.get.query()
           ;
           module.verbose('Searching for query', query);
+          if(settings.fireOnInit === false && module.is.initialLoad()) {
+            module.verbose('Skipping callback on initial load', settings.onSearch);
+          }
+          else {
+            settings.onSearch.call(element, query);
+          }
           if(module.has.minCharacters(query)) {
             module.filter(query);
           }
@@ -4038,6 +4044,7 @@ $.fn.dropdown.settings = {
   onChange      : function(value, text, $selected){},
   onAdd         : function(value, text, $selected){},
   onRemove      : function(value, text, $selected){},
+  onSearch      : function(searchTerm){},
 
   onLabelSelect : function($selectedLabels){},
   onLabelCreate : function(value, text) { return $(this); },

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -299,8 +299,7 @@ $.fn.dropdown = function(parameters) {
           module.verbose('Searching for query', query);
           if(settings.fireOnInit === false && module.is.initialLoad()) {
             module.verbose('Skipping callback on initial load', settings.onSearch);
-          }
-          if(module.has.minCharacters(query) && settings.onSearch.call(element, query) !== false) {
+          } else if(module.has.minCharacters(query) && settings.onSearch.call(element, query) !== false) {
             module.filter(query);
           }
           else {

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -300,10 +300,7 @@ $.fn.dropdown = function(parameters) {
           if(settings.fireOnInit === false && module.is.initialLoad()) {
             module.verbose('Skipping callback on initial load', settings.onSearch);
           }
-          else {
-            settings.onSearch.call(element, query);
-          }
-          if(module.has.minCharacters(query)) {
+          if(module.has.minCharacters(query) && settings.onSearch.call(element, query) !== false) {
             module.filter(query);
           }
           else {


### PR DESCRIPTION
## Description
This PR adds a new `onSearch` callback to allow access to the search term being entered so that external processes can be informed about the term being typed in. Such processes may include an API that requires authentication with a token, especially if the website in question already has an existing API

## Testcase
https://jsfiddle.net/oafqnm3v/

Relates to #1846