### PR TITLE
feat(dropdown) onActionable callback

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -2677,7 +2677,11 @@ $.fn.dropdown = function(parameters) {
                 : value,
               newValue
             ;
-            if(hasInput) {
+            if($selected && $selected.hasClass(className.actionable)){
+              settings.onActionable.call(element, value, text, $selected);
+              return;
+            }
+            else if(hasInput) {
               if(!settings.allowReselection && stringValue == currentValue) {
                 module.verbose('Skipping value update already same value', value, currentValue);
                 if(!module.is.initialLoad()) {
@@ -4038,6 +4042,7 @@ $.fn.dropdown.settings = {
   onChange      : function(value, text, $selected){},
   onAdd         : function(value, text, $selected){},
   onRemove      : function(value, text, $selected){},
+  onActionable  : function(value, text, $selected){},
 
   onLabelSelect : function($selectedLabels){},
   onLabelCreate : function(value, text) { return $(this); },
@@ -4097,7 +4102,8 @@ $.fn.dropdown.settings = {
     icon         : 'icon',     // optional icon name
     iconClass    : 'iconClass', // optional individual class for icon (for example to use flag instead)
     class        : 'class',    // optional individual class for item/header
-    divider      : 'divider'   // optional divider append for group headers
+    divider      : 'divider',  // optional divider append for group headers
+    actionable   : 'actionable' // optional actionable item
   },
 
   keys : {
@@ -4167,7 +4173,8 @@ $.fn.dropdown.settings = {
     header      : 'header',
     divider     : 'divider',
     groupIcon   : '',
-    unfilterable : 'unfilterable'
+    unfilterable : 'unfilterable',
+    actionable : 'actionable'
   }
 
 };
@@ -4242,11 +4249,14 @@ $.fn.dropdown.settings.templates = {
           maybeText = (option[fields.text])
             ? ' data-text="' + deQuote(option[fields.text],true) + '"'
             : '',
+          maybeActionable = (option[fields.actionable])
+            ? className.actionable+' '
+            : '',
           maybeDisabled = (option[fields.disabled])
             ? className.disabled+' '
             : ''
         ;
-        html += '<div class="'+ maybeDisabled + (option[fields.class] ? deQuote(option[fields.class]) : className.item)+'" data-value="' + deQuote(option[fields.value],true) + '"' + maybeText + '>';
+        html += '<div class="'+ maybeActionable + maybeDisabled + (option[fields.class] ? deQuote(option[fields.class]) : className.item)+'" data-value="' + deQuote(option[fields.value],true) + '"' + maybeText + '>';
         if (isMenu) {
           html += '<i class="'+ (itemType.indexOf('left') !== -1 ? 'left' : '') + ' dropdown icon"></i>';
         }


### PR DESCRIPTION
### Description
The intention of this PR is to add a new onActionable callback to allow the possibility of providing a way of having a way of performing actions when an actionable item has been selected

The remaining items are outstanding as am unsure:
- [ ] prevent what seems to be the method being called twice
- [ ] ensure that the original selection is not overwritten with the actionable item (nothing should happen upon selection, aside from firing the callback)
- [ ] ensure that when using the keyboard, that the callback is not triggered unless hitting the enter key and do not use as the value of the dropdown
- [ ] possibly need an `actionableCollapse` field to prevent collapse on selection of an actionable item

### Testcase
https://jsfiddle.net/n1yvb07w/

The gives an example of dynamically adding additional options to the dropdown, but could also fire the additional item to an API to add to a database (validation could also happen on the server to ensure it is unique) and then refresh the list of options.

An alternative option could be that the dropdown could contain something like a navigation tree showing options:
https://jsfiddle.net/n1yvb07w/1/

Although this second example may not be so great, since the menu collapses when selecting the actionable item, so it could be that an additional option `actionableCollapse` may be wanted, where if `false` the menu doesn't collapse on selection


Related to #1847 