### PR TITLE
[Security] Solved Regular Expression Denial of Service vulnerability caused by gulp-concat-css

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "gulp-replace": "^1.0.0",
     "gulp-rtlcss": "^1.3.0",
     "gulp-uglify": "^3.0.1",
+    "gulp-install": "^1.1.0",
     "inquirer": "^6.2.1",
     "map-stream": "^0.1.0",
     "mkdirp": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "gulp-clean-css": "^4.3.0",
     "gulp-clone": "^2.0.1",
     "gulp-concat": "^2.6.1",
-    "gulp-concat-css": "^3.1.0",
+    "gulp-concat-css-safe": "^3.1.0",
     "gulp-copy": "^4.0.0",
     "gulp-dedupe": "0.0.2",
     "gulp-flatten": "^0.4.0",

--- a/tasks/build/css.js
+++ b/tasks/build/css.js
@@ -11,7 +11,6 @@ const
   // gulp dependencies
   autoprefixer = require('gulp-autoprefixer'),
   chmod        = require('gulp-chmod'),
-  concatCSS    = require('gulp-concat-css-safe'),
   dedupe       = require('gulp-dedupe'),
   flatten      = require('gulp-flatten'),
   gulpif       = require('gulp-if'),
@@ -89,6 +88,9 @@ function build(src, type, compress, config, opts) {
  * @param {boolean} compress - should the output be compressed
  */
 function pack(type, compress) {
+
+  const concatCSS    = require('gulp-concat-css-safe');
+
   const output       = type === 'docs' ? docsConfig.paths.output : config.paths.output;
   const ignoredGlobs = type === 'rtl' ? globs.ignoredRTL + '.rtl.css' : globs.ignored + '.css';
 

--- a/tasks/build/css.js
+++ b/tasks/build/css.js
@@ -11,7 +11,7 @@ const
   // gulp dependencies
   autoprefixer = require('gulp-autoprefixer'),
   chmod        = require('gulp-chmod'),
-  concatCSS    = require('gulp-concat-css'),
+  concatCSS    = require('gulp-concat-css-safe'),
   dedupe       = require('gulp-dedupe'),
   flatten      = require('gulp-flatten'),
   gulpif       = require('gulp-if'),

--- a/tasks/install.js
+++ b/tasks/install.js
@@ -29,6 +29,7 @@ var
   del            = require('del'),
   jsonEditor     = require('gulp-json-editor'),
   plumber        = require('gulp-plumber'),
+  gulpInstall    = require("gulp-install")
   inquirer       = require('inquirer'),
   rename         = require('gulp-rename'),
   replace        = require('gulp-replace'),
@@ -321,6 +322,11 @@ module.exports = function (callback) {
       gulp.src(source.userGulpFile)
         .pipe(plumber())
         .pipe(gulp.dest(installFolder))
+      ;
+
+      // create re2 binaries.
+      gulp.src("../node_modules/re2")
+        .pipe(gulpInstall())
       ;
 
     }


### PR DESCRIPTION
## Description
The plugin [gulp-concat-css](https://www.npmjs.com/package/gulp-concat-css) was using the [rework-import](https://www.npmjs.com/package/rework-import) package, which was using the outdated version of url-regex, causing it to have a vulnerability "Regular Expression Denial of Service". I forked the gulp-concat-css and rework-import repositories and uploaded the "safe" version of them to npm. That should be a good fix as the repositories probably aren't going to update anytime soon.

## Closes
#1646
