### PR TITLE
feat(form): escaped caused maximum callstack exceeded

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -416,7 +416,7 @@ $.fn.form = function(parameters) {
               ;
               if( key == keyCode.escape) {
                 module.verbose('Escape key pressed blurring field');
-                $field
+                $field[0]
                   .blur()
                 ;
               }


### PR DESCRIPTION
## Description
Whenever the escape key was pressed inside an input of a form and the validation trigger was set to `blur` and using jquery >= 3.4.0 the "maximum callstack exceeded" error occurs.
This is because jquery removed/changed the internal `blur()` handling.

By using the native `.blur()` instead this error is fixed

## Testcase
- Click into the first inut field, so it gets focus
- Press the ESC Kay
- Watch console

### Broken
"Maximum callstack Exceeded"
https://jsfiddle.net/lubber/ou7ft2bs/2/

### Fixed
No error as expected
https://jsfiddle.net/lubber/ou7ft2bs/3/

## Screenshot
|Broken|Fixed|
|-|-|
|![formcallstack_bad](https://user-images.githubusercontent.com/18379884/107114821-1f3edb80-6869-11eb-81ee-abd17ad4d281.gif)|![formcallstack_good](https://user-images.githubusercontent.com/18379884/107114826-249c2600-6869-11eb-9ce4-150a7f4fbba0.gif)|

## Closes
#1862 