### PR TITLE
feat(dropdown): columns were ignored inside menus

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -218,7 +218,9 @@
   background: @dropdownBackground;
   margin: @dropdownMenuDistance 0 0;
   box-shadow: @dropdownMenuBoxShadow;
-  flex-direction: column !important;
+}
+.ui.menu .dropdown.item:not(.column) .menu {
+  flex-direction: column;
 }
 
 


### PR DESCRIPTION
## Description
`column dropdown` was not working when used inside menus

## Testcase
The right "Leaderboard" Menu entry is supposed to be a `two column` dropdown
### Broken
- It's ignored and still displayed as one column
- https://jsfiddle.net/lubber/or6nd413/10/
### Fixed
- Two columns as expected
https://jsfiddle.net/lubber/or6nd413/9/
 
## Screenshot
|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/107130630-be96b980-68cf-11eb-9043-b4ca905ede95.png)|![image](https://user-images.githubusercontent.com/18379884/107130637-cf472f80-68cf-11eb-8c0a-0fabae9edce6.png)|


