### PR TITLE
feat(dimmer): support individual show/hide transition

### DIFF
--- a/src/definitions/modules/dimmer.js
+++ b/src/definitions/modules/dimmer.js
@@ -255,7 +255,7 @@ $.fn.dimmer = function(parameters) {
                   displayType : settings.useFlex
                     ? 'flex'
                     : 'block',
-                  animation   : settings.transition + ' in',
+                  animation   : (settings.transition.showMethod || settings.transition) + ' in',
                   queue       : false,
                   duration    : module.get.duration(),
                   useFailSafe : true,
@@ -302,7 +302,7 @@ $.fn.dimmer = function(parameters) {
                   displayType : settings.useFlex
                     ? 'flex'
                     : 'block',
-                  animation   : settings.transition + ' out',
+                  animation   : (settings.transition.hideMethod || settings.transition) + ' out',
                   queue       : false,
                   duration    : module.get.duration(),
                   useFailSafe : true,


### PR DESCRIPTION
## Description

This PR offers the same possibility to provide individual transform methods for show and hide animations as we have for `toast`

So in addition to `transition:'fade'` (which still works so stays backward compatible), you can now use the same as in toast:

```javascript
transition: {
  showMethod: 'fade',
  hideMethod: 'zoom'
}
```

