### PR TITLE
[Modal] JS Config Templates, alert, confirm, prompt

### DIFF
--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -146,6 +146,9 @@ $.fn.modal = function(parameters) {
             module.observeChanges();
           }
           module.instantiate();
+          if(settings.autoShow){
+            module.show();
+          }
         },
 
         instantiate: function() {
@@ -158,19 +161,19 @@ $.fn.modal = function(parameters) {
 
         create: {
           modal: function() {
-            $module = $('<div/>', {class: 'ui modal'});
+            $module = $('<div/>', {class: className.modal});
             if (settings.closeIcon) {
               $close = $('<i/>', {class: className.close})
               $module.append($close);
             }
             if (settings.title !== '') {
-              $('<div/>', {class: 'header'}).appendTo($module);
+              $('<div/>', {class: className.title}).appendTo($module);
             }
             if (settings.content !== '') {
-              $('<div/>', {class: 'content'}).appendTo($module);
+              $('<div/>', {class: className.content}).appendTo($module);
             }
             if (module.has.configActions()) {
-              $('<div/>', {class: 'actions'}).appendTo($module);
+              $('<div/>', {class: className.actions}).appendTo($module);
             }
             $context.append($module);
           },
@@ -300,6 +303,12 @@ $.fn.modal = function(parameters) {
         get: {
           id: function() {
             return (Math.random().toString(16) + '000000000').substr(2, 8);
+          },
+          element: function() {
+            return $module;
+          },
+          settings: function() {
+            return settings;
           }
         },
 
@@ -1195,9 +1204,16 @@ $.fn.modal = function(parameters) {
 
       if(methodInvoked) {
         if(instance === undefined) {
+          if ($.isFunction(settings.templates[query])) {
+            settings.autoShow = true;
+            settings.className.modal = settings.className.template;
+            settings = $.extend(settings, settings.templates[query].apply(module ,queryArguments));
+          }
           module.initialize();
         }
-        module.invoke(query);
+        if (!$.isFunction(settings.templates[query])) {
+          module.invoke(query);
+        }
       }
       else {
         if(instance !== undefined) {
@@ -1235,6 +1251,7 @@ $.fn.modal.settings = {
   closable       : true,
   autofocus      : true,
   restoreFocus   : true,
+  autoShow       : false,
 
   inverted       : false,
   blurring       : false,
@@ -1304,7 +1321,8 @@ $.fn.modal.settings = {
     deny     : '.actions .negative, .actions .deny, .actions .cancel',
     modal    : '.ui.modal',
     dimmer   : '> .ui.dimmer',
-    bodyFixed: '> .ui.fixed.menu, > .ui.right.toast-container, > .ui.right.sidebar, > .ui.fixed.nag, > .ui.fixed.nag > .close'
+    bodyFixed: '> .ui.fixed.menu, > .ui.right.toast-container, > .ui.right.sidebar, > .ui.fixed.nag, > .ui.fixed.nag > .close',
+    prompt   : '.ui.input > input'
   },
   error : {
     dimmer    : 'UI Dimmer, a required component is not included in this page',
@@ -1322,9 +1340,102 @@ $.fn.modal.settings = {
     undetached : 'undetached',
     front      : 'front',
     close      : 'close icon',
-    button     : 'ui button'
+    button     : 'ui button',
+    modal      : 'ui modal',
+    title      : 'header',
+    content    : 'content',
+    actions    : 'actions',
+    template   : 'ui tiny modal',
+    ok         : 'positive',
+    cancel     : 'negative',
+    prompt     : 'ui fluid input'
+  },
+  text: {
+    ok    : 'Ok',
+    cancel: 'Cancel'
   }
 };
 
+$.fn.modal.settings.templates = {
+  getArguments: function(args) {
+    var queryArguments = [].slice.call(args);
+    if($.isPlainObject(queryArguments[0])){
+      return $.extend({
+        handler:function(){},
+        content:'',
+        title: ''
+      }, queryArguments[0]);
+    } else {
+      if(!$.isFunction(queryArguments[queryArguments.length-1])) {
+        queryArguments.push(function() {});
+      }
+      return {
+        handler: queryArguments.pop(),
+        content: queryArguments.pop() || '',
+        title: queryArguments.pop() || ''
+      };
+    }
+  },
+  alert: function () {
+    var settings = this.get.settings(),
+        args     = settings.templates.getArguments(arguments)
+    ;
+    return {
+      title  : args.title,
+      content: args.content,
+      actions: [{
+        text : settings.text.ok,
+        class: settings.className.ok,
+        click: args.handler
+      }]
+    }
+  },
+  confirm: function () {
+    var settings = this.get.settings(),
+        args     = settings.templates.getArguments(arguments)
+    ;
+    return {
+      title  : args.title,
+      content: args.content,
+      actions: [{
+        text : settings.text.ok,
+        class: settings.className.ok,
+        click: function(){args.handler(true)}
+      },{
+        text: settings.text.cancel,
+        class: settings.className.cancel,
+        click: function(){args.handler(false)}
+      }]
+    }
+  },
+  prompt: function () {
+    var $this    = this,
+        settings = this.get.settings(),
+        args     = settings.templates.getArguments(arguments),
+        input    = $($.parseHTML(args.content)).filter('.ui.input')
+    ;
+    if (input.length === 0) {
+      args.content += '<p><div class="'+settings.className.prompt+'"><input placeholder="'+this.helpers.deQuote(args.placeholder || '')+'" type="text" value="'+this.helpers.deQuote(args.defaultValue || '')+'"></div></p>';
+    }
+    return {
+      title  : args.title,
+      content: args.content,
+      actions: [{
+        text: settings.text.ok,
+        class: settings.className.ok,
+        click: function(){
+          var settings = $this.get.settings(),
+              inputField = $this.get.element().find(settings.selector.prompt)[0]
+          ;
+          args.handler($(inputField).val());
+        }
+      },{
+        text: settings.text.cancel,
+        class: settings.className.cancel,
+        click: function(){args.handler(null)}
+      }]
+    }
+  }
+}
 
 })( jQuery, window, document );

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -1207,7 +1207,7 @@ $.fn.modal = function(parameters) {
           if ($.isFunction(settings.templates[query])) {
             settings.autoShow = true;
             settings.className.modal = settings.className.template;
-            settings = $.extend(settings, settings.templates[query].apply(module ,queryArguments));
+            settings = $.extend(true, settings, settings.templates[query].apply(module ,queryArguments));
           }
           module.initialize();
         }

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -1207,7 +1207,13 @@ $.fn.modal = function(parameters) {
           if ($.isFunction(settings.templates[query])) {
             settings.autoShow = true;
             settings.className.modal = settings.className.template;
-            settings = $.extend(true, settings, settings.templates[query].apply(module ,queryArguments));
+            settings = $.extend(true, {}, settings, settings.templates[query].apply(module ,queryArguments));
+
+            // reassign shortcuts
+            className = settings.className;
+            namespace = settings.namespace;
+            fields    = settings.fields;
+            error     = settings.error;
           }
           module.initialize();
         }

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -486,9 +486,9 @@ $.fn.modal = function(parameters) {
                 $module
                   .transition({
                     debug       : settings.debug,
-                    animation   : settings.transition + ' in',
+                    animation   : (settings.transition.showMethod || settings.transition) + ' in',
                     queue       : settings.queue,
-                    duration    : settings.duration,
+                    duration    : settings.transition.showDuration || settings.duration,
                     useFailSafe : true,
                     onComplete : function() {
                       settings.onVisible.apply(element);
@@ -536,9 +536,9 @@ $.fn.modal = function(parameters) {
               $module
                 .transition({
                   debug       : settings.debug,
-                  animation   : settings.transition + ' out',
+                  animation   : (settings.transition.hideMethod || settings.transition) + ' out',
                   queue       : settings.queue,
-                  duration    : settings.duration,
+                  duration    : settings.transition.hideDuration || settings.duration,
                   useFailSafe : true,
                   onStart     : function() {
                     if(!module.others.active() && !module.others.animating() && !keepDimmed) {

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -944,8 +944,8 @@ $.fn.modal = function(parameters) {
                 closable   : 'auto',
                 useFlex    : module.can.useFlex(),
                 duration   : {
-                  show     : settings.duration,
-                  hide     : settings.duration
+                  show     : settings.transition.showDuration || settings.duration,
+                  hide     : settings.transition.hideDuration || settings.duration
                 }
               },
               dimmerSettings = $.extend(true, defaultSettings, settings.dimmerSettings)

--- a/src/definitions/modules/modal.less
+++ b/src/definitions/modules/modal.less
@@ -40,9 +40,9 @@
   will-change: top, left, margin, transform, opacity;
 }
 
-.ui.modal > :first-child:not(.icon):not(.dimmer),
+.ui.modal > :first-child:not(.close):not(.dimmer),
 .ui.modal > i.icon:first-child + *,
-.ui.modal > .dimmer:first-child + *:not(.icon),
+.ui.modal > .dimmer:first-child + *:not(.close),
 .ui.modal > .dimmer:first-child + i.icon + * {
   border-top-left-radius: @borderRadius;
   border-top-right-radius: @borderRadius;
@@ -477,8 +477,8 @@
       border-radius:0;
     }
   }
-  .ui.modal > .close.inside + .header,
-  .ui.fullscreen.modal > .close + .header {
+  .ui.modal > .close.inside + .header:not(.centered):not(.center):not(.icon),
+  .ui.fullscreen.modal > .close + .header:not(.centered):not(.center):not(.icon) {
     padding-right: @closeHitbox;
   }
   .ui.modal > .close.inside,


### PR DESCRIPTION
## Description
This PR adds the possibility of using JS config templates for the modal module.
That means you can declare a reusable dynamic template function which returns predefined config settings (modified depending of your input to the template function) as the modal is already prepared to create dynamic content out of pure js since #1774 

For this reason modal now also has an optional `autoshow` option, which enables you to immediatly show the modal on instantiation time, so no more need for `$(.ui.modal).modal({closable:false}).modal('show')` but `$(.ui.modal).modal({closable:false, autoShow:true})`

Modal now also can use the transition methods for show/hide individually (backwards compatible) (just like in toast and for dimmer in #1867) 

### General usage
A js template is called as a modal behavior

```javascript
$('body').modal('alert','hello')
$('body').modal('confirm','Are you sure?',function(value){})
$('body').modal('prompt','Enter Code', function(value){})
```

Three basic templates are included: `alert`, `confirm`, `prompt` as an equivalent to existing vanilla JS variants but with more possibilities to customize the look & feel. (see below)

### alert / confirm
Possible parameters are: title, content, handler (in that order to stay nearly identical to vanilla js usage) or a given object `{title:'',content:'',handler:function(){}}` where as title and content can contain HTML. 

> If you don't trust the content set the global modal setting for `preserveHTML` to false.

#### Example
```javascript
 // content only
$('body').modal('alert','<span class="ui big text">hello</span>');
// title and content
$('body').modal('confirm','Attention!','Ready?');
 // title, content and handler
$('body').modal('confirm','Attention!','Ready?', function(choice){
	console.log('You '+ (choice ? 'Accepted':'Declined'))
});
// content and handler
$('body').modal('confirm','Ready?', function(choice){
	console.log('You '+ (choice ? 'Accepted':'Declined'))
});
// title and handler
$('body').modal('confirm',{
	title: 'Ready?',
	handler: function(choice){
		console.log('You '+ (choice ? 'Accepted':'Declined'))
	}
});

```

### prompt
The call for prompt is basically identical to alert and confirm. There are 2 more options available when an object is given (`placeholder` and `defaultValue`.
If you provide HTML Code for the content and this contains an input, this will be used as the inputfield. Otherwise it creates one dynamically for you.

```javascript
$('body').modal('prompt',{
	title: 'Entry Code?',
    placeholder: 'do not enter your mothers name!',
	handler: function(choice){
		console.log('You '+ (choice ? 'Accepted':'Declined'))
	}
});
```

Config template modals will be always autoshown (see above), so no manual `show` is needed)

### Create your own template

Extend the modals templates object. It has to return an object which will me merged into the modals settings prior to creating/showing the modal. 

```javascript
$.fn.modal.settings.templates.welcome = function(username) {
// do something according to modals settings and/or given parameters
  var settings = this.get.settings(); // "this" is the modal instance
	return {
		closable: false,
		title: 'Welcome '+ username
	}
}
```

Reuse this whenever you need
```javascript
$('body').modal('welcome','hammy')
$('body').modal('welcome','prudho')
$('body').modal('welcome','colinfrick')
$('body').modal('welcome','ko2in')
$('body').modal('welcome','exoego')
$('body').modal('welcome','lubber')
```

## Testcase
Here is a jsfiddle to show the basic usage as well as a custom template which behaves like the [SweetAlert2](https://github.com/sweetalert2/sweetalert2) Style
https://jsfiddle.net/lubber/7u2s4h6k/56/

Here i started a dedicated jfiddle to use a custom Fomantic modal template as a dropin replacement for sweetalert to see what's possible. This is WIP, but shows that you can reuse your existing code. This code will never be part of fomantic core because it's using promises and simulates the config settings from sweetalert2
Thanks to @prudho for his fui alert plugin (#1716) inspiration (and him mentioning he uses swal ;) )
https://jsfiddle.net/lubber/pujwkxz1/6/

## Screenshots
![modalconfigtemplates](https://user-images.githubusercontent.com/18379884/107154609-1e46a080-6974-11eb-82b7-b296c3798a4f.gif)
![sweetalert03](https://user-images.githubusercontent.com/18379884/107154825-4387de80-6975-11eb-9cb9-befdc4c7261f.gif)

## Closes
#1407 

