### PR TITLE
fix(dropdown): double declaration of name

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -4094,7 +4094,6 @@ $.fn.dropdown.settings = {
     name                 : 'name',     // displayed dropdown text
     description          : 'description', // displayed dropdown description
     descriptionVertical  : 'descriptionVertical', // whether description should be vertical
-    name                 : 'name',     // displayed dropdown text
     value                : 'value',    // actual dropdown value
     text                 : 'text',     // displayed text when selected
     type                 : 'type',     // type of dropdown element


### PR DESCRIPTION
## Description

The `name` fields property was doubled by #1852 . This PR removes the redundant entry

