### PR TITLE
fix(dropdown): autocomplete in chrome does not support "off"

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -372,7 +372,7 @@ $.fn.dropdown = function(parameters) {
               module.verbose('Adding search input');
               $search = $('<input />')
                 .addClass(className.search)
-                .prop('autocomplete', 'off')
+                .prop('autocomplete', module.is.chrome() ? 'fomantic-search' : 'off')
                 .insertBefore($text)
               ;
             }
@@ -3378,6 +3378,9 @@ $.fn.dropdown = function(parameters) {
           },
           bubbledIconClick: function(event) {
             return $(event.target).closest($icon).length > 0;
+          },
+          chrome: function() {
+            return !!window.chrome && (!!window.chrome.webstore || !!window.chrome.runtime);
           },
           alreadySetup: function() {
             return ($module.is('select') && $module.parent(selector.dropdown).data(moduleNamespace) !== undefined && $module.prev().length === 0);

--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -118,7 +118,7 @@ $.fn.search = function(parameters) {
                 .on(module.get.inputEvent() + eventNamespace, selector.prompt, module.event.input)
               ;
               $prompt
-                .attr('autocomplete', 'off')
+                .attr('autocomplete', module.is.chrome() ? 'fomantic-search' : 'off')
               ;
             }
             $module
@@ -400,6 +400,9 @@ $.fn.search = function(parameters) {
         is: {
           animating: function() {
             return $results.hasClass(className.animating);
+          },
+          chrome: function() {
+            return !!window.chrome && (!!window.chrome.webstore || !!window.chrome.runtime);
           },
           hidden: function() {
             return $results.hasClass(className.hidden);


### PR DESCRIPTION
## Description
Chrome based Browsers ignore `autocomplete='off'` 
Read their reasons here https://bugs.chromium.org/p/chromium/issues/detail?id=468153#c164

Unfortunately this leads into having the search input field in a dropdown getting those autocompletes as well.
As the above mentioned comment mentions, this PR set a semantic name as autocomplete value instead of "off" when the browser is chromium based.

## Testcase
Here, the dropdown has a label named "Adress". This triggers Chrome to show the autocomplete even if "autocomplete="off" is set (which works in other browsers like firefox as expected)

You may have to create an address in the chrome settings (in case you havent already save any) to see the autofill
https://jsfiddle.net/lubber/3gw9rk8o/6/

### Fixed
No autofill
https://jsfiddle.net/lubber/3gw9rk8o/8/



## Closes
#1880 
https://github.com/Semantic-Org/Semantic-UI/issues/6075