### PR TITLE
feat(dependency): support a possible installed v4 of less

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "gulp-debug": "^4.0.0",
     "gulp-git": "^2.9.0",
     "gulp-tap": "^1.0.1",
-    "less": ">=3.7.0",
+    "less": "^3.7.1 || ^4.0.0",
     "merge-stream": "^2.0.0",
     "better-console": "1.0.1",
     "del": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "gulp-debug": "^4.0.0",
     "gulp-git": "^2.9.0",
     "gulp-tap": "^1.0.1",
-    "less": "^3.7.0",
+    "less": ">=3.7.0",
     "merge-stream": "^2.0.0",
     "better-console": "1.0.1",
     "del": "^3.0.0",

--- a/src/definitions/modules/dimmer.js
+++ b/src/definitions/modules/dimmer.js
@@ -255,7 +255,7 @@ $.fn.dimmer = function(parameters) {
                   displayType : settings.useFlex
                     ? 'flex'
                     : 'block',
-                  animation   : settings.transition + ' in',
+                  animation   : (settings.transition.showMethod || settings.transition) + ' in',
                   queue       : false,
                   duration    : module.get.duration(),
                   useFailSafe : true,
@@ -302,7 +302,7 @@ $.fn.dimmer = function(parameters) {
                   displayType : settings.useFlex
                     ? 'flex'
                     : 'block',
-                  animation   : settings.transition + ' out',
+                  animation   : (settings.transition.hideMethod || settings.transition) + ' out',
                   queue       : false,
                   duration    : module.get.duration(),
                   useFailSafe : true,


### PR DESCRIPTION
## Description
We fixed support for LESS 4 by #1819 , but the package.json retricts installation to 3.x if less 4.x is already installed by throwing "this version is not supported". Seems more and more people have LESS 4 installed now which breaks installation in some setup environments 

I changed the dependency so every version >= 3.7 is supported now

## Related
#1893 