### PR TITLE
fix(search): dont set value when onselect returns false

### DIFF
--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -227,9 +227,7 @@ $.fn.search = function(parameters) {
                 results = module.get.results(),
                 result  = $result.data(metadata.result) || module.get.result(value, results)
               ;
-              if(value) {
-                module.set.value(value);
-              }
+              var oldValue = module.get.value();
               if( $.isFunction(settings.onSelect) ) {
                 if(settings.onSelect.call(element, result, results) === false) {
                   module.debug('Custom onSelect callback cancelled default select action');
@@ -238,6 +236,9 @@ $.fn.search = function(parameters) {
                 }
               }
               module.hideResults();
+              if(value && module.get.value() === oldValue) {
+                module.set.value(value);
+              }
               if(href) {
                 event.preventDefault();
                 module.verbose('Opening search link found in result', $link);


### PR DESCRIPTION
## Description
As the docs tell, when the `onSelect` callback returns `false` there should be no selection and menu hiding happen.
But infact only the menu is not hidden, the value is still selected.

This is because of #83 where it was made possible to change the value inside the onSelect callback.
To still support this i moved the value setting back to the point after the callback but now the value is only overridden if the previous value is still unchanged (to recognize a possible manual change in the callback.

## Testcase
- Enter something in the searchfield to bring up the menulist
- Select something from the list

### Broken
Although the onSelect callback returns false, the value is still overridden, while the menu remains
http://jsfiddle.net/lubber/9z4j5wqo/9/

### Fixed
Value is not overridden, menu remains, just as the docs say (and SUI does)
http://jsfiddle.net/lubber/9z4j5wqo/8/

## Proof of previous logic
Callback does not return false, but changes value inside the callback. It will be kept as before :)
http://jsfiddle.net/lubber/9z4j5wqo/10/

## Screenshot
### Broken
![searchcallback_bad](https://user-images.githubusercontent.com/18379884/108785085-06287100-7571-11eb-9060-9a976ce4153d.gif)

### Fixed
![searchcallback_good](https://user-images.githubusercontent.com/18379884/108785098-0b85bb80-7571-11eb-8f49-55e920f2183c.gif)


## Closes
#1895 