### PR TITLE
feat(validation): allow credit card numbers with spaces

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1993,6 +1993,9 @@ $.fn.form.settings = {
 
       // allow dashes in card
       cardNumber = cardNumber.replace(/[\-]/g, '');
+      
+      // allow spaces in card
+      cardNumber = cardNumber.replace(/\s/g, '');
 
       // verify card types
       if(requiredTypes) {

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1991,11 +1991,8 @@ $.fn.form.settings = {
         return;
       }
 
-      // allow dashes in card
-      cardNumber = cardNumber.replace(/[\-]/g, '');
-      
-      // allow spaces in card
-      cardNumber = cardNumber.replace(/\s/g, '');
+      // allow dashes and spaces in card
+      cardNumber = cardNumber.replace(/[\s\-]/g, '');
 
       // verify card types
       if(requiredTypes) {


### PR DESCRIPTION
## Description
When using input masking libraries like [Cleave.js](https://github.com/nosir/cleave.js/) in conjunction with Fomantic form validation rules for payments, legitimate card numbers from Fomantic's test cards would not validate if it contained spaces.

## Testcase
JSFiddle showing the problem: https://jsfiddle.net/h8pe31qb/

JSFiddle showing the solution with the modified line in this PR (excuse the roughness, I simply pasted in the result of my `gulp build` with the change included: https://jsfiddle.net/og5a6x2w/

## Screenshots
Failure on valid credit card number:
![image](https://user-images.githubusercontent.com/28184313/109758447-a418dd00-7bfc-11eb-89e7-81506f46b3fd.png)

After fix: No validation error
![image](https://user-images.githubusercontent.com/28184313/109758623-e8a47880-7bfc-11eb-93b8-3d050171558b.png)


