### PR TITLE
fix(header): icon headers should not have a left content padding

### DIFF
--- a/src/definitions/elements/header.less
+++ b/src/definitions/elements/header.less
@@ -113,8 +113,8 @@
 }
 
 /* After Icon */
-.ui.header:not(.centered):not(.aligned) > .icons + .content,
-.ui.header:not(.centered):not(.aligned) > i.icon + .content {
+.ui.header:not(.icon):not(.centered):not(.aligned) > .icons + .content,
+.ui.header:not(.icon):not(.centered):not(.aligned) > i.icon + .content {
   padding-left: @iconMargin;
   display: table-cell;
   vertical-align: @contentIconAlignment;


### PR DESCRIPTION
## Descripton
An `icon header` has got a left padding which is only supposed to be needed when it's a normal header having an icon next to the header text

## Testcase
https://jsfiddle.net/lubber/c0vapqbz/2/

## Screenshot
![iconheaderpadding](https://user-images.githubusercontent.com/18379884/110174446-6b495580-7e00-11eb-9ccc-81d37da31e36.gif)

## Closes
#1908 