### PR TITLE
fix(segment): support placeholder segments for tab usage

### DIFF
--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -139,6 +139,12 @@
     background: @placeholderBackground;
     border-color: @placeholderBorderColor;
     box-shadow: @placeholderBoxShadow;
+    &.tab {
+      display: none;
+      &.active {
+        display: flex;
+      }
+    }
   }
 
   .ui.placeholder.segment .button,


### PR DESCRIPTION
## Description
When a `placeholder segment` is used for tabs, it messes up the display.

## Testcase
Switch between the tabs, the placeholder tab should only be visible when tab 2 gets activated

### Before
Messed up, the placeholder is shown all the time and also totally misaligned
https://jsfiddle.net/eo7sut0g/

### After
All fine
https://jsfiddle.net/lubber/bf1t4nzq/12/

## Screenshot
### Before
![placeholdersegmenttabbroken](https://user-images.githubusercontent.com/18379884/111870437-0ad02180-8985-11eb-9a4b-8b7706ff064f.gif)

### After
![placeholdersegmenttabfixed](https://user-images.githubusercontent.com/18379884/111870439-0f94d580-8985-11eb-854e-6a6d069bcf28.gif)

## Closes
#1920 