### PR TITLE
fix(calendar): disabled week days should not affect month and year view

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -972,7 +972,7 @@ $.fn.calendar = function(parameters) {
 
         helper: {
           isDisabled: function(date, mode) {
-            return (mode === 'day' || mode === 'month' || mode === 'year') && ((settings.disabledDaysOfWeek.indexOf(date.getDay()) !== -1) || settings.disabledDates.some(function(d){
+            return (mode === 'day' || mode === 'month' || mode === 'year') && ((mode === 'day' && settings.disabledDaysOfWeek.indexOf(date.getDay()) !== -1) || settings.disabledDates.some(function(d){
               if(typeof d === 'string') {
                 d = module.helper.sanitiseDate(d);
               }


### PR DESCRIPTION
## Description
When the `disabledDaysOfWeek` setting is used for the `calendar` module, this messed up the month or year selection

## Testcase
Open the calendar and click on the year to select a different month or a different year

### Broken
Some months/years are also disabled
https://jsfiddle.net/lubber/twhdeuqb/

### Fixed
All months and years are selectable
https://jsfiddle.net/lubber/twhdeuqb/2/

## Screenshot
|Broken|Fixed|
|-|-|
|![disableddays_broken](https://user-images.githubusercontent.com/18379884/112612731-8ca9ca00-8e1f-11eb-8d28-370128957404.gif)|![disableddays_fixed](https://user-images.githubusercontent.com/18379884/112612748-90d5e780-8e1f-11eb-9686-f8b648f27d22.gif)|

## Closes
#1927 

