### PR TITLE
fix(form): file upload fields trigger error using jquery > 3.4.0

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1602,9 +1602,9 @@ $.fn.form.settings = {
   selector : {
     checkbox   : 'input[type="checkbox"], input[type="radio"]',
     clear      : '.clear',
-    field      : 'input:not(.search), textarea, select',
+    field      : 'input:not(.search):not([type="file"]), textarea, select',
     group      : '.field',
-    input      : 'input',
+    input      : 'input:not([type="file"])',
     message    : '.error.message',
     prompt     : '.prompt.label',
     radio      : 'input[type="radio"]',


### PR DESCRIPTION
## Description
When a form contains a file upload field it is also bound to several form events which are not supposed to happen on those and do not work because flie upload fields are limited in access.

That said, when using jQuery > 3.4.0, it triggers a `Maximum callstack exceeded instead`

## Testcase
- Click on the "Upload image" Button and select something you like 
- Watch console

### Broken
"maximum callstack exceeded"
https://jsfiddle.net/vzctb5pu/2/

### Fixed
Nothing 🙂 
https://jsfiddle.net/lubber/7f269p84/8/

## Screenshot
|Broken|Fixed|
|-|-|
|![formfilebroken](https://user-images.githubusercontent.com/18379884/115141916-263f5280-a03f-11eb-9a03-cb6936c7847e.gif)|![formfilefixed](https://user-images.githubusercontent.com/18379884/115141919-2a6b7000-a03f-11eb-8384-ad8db6bd0dd3.gif)|
