### PR TITLE
fix(form): separate dirty events trigger multiple native event calls

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -172,10 +172,8 @@ $.fn.form = function(parameters) {
           }
 
           $field.on('change click keyup keydown blur', function(e) {
-            $(this).triggerHandler(e.type + ".dirty");
+            module.determine.isDirty();
           });
-
-          $field.on('change.dirty click.dirty keyup.dirty keydown.dirty blur.dirty', module.determine.isDirty);
 
           $module.on('dirty' + eventNamespace, function(e) {
             settings.onDirty.call();
@@ -303,10 +301,6 @@ $.fn.form = function(parameters) {
               module.set.clean();
             }
 
-            if (e && e.namespace === 'dirty') {
-              e.stopImmediatePropagation();
-              e.preventDefault();
-            }
           }
         },
 


### PR DESCRIPTION
## Description
The dirty functionality uses jquerys `triggerHandler` method to bind namespaces extra events. Unfortunately this also calls native bound events twice.
The extra events however are not necessary, it is enough to call the namespaces dirty/clean checker on the original events which prevents the multiple calls

## Testcase
- Open the modal
- Start typing something in the input field
- Watch console
### Broken
- The `keyup` event is triggered twice
https://jsfiddle.net/lubber/p51nx39y

### Fixed
- The `keyup` event is triggered only once
https://jsfiddle.net/lubber/p51nx39y/1/

## Screenshots
|Broken|Fixed|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/116621741-f39d3000-a943-11eb-946a-77d331fdd9f4.png)|![image](https://user-images.githubusercontent.com/18379884/116621702-e3855080-a943-11eb-9401-c80051a14511.png)

## Closes
#1942 