### PR TITLE
fix(search): fetch "Cannot read property 'top' of undefined

### DIFF
--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -252,16 +252,16 @@ $.fn.search = function(parameters) {
             }
           }
         },
-        ensureVisible: function ensureVisible($el) {
+        ensureVisible: function($el) {
           var elTop, elBottom, resultsScrollTop, resultsHeight;
-
+          if($el.length === 0) {
+            return;
+          }
           elTop = $el.position().top;
           elBottom = elTop + $el.outerHeight(true);
 
           resultsScrollTop = $results.scrollTop();
-          resultsHeight = $results.height()
-            parseInt($results.css('paddingTop'), 0) +
-            parseInt($results.css('paddingBottom'), 0);
+          resultsHeight = $results.height();
             
           if (elTop < 0) {
             $results.scrollTop(resultsScrollTop + elTop);
@@ -980,9 +980,7 @@ $.fn.search = function(parameters) {
                   duration   : settings.duration,
                   onShow     : function() {
                     var $firstResult = $module.find(selector.result).eq(0);
-                    if($firstResult.length > 0) {
-                      module.ensureVisible($firstResult);
-                    }
+                    module.ensureVisible($firstResult);
                   },
                   onComplete : function() {
                     callback();


### PR DESCRIPTION
## Description
When a search has no result and one presses the "arrow down" key on the keyboard, a javascript error
> Cannot read property 'top' of undefined

occurs

This PR also fixes dead, unused and unnecessary code of the affected function "ensureVisible"

## Testcase

### Broken
https://jsfiddle.net/vphxjf61

### Fixed
https://jsfiddle.net/vphxjf61/1/

## Closes
#1964 