### PR TITLE
feat(segment): support equal width

### DIFF
--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -483,6 +483,10 @@
     .ui.horizontal.segments > .segment:last-child {
       border-radius: 0 @borderRadius @borderRadius 0;
     }
+    /* Equal Width */
+    .ui[class*="equal width"].horizontal.segments > .segment {
+      width: 100%;
+    }
   }
 }
 


### PR DESCRIPTION
## Description
This PR adds support for `equal width` horizontal segments. We already have equal width in form and grid.

## Testcase
https://jsfiddle.net/lubber/dpr5fuq3/12/

## Screenshot
|Before|After
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/119235478-0cf45f00-bb33-11eb-8051-7c84c57493ec.png)|![image](https://user-images.githubusercontent.com/18379884/119235469-fea64300-bb32-11eb-865b-3cbe7abc5cd2.png)|

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5878