### PR TITLE
fix(rating): disabled rating should not allow pointer events

### DIFF
--- a/src/definitions/modules/rating.less
+++ b/src/definitions/modules/rating.less
@@ -138,6 +138,7 @@ each(@colors, {
   /* disabled rating */
   .ui.disabled.rating .icon {
     cursor: default;
+    pointer-events: none;
   }
 }
 


### PR DESCRIPTION
## Desciption
A `disabled rating` component only changes the cursor but still allows for pointer events (for example when used inside a `card`.

## Testcase

### Broken
https://jsfiddle.net/lubber/opLg53bq/1/

### Fixed
https://jsfiddle.net/lubber/opLg53bq/2/

## Screenshot
## Broken
![disabledratingincard](https://user-images.githubusercontent.com/18379884/120105212-498a1100-c158-11eb-8f2c-efca9a10f237.gif)

## Fixed
![disabledratingincardFixed](https://user-images.githubusercontent.com/18379884/120105246-6e7e8400-c158-11eb-9aa8-f62c398e57fa.gif)


## Closes
#1972 


