### PR TITLE
feat(dimmer): support individual show/hide duration

### DIFF
--- a/src/definitions/modules/dimmer.js
+++ b/src/definitions/modules/dimmer.js
@@ -335,15 +335,12 @@ $.fn.dimmer = function(parameters) {
             return $dimmer;
           },
           duration: function() {
-            if(typeof settings.duration == 'object') {
-              if( module.is.active() ) {
-                return settings.duration.hide;
-              }
-              else {
-                return settings.duration.show;
-              }
+            if( module.is.active() ) {
+              return settings.transition.hideDuration || settings.duration.hide || settings.duration;
             }
-            return settings.duration;
+            else {
+              return settings.transition.hideDuration || settings.duration.show || settings.duration;
+            }
           }
         },
 

--- a/src/definitions/modules/dimmer.js
+++ b/src/definitions/modules/dimmer.js
@@ -339,7 +339,7 @@ $.fn.dimmer = function(parameters) {
               return settings.transition.hideDuration || settings.duration.hide || settings.duration;
             }
             else {
-              return settings.transition.hideDuration || settings.duration.show || settings.duration;
+              return settings.transition.showDuration || settings.duration.show || settings.duration;
             }
           }
         },


### PR DESCRIPTION
## Description
This PR adds the same syntax for the optional `hideDuration/showDuration` value of the `transition` setting to the `dimmer` module as we already have in toast, modal, popup and dropdown.

As dimmer was the only module which was already/also supporting an object for the duration value, i kept the logic in for backward compatibility

## Testcase
https://jsfiddle.net/lubber/x2dzht4b/6/


