### PR TITLE
feat(icon): support loading variant for icon groups

### DIFF
--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -68,9 +68,11 @@ i.icon:before {
       Loading
   ---------------*/
 
-  i.loading.icon, i.loading.icons {
+  i.loading.icon {
     height: 1em;
     line-height: 1;
+  }
+  i.loading.icon, i.loading.icons {
     animation: loader @loadingDuration linear infinite;
   }
 }

--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -68,7 +68,7 @@ i.icon:before {
       Loading
   ---------------*/
 
-  i.icon.loading {
+  i.loading.icon, i.loading.icons {
     height: 1em;
     line-height: 1;
     animation: loader @loadingDuration linear infinite;


### PR DESCRIPTION
## Description
The `loading` variant was missing for icon groups

## Testcase
https://jsfiddle.net/lubber/9q6g0d83/6/

## Screenshot
![Animation](https://user-images.githubusercontent.com/18379884/120929301-d567e400-c6e8-11eb-82a9-e92c95a96c4d.gif)
