### PR TITLE
fix(slider): less 4 support needs parenthesis

### DIFF
--- a/src/definitions/modules/slider.less
+++ b/src/definitions/modules/slider.less
@@ -247,7 +247,7 @@
       top: 50%;
     }
     .ui.labeled.vertical.slider > .labels .halftick.label:after {
-      width: @labelHeight / 2;
+      width: (@labelHeight / 2);
       height: @labelWidth;
     }
 


### PR DESCRIPTION
## Description

LESS 4 forces parenthesis for math division. There was one line missing to take care of that. Everything else was covered by #1819  already

