### PR TITLE
[slider] Add option to disable touch-/mouse-sliding on the track

### DIFF
--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -283,7 +283,7 @@ $.fn.slider = function(parameters) {
               event.preventDefault();
               module.event.down(event);
             });
-            if(!slideEverywhere) {
+            if(!settings.slideEverywhere) {
               $module.on('touchstart' + eventNamespace, module.event.down);
             }
           },

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -786,7 +786,11 @@ $.fn.slider = function(parameters) {
             return value;
           },
           eventPos: function(event) {
-            if(event.type !== 'click') {
+            // unwrap jQuery event objects
+            if(!(event.pageX || event.changedTouches)) {
+              event = event.originalEvent;
+            }
+            if(event.changedTouches) {
               var
                 touchEvent = event.changedTouches ? event : event.originalEvent,
                 touches = touchEvent.changedTouches[0] ? touchEvent.changedTouches : touchEvent.touches,

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -284,6 +284,13 @@ $.fn.slider = function(parameters) {
               module.event.down(event);
             });
             if(!settings.slideEverywhere) {
+              $module.find('.track, .inner').on('click' + eventNamespace, function(event) {
+                event.stopImmediatePropagation();
+                event.preventDefault();
+                module.event.up(event);
+              });
+              $module.on('click' + eventNamespace, module.event.up);
+            } else {
               $module.on('touchstart' + eventNamespace, module.event.down);
             }
           },
@@ -779,7 +786,7 @@ $.fn.slider = function(parameters) {
             return value;
           },
           eventPos: function(event) {
-            if(module.is.touch()) {
+            if(event.type !== 'click') {
               var
                 touchEvent = event.changedTouches ? event : event.originalEvent,
                 touches = touchEvent.changedTouches[0] ? touchEvent.changedTouches : touchEvent.touches,

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -252,12 +252,22 @@ $.fn.slider = function(parameters) {
           },
           mouseEvents: function() {
             module.verbose('Binding mouse events');
-            $module.find('.track, .thumb, .inner').on('mousedown' + eventNamespace, function(event) {
+            var downElements = settings.slideEverywhere ? '.thumb,.inner,.track' : '.thumb';
+            $module.find(downElements).on('mousedown' + eventNamespace, function(event) {
               event.stopImmediatePropagation();
               event.preventDefault();
               module.event.down(event);
             });
-            $module.on('mousedown' + eventNamespace, module.event.down);
+            if(!settings.slideEverywhere) {
+              $module.find('.track, .inner').on('click' + eventNamespace, function(event) {
+                event.stopImmediatePropagation();
+                event.preventDefault();
+                module.event.up(event);
+              });
+              $module.on('click' + eventNamespace, module.event.up);
+            } else {
+              $module.on('mousedown' + eventNamespace, module.event.down);
+            }
             $module.on('mouseenter' + eventNamespace, function(event) {
               isHover = true;
             });
@@ -267,12 +277,15 @@ $.fn.slider = function(parameters) {
           },
           touchEvents: function() {
             module.verbose('Binding touch events');
-            $module.find('.track, .thumb, .inner').on('touchstart' + eventNamespace, function(event) {
+            var downElements = settings.slideEverywhere ? '.thumb,.inner,.track' : '.thumb';
+            $module.find(downElements).on('touchstart' + eventNamespace, function(event) {
               event.stopImmediatePropagation();
               event.preventDefault();
               module.event.down(event);
             });
-            $module.on('touchstart' + eventNamespace, module.event.down);
+            if(!slideEverywhere) {
+              $module.on('touchstart' + eventNamespace, module.event.down);
+            }
           },
           slidingEvents: function() {
             // these don't need the identifier because we only ever want one of them to be registered with document
@@ -1295,6 +1308,7 @@ $.fn.slider.settings = {
   preventCrossover : true,
   fireOnInit       : false,
   interpretLabel   : false,
+  slideEverywhere  : true,       // If false, only allow clicking, not sliding on the track
 
   //the decimal place to round to if step is undefined
   decimalPlaces  : 2,


### PR DESCRIPTION
## Description
Currently, the slider is quite sensible to mouse and touch events: Any mouse drag and touch event that *starts* anywhere on the slider will move the knob (not only when hitting the knob). This is especially annoying when trying to scroll a page with many sliders on a mobile device with touch screen. You'll find yourself moving a slider accidentially quite often.

Thus, this PR introduces a setting `slideEverywhere` to sliders to change the click and touch behaviour. By default, it is `true`, which corresponds to the old behaviour. With `slideEverywhere=true`, the slider can only be moved by either dragging **the knob** or by clicking / tapping (not dragging) anywhere on the slider. 

## Testcase
https://jsfiddle.net/81cs7dbg/1/

## Screenshot (if possible)
Does not change anything visually.
