### PR TITLE
fix(modal): dont stack same actions buttons

### DIFF
--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -110,6 +110,10 @@ $.fn.modal = function(parameters) {
           }
           if(module.has.configActions()){
             var $actions = $module.find(selector.actions).addClass(settings.classActions);
+            if ($actions.length === 0) {
+              $actions = $('<div/>', {class: className.actions + ' ' + (settings.classActions || '')}).appendTo($module);
+            }
+            $actions.empty();
             settings.actions.forEach(function (el) {
               var icon = el[fields.icon] ? '<i class="' + module.helpers.deQuote(el[fields.icon]) + ' icon"></i>' : '',
                   text = module.helpers.escape(el[fields.text] || '', settings.preserveHTML),

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -112,8 +112,9 @@ $.fn.modal = function(parameters) {
             var $actions = $module.find(selector.actions).addClass(settings.classActions);
             if ($actions.length === 0) {
               $actions = $('<div/>', {class: className.actions + ' ' + (settings.classActions || '')}).appendTo($module);
+            } else {
+              $actions.empty();
             }
-            $actions.empty();
             settings.actions.forEach(function (el) {
               var icon = el[fields.icon] ? '<i class="' + module.helpers.deQuote(el[fields.icon]) + ' icon"></i>' : '',
                   text = module.helpers.escape(el[fields.text] || '', settings.preserveHTML),


### PR DESCRIPTION
## Description

While preparing the docs for #1774 , i recognized that modal

- does not create action buttons at all when the actions container is not available in the DOM
- does always stack action buttons on DOM modals when reused

## Testcase
### Broken
#### Missing action div container
https://jsfiddle.net/lubber/5f6rm830/2/
#### Actions stacked on each call
https://jsfiddle.net/lubber/5f6rm830/3/

### Fixed
#### Actions do not stack on each call
https://jsfiddle.net/lubber/5f6rm830/6/
#### Missing action div container will be created at runtime
https://jsfiddle.net/lubber/5f6rm830/5/

## Screenshot
![stackedactionsbug](https://user-images.githubusercontent.com/18379884/122973585-b0829a80-d391-11eb-82fe-6105c6f9ef2d.gif)