### PR TITLE
fix(nightly): check for already uploaded versions and support downgrades

### DIFF
--- a/scripts/nightly-version.js
+++ b/scripts/nightly-version.js
@@ -35,23 +35,38 @@ const getNpmPreRelease = async function () {
     .then(pr => pr === null ? ['beta', 0] : pr)
 }
 
+const getAllNpmVersions = async function () {
+  // The versions property sometimes does not include versions which are in "time"!
+  // That's why "time" is used here
+  return fetch(`${npmBase}/${npmPackage}`)
+      .then(r => r.json())
+      .then(p => Object.keys(p['time']))
+}
+
 const getNightlyVersion = async function () {
   const nextVersion = await getGitHubVersion()
   const currentNightlyWithPre = semver.parse(await getCurrentNpmVersion())
   const currentNightly = `${currentNightlyWithPre.major}.${currentNightlyWithPre.minor}.${currentNightlyWithPre.patch}`
+  const allNpmVersions = await getAllNpmVersions()
+  let nightlyVersion = `${nextVersion}-beta.0`
 
-  if (!semver.gt(nextVersion, currentNightly)) {
-    if (semver.minor(nextVersion) === semver.minor(currentNightly)) {
-      const preRelease = await getNpmPreRelease()
+  if (semver.eq(nextVersion, currentNightly)) {
+    const preRelease = await getNpmPreRelease()
 
-      return semver.inc(
-        `${nextVersion}-${preRelease[0]}.${preRelease[1]}`,
+    nightlyVersion = semver.inc(
+      `${nextVersion}-${preRelease[0]}.${preRelease[1]}`,
+      'prerelease'
+    )
+  }
+  //check if version was already uploaded to npm previously
+   while (allNpmVersions.indexOf(nightlyVersion) !== -1) {
+    nightlyVersion = semver.inc(
+        nightlyVersion,
         'prerelease'
-      )
-    }
+    )
   }
 
-  return `${nextVersion}-beta.0`
+  return nightlyVersion
 }
 
 getNightlyVersion()


### PR DESCRIPTION
## Description
The current nightly build is broken, because the next nightly version would be `2.9.0-beta-0`, which was already uploaded (by accident) to npm in 2019, so it already exists, which breaks the build.

This PR now checks for possible existing npm versions and increases the beta number accordingly.
> i found out that `2.9.0-beta.0` is not available in the `versions` property from the npm api, but it is in the `time` property of https://registry.npmjs.org/fomantic-ui

This PR also allows for possible downgrades.
Means, if we have a `2.9.0-beta.1234` but , by some reason, we would have to create a 2.8.9 at a later stage, the script would not allow that (the next github milestone was always supposed to be greater than the latest nightly) 