### PR TITLE
fix(calendar): arrow keys on endCalendar when startCal has future month

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -923,6 +923,7 @@ $.fn.calendar = function(parameters) {
                 //if this is a range calendar, focus the container or input. This will open the popup from its event listeners.
                 var endModule = module.get.calendarModule(settings.endCalendar);
                 if (endModule) {
+                  endModule.refresh();
                   if (endModule.setting('on') !== 'focus') {
                     endModule.popup('show');
                   }


### PR DESCRIPTION
## Description
Selecting a future month on a `startCalendar` didn't allow to use arrows on the `endCalendar`, since it was not refreshed before showing it.

## Testcase
See #1851

## Screenshot (if possible)
Broken:
![Broken](https://i.ibb.co/Tthkbct/Animation.gif)

Fixed:
![Fixed](https://i.ibb.co/FWkPG44/Animation-1.gif)

## Closes
#1851
