### PR TITLE
 feat(calendar): trigger onSelect() event on enter key down

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -611,7 +611,9 @@ $.fn.calendar = function(parameters) {
                 var mode = module.get.mode();
                 var date = module.get.focusDate();
                 if (date && !settings.isDisabled(date, mode) && !module.helper.isDisabled(date, mode) && module.helper.isEnabled(date, mode)) {
-                  module.selectDate(date);
+                  if (settings.onSelect.call(element, date, module.get.mode()) !== false) {
+                    module.selectDate(date);
+                  }
                 }
                 //disable form submission:
                 event.preventDefault();


### PR DESCRIPTION
## Description
This PR adds triggering of the `onSelect` event when user press the Enter key after entering a date in the input field. It also allow user to rollback if the date field is not correct for him by returning `false` (can be usefull for #1517 and #1518).

## Screenshot (if possible)
Before:
![Before](https://i.ibb.co/xfr1Djq/Animation.gif)

After:
![After](https://i.ibb.co/zS3P2R0/Animation-1.gif)
