### PR TITLE
feat(dimmer): add onVisible and onHidden callbacks

### DIFF
--- a/src/definitions/modules/dimmer.js
+++ b/src/definitions/modules/dimmer.js
@@ -264,6 +264,7 @@ $.fn.dimmer = function(parameters) {
                   },
                   onComplete  : function() {
                     module.set.active();
+                    settings.onVisible.call($dimmer);
                     callback();
                   }
                 })
@@ -285,6 +286,7 @@ $.fn.dimmer = function(parameters) {
                 .fadeTo(module.get.duration(), settings.opacity, function() {
                   $dimmer.removeAttr('style');
                   module.set.active();
+                  settings.onVisible.call($dimmer);
                   callback();
                 })
               ;
@@ -310,6 +312,7 @@ $.fn.dimmer = function(parameters) {
                     module.remove.dimmed();
                     module.remove.variation();
                     module.remove.active();
+                    settings.onHidden.call($dimmer);
                     callback();
                   }
                 })
@@ -323,6 +326,7 @@ $.fn.dimmer = function(parameters) {
                   module.remove.dimmed();
                   module.remove.active();
                   $dimmer.removeAttr('style');
+                  settings.onHidden.call($dimmer);
                   callback();
                 })
               ;
@@ -704,6 +708,8 @@ $.fn.dimmer.settings = {
   onChange    : function(){},
   onShow      : function(){},
   onHide      : function(){},
+  onVisible   : function(){},
+  onHidden    : function(){},
 
   error   : {
     method   : 'The method you called is not defined.'


### PR DESCRIPTION
## Description
From my work on ES6 modules, I have implemented the `onVisible` and `onHidden` callbacks for the `Dimmer` module.

`onVisible` is triggereg when dimmer is fully shown, and `onHidden` when dimmer fully hidden.

## Screenshot
![Dimmer's callbacks](https://i.ibb.co/Syk4Z3z/Animation.gif)
