### PR TITLE
feat(calendar): disabledhours

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -1019,7 +1019,7 @@ $.fn.calendar = function(parameters) {
                 }
               }
             })) || (mode === 'hour' && settings.disabledHours.some(function(d){
-              if(typeof d === 'string') {
+              if (typeof d === 'string') {
                 d = module.helper.sanitiseDate(d);
               }
               if (d instanceof Date) {
@@ -1127,20 +1127,31 @@ $.fn.calendar = function(parameters) {
           findHourAsObject: function(date, mode, hours) {
             if (mode === 'hour') {
               var d;
+              var hourCheck = function(date, d) {
+                 if (d[metadata.hours]) {
+                    if (typeof d[metadata.hours] === 'number' && date.getHours() == d[metadata.hours]) {
+                      return d;
+                  } else if (Array.isArray(d[metadata.hours])) {
+                    if (d[metadata.hours].indexOf(date.getHours()) > -1) {
+                      return d;
+                    }
+                  }
+                }
+              }
               for (var i = 0; i < hours.length; i++) {
                 d = hours[i];
                 if (typeof d === 'number' && date.getHours() == d) {
                   return null;
                 } else if (d !== null && typeof d === 'object') {
-                  if (d[metadata.days]) {
+                  if (d[metadata.days] && hourCheck(date,d)) {
                     if (typeof d[metadata.days] === 'number' && date.getDay() == d[metadata.days]) {
-                        return d;
+                      return d;
                     } else if (Array.isArray(d[metadata.days])) {
                       if (d[metadata.days].indexOf(date.getDay()) > -1) {
                         return d;
                       }
                     }
-                  } else if (d[metadata.date]) {
+                  } else if (d[metadata.date] && hourCheck(date,d)) {
                     if (d[metadata.date] instanceof Date && module.helper.dateEqual(date, module.helper.sanitiseDate(d[metadata.date]))) {
                       return d;
                     } else if (Array.isArray(d[metadata.date])) {
@@ -1148,14 +1159,8 @@ $.fn.calendar = function(parameters) {
                         return d;
                       }
                     }
-                  } else if (d[metadata.hours]) {
-                    if (typeof d[metadata.hours] === 'number' && date.getHours() == d[metadata.hours]) {
-                      return d;
-                    } else if (Array.isArray(d[metadata.hours])) {
-                      if (d[metadata.hours].indexOf(date.getHours()) > -1) {
-                        return d;
-                      }
-                    }
+                  } else if (hourCheck(date,d)) {
+                    return d;
                   }
                 }
               }

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -392,7 +392,6 @@ $.fn.calendar = function(parameters) {
                     }
                     if (mode === 'hour') {
                       var disabledHour = module.helper.findHourAsObject(cellDate, mode, settings.disabledHours);
-                      console.log(cellDate, disabledHour)
                       if (disabledHour !== null && disabledHour[metadata.message]) {
                         cell.attr("data-tooltip", disabledHour[metadata.message]);
                         cell.attr("data-position", disabledHour[metadata.position] || tooltipPosition);

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -390,6 +390,20 @@ $.fn.calendar = function(parameters) {
                         cell.attr("data-variation", disabledDate[metadata.variation]);
                       }
                     }
+                    if (mode === 'hour') {
+                      var disabledHour = module.helper.findHourAsObject(cellDate, mode, settings.disabledHours);
+                      console.log(cellDate, disabledHour)
+                      if (disabledHour !== null && disabledHour[metadata.message]) {
+                        cell.attr("data-tooltip", disabledHour[metadata.message]);
+                        cell.attr("data-position", disabledHour[metadata.position] || tooltipPosition);
+                        if(disabledHour[metadata.inverted] || (isInverted && disabledHour[metadata.inverted] === undefined)) {
+                          cell.attr("data-inverted", '');
+                        }
+                        if(disabledHour[metadata.variation]) {
+                          cell.attr("data-variation", disabledHour[metadata.variation]);
+                        }
+                      }
+                    }
                   } else {
                     eventDate = module.helper.findDayAsObject(cellDate, mode, settings.eventDates);
                     if (eventDate !== null) {
@@ -972,7 +986,7 @@ $.fn.calendar = function(parameters) {
 
         helper: {
           isDisabled: function(date, mode) {
-            return (mode === 'day' || mode === 'month' || mode === 'year') && ((mode === 'day' && settings.disabledDaysOfWeek.indexOf(date.getDay()) !== -1) || settings.disabledDates.some(function(d){
+            return (mode === 'day' || mode === 'month' || mode === 'year' || mode === 'hour') && (((mode === 'day' && settings.disabledDaysOfWeek.indexOf(date.getDay()) !== -1) || settings.disabledDates.some(function(d){
               if(typeof d === 'string') {
                 d = module.helper.sanitiseDate(d);
               }
@@ -1005,7 +1019,45 @@ $.fn.calendar = function(parameters) {
                   }
                 }
               }
-            }));
+            })) || (mode === 'hour' && settings.disabledHours.some(function(d){
+              if(typeof d === 'string') {
+                d = module.helper.sanitiseDate(d);
+              }
+              if (d instanceof Date) {
+                return module.helper.dateEqual(date, d, mode);
+              } else if (typeof d === 'number') {
+                return date.getHours() === d;
+              }
+              if (d !== null && typeof d === 'object') {
+                var blocked = true;
+
+                if (d[metadata.date]) {
+                  if (d[metadata.date] instanceof Date) {
+                    blocked = module.helper.dateEqual(date, module.helper.sanitiseDate(d[metadata.date]));
+                  } else if (Array.isArray(d[metadata.date])) {
+                    return d[metadata.date].some(function(idate) {
+                      blocked = module.helper.dateEqual(date, idate, mode);
+                    });
+                  }
+                }
+
+                if (d[metadata.days]) {
+                  if (typeof d[metadata.days] === 'number') {
+                    blocked = date.getDay() == d[metadata.days];
+                  } else if (Array.isArray(d[metadata.days])) {
+                    blocked = d[metadata.days].indexOf(date.getDay()) > -1;
+                  }
+                }
+
+                if (d[metadata.hours]) {
+                  if (typeof d[metadata.hours] === 'number') {
+                    return blocked && date.getHours() == d[metadata.hours];
+                  } else if (Array.isArray(d[metadata.hours])) {
+                    return blocked && d[metadata.hours].indexOf(date.getHours()) > -1;
+                  }
+                }
+              }
+            })));
           },
           isEnabled: function(date, mode) {
             if (mode === 'day') {
@@ -1064,6 +1116,44 @@ $.fn.calendar = function(parameters) {
                       return d;
                     } else if (Array.isArray(d[metadata.date])) {
                       if(d[metadata.date].some(function(idate) { return module.helper.dateEqual(date, idate, mode); })) {
+                        return d;
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            return null;
+          },
+          findHourAsObject: function(date, mode, hours) {
+            if (mode === 'hour') {
+              var d;
+              for (var i = 0; i < hours.length; i++) {
+                d = hours[i];
+                if (typeof d === 'number' && date.getHours() == d) {
+                  return null;
+                } else if (d !== null && typeof d === 'object') {
+                  if (d[metadata.days]) {
+                    if (typeof d[metadata.days] === 'number' && date.getDay() == d[metadata.days]) {
+                        return d;
+                    } else if (Array.isArray(d[metadata.days])) {
+                      if (d[metadata.days].indexOf(date.getDay()) > -1) {
+                        return d;
+                      }
+                    }
+                  } else if (d[metadata.date]) {
+                    if (d[metadata.date] instanceof Date && module.helper.dateEqual(date, module.helper.sanitiseDate(d[metadata.date]))) {
+                      return d;
+                    } else if (Array.isArray(d[metadata.date])) {
+                      if (d[metadata.date].some(function(idate) { return module.helper.dateEqual(date, idate, mode); })) {
+                        return d;
+                      }
+                    }
+                  } else if (d[metadata.hours]) {
+                    if (typeof d[metadata.hours] === 'number' && date.getHours() == d[metadata.hours]) {
+                      return d;
+                    } else if (Array.isArray(d[metadata.hours])) {
+                      if (d[metadata.hours].indexOf(date.getHours()) > -1) {
                         return d;
                       }
                     }
@@ -1358,6 +1448,7 @@ $.fn.calendar.settings = {
   multiMonth         : 1,          // show multiple months when in 'day' mode
   minTimeGap         : 5,
   showWeekNumbers    : null,       // show Number of Week at the very first column of a dayView
+  disabledHours      : [],         // specific hour(s) which won't be selectable and contain additional information.
   disabledDates      : [],         // specific day(s) which won't be selectable and contain additional information.
   disabledDaysOfWeek : [],         // day(s) which won't be selectable(s) (0 = Sunday)
   enabledDates       : [],         // specific day(s) which will be selectable, all other days will be disabled
@@ -1763,7 +1854,9 @@ $.fn.calendar.settings = {
     variation: 'variation',
     position: 'position',
     month: 'month',
-    year: 'year'
+    year: 'year',
+    hours: 'hours',
+    days: 'days'
   },
 
   eventClass: 'blue'


### PR DESCRIPTION
## Description
This PR allow some hours to be disabled trough a new parameter called `disabledHours`. It's adapted from @lubber-de's code to disable days.

Hours can be disabled using these patterns:
```js
disabledHours: [
  0, // Midnight will always be disabled
  {
    // Every Saturday and Sunday will be entirely disabled (not this is just an example, not the way to do it...)
    days: [0, 6],
    hours: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
    message: 'We dont work on Saturday and Sunday',
    inverted: true,
    variation: 'basic'
  },
  {
    // Friday afternoon will be disabled
    date: new Date('2021-07-02'),
    hours: [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
    message: 'Sorry this afternoon we are closed !',
    inverted: true
  },
  {
    // All hours between 1 and 7 will be disabled every day
    hours: [1, 2, 3, 4, 5, 6, 7],
    message: 'We are sleeping !'
  },
  {
    // 12h and 13h will be disabled every day
    hours: [12, 13],
    message: 'Lunch time !'
  }
]
```

## Testcase
[JSFiddle](https://jsfiddle.net/lubber/84zwrnud/)

## Screenshot
![Animation](https://i.ibb.co/znbfghG/Animation.gif)

## Closes
#1351, #1598
