### PR TITLE
feat(toast): new centered variant to display in the middle of the screen

### DIFF
--- a/src/definitions/modules/toast.less
+++ b/src/definitions/modules/toast.less
@@ -103,6 +103,11 @@
       bottom: @toastContainerDistance;
     }
   }
+  &.centered when (@variationToastCentered) {
+    transform: translate(-50%, -50%);
+    top: 50%;
+    left: 50%;
+  }
   & .visible.toast-box,
   .animating.toast-box,
   .toast-box {

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -538,6 +538,7 @@
 @variationToastLeft: true;
 @variationToastRight: true;
 @variationToastCenter: true;
+@variationToastCentered: true;
 @variationToastInfo: true;
 @variationToastWarning: true;
 @variationToastSuccess: true;


### PR DESCRIPTION
## Description
This PR adds a new `centered` variant to the toast position to be able to display them in the middle of the screen

```javascript
$('body').toast({
  message: 'I am so centered',
  position: 'centered'
})
```

## Testcase
https://jsfiddle.net/lubber/x3w1gsht/13/

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/124495215-21757980-ddb8-11eb-8c5a-fc8e6d939794.png)
 