### PR TITLE
fix(docs): various typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ Anyone can jump on the issues board and grab off bugs to fix. This is probably t
 - Please try and stick to a similar code style so everyone can read your code.
 - When you commit don't include your dist files, this can cause merge conflicts and also adds unnecessary changes to the PR.
 
-#### Setup your enviroment
+#### Setup your environment
 These few steps are the easiest way to setup your dev environment.
 
 1. Fork the [main repository](https://github.com/fomantic/Fomantic-UI).

--- a/dist/components/dropdown.js
+++ b/dist/components/dropdown.js
@@ -560,7 +560,7 @@ $.fn.dropdown = function(parameters) {
             if(settings.onHide.call(element) !== false) {
               module.animate.hide(function() {
                 module.remove.visible();
-                // hidding search focus
+                // hiding search focus
                 if ( module.is.focusedOnSearch() && preventBlur !== true ) {
                   $search.blur();
                 }

--- a/dist/components/menu.css
+++ b/dist/components/menu.css
@@ -382,7 +382,7 @@
 ---------------*/
 
 
-/* Menu divider shouldnt apply */
+/* Menu divider shouldn't apply */
 .ui.menu .list .item:before {
   background: none !important;
 }
@@ -1252,7 +1252,7 @@ Floated Menu / Item
   opacity: 1;
 }
 
-/* Icon Gylph */
+/* Icon Glyph */
 .ui.icon.menu i.icon:before {
   opacity: 1;
 }

--- a/dist/components/progress.js
+++ b/dist/components/progress.js
@@ -93,7 +93,7 @@ $.fn.progress = function(parameters) {
            *
            * @param min A minimum value within multiple values
            * @param total A total amount of multiple values
-           * @returns {number} A precison. Could be 1, 10, 100, ... 1e+10.
+           * @returns {number} A precision. Could be 1, 10, 100, ... 1e+10.
            */
           derivePrecision: function(min, total) {
             var precisionPower = 0
@@ -991,7 +991,7 @@ $.fn.progress.settings = {
     nonNumeric      : 'Progress value is non numeric',
     tooHigh         : 'Value specified is above 100%',
     tooLow          : 'Value specified is below 0%',
-    sumExceedsTotal : 'Sum of multple values exceed total',
+    sumExceedsTotal : 'Sum of multiple values exceed total',
   },
 
   regExp: {

--- a/dist/components/transition.js
+++ b/dist/components/transition.js
@@ -1097,7 +1097,7 @@ $.fn.transition.settings = {
 
   // possible errors
   error: {
-    noAnimation : 'Element is no longer attached to DOM. Unable to animate.  Use silent setting to surpress this warning in production.',
+    noAnimation : 'Element is no longer attached to DOM. Unable to animate.  Use silent setting to suppress this warning in production.',
     repeated    : 'That animation is already occurring, cancelling repeated animation',
     method      : 'The method you called is not defined',
     support     : 'This browser does not support CSS animations'

--- a/dist/components/visibility.js
+++ b/dist/components/visibility.js
@@ -1237,7 +1237,7 @@ $.fn.visibility.settings = {
   // callback should only occur one time
   once                   : true,
 
-  // callback should fire continuously whe evaluates to true
+  // callback should fire continuously when evaluates to true
   continuous             : false,
 
   // offset to use with scroll top

--- a/dist/semantic.css
+++ b/dist/semantic.css
@@ -46161,7 +46161,7 @@ span.ui.massive.text {
      List
 ---------------*/
 
-/* Menu divider shouldnt apply */
+/* Menu divider shouldn't apply */
 
 .ui.menu .list .item:before {
   background: none !important;
@@ -47128,7 +47128,7 @@ Floated Menu / Item
   opacity: 1;
 }
 
-/* Icon Gylph */
+/* Icon Glyph */
 
 .ui.icon.menu i.icon:before {
   opacity: 1;

--- a/dist/semantic.js
+++ b/dist/semantic.js
@@ -7156,7 +7156,7 @@ $.fn.dropdown = function(parameters) {
             if(settings.onHide.call(element) !== false) {
               module.animate.hide(function() {
                 module.remove.visible();
-                // hidding search focus
+                // hiding search focus
                 if ( module.is.focusedOnSearch() && preventBlur !== true ) {
                   $search.blur();
                 }
@@ -15284,7 +15284,7 @@ $.fn.progress = function(parameters) {
            *
            * @param min A minimum value within multiple values
            * @param total A total amount of multiple values
-           * @returns {number} A precison. Could be 1, 10, 100, ... 1e+10.
+           * @returns {number} A precision. Could be 1, 10, 100, ... 1e+10.
            */
           derivePrecision: function(min, total) {
             var precisionPower = 0
@@ -16182,7 +16182,7 @@ $.fn.progress.settings = {
     nonNumeric      : 'Progress value is non numeric',
     tooHigh         : 'Value specified is above 100%',
     tooLow          : 'Value specified is below 0%',
-    sumExceedsTotal : 'Sum of multple values exceed total',
+    sumExceedsTotal : 'Sum of multiple values exceed total',
   },
 
   regExp: {
@@ -22511,7 +22511,7 @@ $.fn.sticky.settings = {
 
   error         : {
     container      : 'Sticky element must be inside a relative container',
-    visible        : 'Element is hidden, you must call refresh after element becomes visible. Use silent setting to surpress this warning in production.',
+    visible        : 'Element is hidden, you must call refresh after element becomes visible. Use silent setting to suppress this warning in production.',
     method         : 'The method you called is not defined.',
     invalidContext : 'Context specified does not exist',
     elementSize    : 'Sticky element is larger than its container, cannot create sticky.'
@@ -25523,7 +25523,7 @@ $.fn.transition.settings = {
 
   // possible errors
   error: {
-    noAnimation : 'Element is no longer attached to DOM. Unable to animate.  Use silent setting to surpress this warning in production.',
+    noAnimation : 'Element is no longer attached to DOM. Unable to animate.  Use silent setting to suppress this warning in production.',
     repeated    : 'That animation is already occurring, cancelling repeated animation',
     method      : 'The method you called is not defined',
     support     : 'This browser does not support CSS animations'
@@ -25668,7 +25668,7 @@ $.api = $.fn.api = function(parameters) {
                response = JSON.parse(response);
               }
               catch(e) {
-                // isnt json string
+                // isn't json string
               }
             }
             return response;
@@ -28663,7 +28663,7 @@ $.fn.visibility.settings = {
   // callback should only occur one time
   once                   : true,
 
-  // callback should fire continuously whe evaluates to true
+  // callback should fire continuously when evaluates to true
   continuous             : false,
 
   // offset to use with scroll top

--- a/examples/assets/library/iframe-content.js
+++ b/examples/assets/library/iframe-content.js
@@ -779,7 +779,7 @@
       },
 
       offset: function() {
-        return getHeight.bodyOffset(); //Backwards compatability
+        return getHeight.bodyOffset(); //Backwards compatibility
       },
 
       bodyScroll: function getBodyScrollHeight() {
@@ -1029,7 +1029,7 @@
       moveToAnchor: function moveToAnchorF() {
         inPageLinks.findTarget(getData());
       },
-      inPageLink: function inPageLinkF() {this.moveToAnchor();}, //Backward compatability
+      inPageLink: function inPageLinkF() {this.moveToAnchor();}, //Backward compatibility
 
       pageInfo: function pageInfoFromParent() {
         var msgBody = getData();
@@ -1065,7 +1065,7 @@
 
     function isInitMsg() {
       //Test if this message is from a child below us. This is an ugly test, however, updating
-      //the message format would break backwards compatibity.
+      //the message format would break backwards compatibility.
       return event.data.split(':')[2] in {'true':1,'false':1};
     }
 

--- a/examples/assets/library/iframe.js
+++ b/examples/assets/library/iframe.js
@@ -231,7 +231,7 @@
 
     function isMessageFromMetaParent() {
       //Test if this message is from a parent above us. This is an ugly test, however, updating
-      //the message format would break backwards compatibity.
+      //the message format would break backwards compatibility.
       var retCode = messageData.type in {'true':1,'false':1,'undefined':1};
 
       if (retCode) {
@@ -659,7 +659,7 @@
       function warning() {
         if (settings[id] && !settings[id].loaded && !errorShown) {
           errorShown = true;
-          warn(id, 'IFrame has not responded within '+ settings[id].warningTimeout/1000 +' seconds. Check iFrameResizer.contentWindow.js has been loaded in iFrame. This message can be ingored if everything is working, or you can set the warningTimeout option to a higher value or zero to suppress this warning.');
+          warn(id, 'IFrame has not responded within '+ settings[id].warningTimeout/1000 +' seconds. Check iFrameResizer.contentWindow.js has been loaded in iFrame. This message can be ignored if everything is working, or you can set the warningTimeout option to a higher value or zero to suppress this warning.');
         }
       }
 
@@ -941,7 +941,7 @@
     }
 
     if('hidden' !== document.visibilityState) {
-      log('document','Trigger event: Visiblity change');
+      log('document','Trigger event: Visibility change');
       debouce(resize,16);
     }
   }

--- a/src/definitions/behaviors/api.js
+++ b/src/definitions/behaviors/api.js
@@ -132,7 +132,7 @@ $.api = $.fn.api = function(parameters) {
                response = JSON.parse(response);
               }
               catch(e) {
-                // isnt json string
+                // isn't json string
               }
             }
             return response;

--- a/src/definitions/behaviors/visibility.js
+++ b/src/definitions/behaviors/visibility.js
@@ -1237,7 +1237,7 @@ $.fn.visibility.settings = {
   // callback should only occur one time
   once                   : true,
 
-  // callback should fire continuously whe evaluates to true
+  // callback should fire continuously when evaluates to true
   continuous             : false,
 
   // offset to use with scroll top

--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -372,7 +372,7 @@
      List
 ---------------*/
 
-/* Menu divider shouldnt apply */
+/* Menu divider shouldn't apply */
 .ui.menu .list .item:before {
   background: none !important;
 }
@@ -1232,7 +1232,7 @@ Floated Menu / Item
   opacity: 1;
 }
 
-/* Icon Gylph */
+/* Icon Glyph */
 .ui.icon.menu i.icon:before {
   opacity: 1;
 }

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -560,7 +560,7 @@ $.fn.dropdown = function(parameters) {
             if(settings.onHide.call(element) !== false) {
               module.animate.hide(function() {
                 module.remove.visible();
-                // hidding search focus
+                // hiding search focus
                 if ( module.is.focusedOnSearch() && preventBlur !== true ) {
                   $search.blur();
                 }

--- a/src/definitions/modules/progress.js
+++ b/src/definitions/modules/progress.js
@@ -93,7 +93,7 @@ $.fn.progress = function(parameters) {
            *
            * @param min A minimum value within multiple values
            * @param total A total amount of multiple values
-           * @returns {number} A precison. Could be 1, 10, 100, ... 1e+10.
+           * @returns {number} A precision. Could be 1, 10, 100, ... 1e+10.
            */
           derivePrecision: function(min, total) {
             var precisionPower = 0
@@ -991,7 +991,7 @@ $.fn.progress.settings = {
     nonNumeric      : 'Progress value is non numeric',
     tooHigh         : 'Value specified is above 100%',
     tooLow          : 'Value specified is below 0%',
-    sumExceedsTotal : 'Sum of multple values exceed total',
+    sumExceedsTotal : 'Sum of multiple values exceed total',
   },
 
   regExp: {

--- a/src/definitions/modules/sticky.js
+++ b/src/definitions/modules/sticky.js
@@ -938,7 +938,7 @@ $.fn.sticky.settings = {
 
   error         : {
     container      : 'Sticky element must be inside a relative container',
-    visible        : 'Element is hidden, you must call refresh after element becomes visible. Use silent setting to surpress this warning in production.',
+    visible        : 'Element is hidden, you must call refresh after element becomes visible. Use silent setting to suppress this warning in production.',
     method         : 'The method you called is not defined.',
     invalidContext : 'Context specified does not exist',
     elementSize    : 'Sticky element is larger than its container, cannot create sticky.'

--- a/src/definitions/modules/transition.js
+++ b/src/definitions/modules/transition.js
@@ -1097,7 +1097,7 @@ $.fn.transition.settings = {
 
   // possible errors
   error: {
-    noAnimation : 'Element is no longer attached to DOM. Unable to animate.  Use silent setting to surpress this warning in production.',
+    noAnimation : 'Element is no longer attached to DOM. Unable to animate.  Use silent setting to suppress this warning in production.',
     repeated    : 'That animation is already occurring, cancelling repeated animation',
     method      : 'The method you called is not defined',
     support     : 'This browser does not support CSS animations'

--- a/tasks/admin/components/init.js
+++ b/tasks/admin/components/init.js
@@ -6,8 +6,8 @@
 
  This task pulls the latest version of each component from GitHub
 
-  * Creates new repo if doesnt exist (locally & GitHub)
-  * Adds remote it doesnt exists
+  * Creates new repo if doesn't exist (locally & GitHub)
+  * Adds remote it doesn't exists
   * Pulls latest changes from repo
 
 */

--- a/tasks/admin/distributions/init.js
+++ b/tasks/admin/distributions/init.js
@@ -6,8 +6,8 @@
 
  This task pulls the latest version of distribution from GitHub
 
-  * Creates new repo if doesnt exist (locally & GitHub)
-  * Adds remote it doesnt exists
+  * Creates new repo if doesn't exist (locally & GitHub)
+  * Adds remote it doesn't exists
   * Pulls latest changes from repo
 
 */


### PR DESCRIPTION
Found via `codespell -q 3 -S *.min.js,CHANGELOG.md -L adn,ba,te,ue,varius`