### PR TITLE
fix(api): source typos

### DIFF
--- a/examples/assets/library/iframe-content.js
+++ b/examples/assets/library/iframe-content.js
@@ -746,12 +746,12 @@
     return maxVal;
   }
 
-  function getAllMeasurements(dimention) {
+  function getAllMeasurements(dimension) {
     return [
-      dimention.bodyOffset(),
-      dimention.bodyScroll(),
-      dimention.documentElementOffset(),
-      dimention.documentElementScroll()
+      dimension.bodyOffset(),
+      dimension.bodyScroll(),
+      dimension.documentElementOffset(),
+      dimension.documentElementScroll()
     ];
   }
 

--- a/src/definitions/behaviors/api.js
+++ b/src/definitions/behaviors/api.js
@@ -334,7 +334,7 @@ $.api = $.fn.api = function(parameters) {
           cancelled: function() {
             return (module.cancelled || false);
           },
-          succesful: function() {
+          successful: function() {
             module.verbose('This behavior will be deleted due to typo. Use "was successful" instead.');
             return module.was.successful();
           },

--- a/src/definitions/behaviors/api.js
+++ b/src/definitions/behaviors/api.js
@@ -335,10 +335,6 @@ $.api = $.fn.api = function(parameters) {
             return (module.cancelled || false);
           },
           successful: function() {
-            module.verbose('This behavior will be deleted due to typo. Use "was successful" instead.');
-            return module.was.successful();
-          },
-          successful: function() {
             return (module.request && module.request.state() == 'resolved');
           },
           failure: function() {

--- a/test/helpers/sinon.js
+++ b/test/helpers/sinon.js
@@ -4232,7 +4232,7 @@ if (typeof module !== 'undefined' && module.exports) {
  * Add-on for sinon.fakeServer that automatically handles a fake timer along with
  * the FakeXMLHttpRequest. The direct inspiration for this add-on is jQuery
  * 1.3.x, which does not use xhr object's onreadystatehandler at all - instead,
- * it polls the object for completion with setInterval. Dispite the direct
+ * it polls the object for completion with setInterval. Despite the direct
  * motivation, there is nothing jQuery-specific in this file, so it can be used
  * in any environment where the ajax implementation depends on setInterval or
  * setTimeout.


### PR DESCRIPTION
Found via `codespell -q 3 -S ./dist.*.min.js,CHANGELOG.md -L adn,ba,te,ue,varius