### PR TITLE
fix(rating): partial rating needs webkit prefix

### DIFF
--- a/src/definitions/modules/rating.less
+++ b/src/definitions/modules/rating.less
@@ -69,14 +69,20 @@
   color: @activeColor;
 }
 
-/* Partially Active Icon */
-.ui.rating .icon.partial.active {
-  background: linear-gradient(to right, @activeColor 0% var(--full), @inactiveColor var(--full) 100%);
-  -webkit-background-clip: text;
-  background-clip: text;
-  color: transparent;
-}
+& when (@variationRatingPartial) {
+  /* Partially Active Icon */
+  .ui.rating .icon.partial.active {
+    background: linear-gradient(to right, @activeColor 0% var(--full), @inactiveColor var(--full) 100%);
+  }
 
+  /* central override for colors */
+  .ui.ui.rating .icon.partial.active {
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    text-shadow: none;
+  }
+}
 /* Selected Icon */
 .ui.rating .icon.selected,
 .ui.rating .icon.selected.active,
@@ -117,12 +123,11 @@ each(@colors, {
     -webkit-text-stroke: unset;
     background-clip: unset;
   }
-  .ui.@{color}.rating .icon.partial.active {
-    background: linear-gradient(to right, @l 0% var(--full), @inactiveColor var(--full) 100%);
-    text-shadow: none;
-    -webkit-text-stroke: @c 0.78px;
-    background-clip: text;
-    color: transparent;
+  & when (@variationRatingPartial) {
+    .ui.@{color}.rating .icon.partial.active {
+      background: linear-gradient(to right, @l 0% var(--full), @inactiveColor var(--full) 100%);
+      -webkit-text-stroke: @c 0.78px;
+    }
   }
 })
 

--- a/src/definitions/modules/rating.less
+++ b/src/definitions/modules/rating.less
@@ -72,6 +72,7 @@
 /* Partially Active Icon */
 .ui.rating .icon.partial.active {
   background: linear-gradient(to right, @activeColor 0% var(--full), @inactiveColor var(--full) 100%);
+  -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
 }

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -485,6 +485,7 @@
 
 /* Rating */
 @variationRatingDisabled: true;
+@variationRatingPartial: true;
 @variationRatingSizes: @variationAllSizes;
 
 /* Search */


### PR DESCRIPTION
## Description

The autoprefixer was not creating the vendor specific attributes for the rating module anymore, making partial ratings not visually work in chrome/webkit based browsers.

## Testcase
Try in Chrome

### Broken
https://jsfiddle.net/lubber/2tayv1h0/12/

### Fixed
https://jsfiddle.net/lubber/2tayv1h0/10/

## Screenshot

|Broken|Fixed|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/126663620-1a11b27a-7d58-4dd7-9193-d1700404b123.png)|![image](https://user-images.githubusercontent.com/18379884/126663687-eff5c1ce-ecaa-4317-aa39-ec18ab589820.png)|

