### PR TITLE
fix(form): avoid double submit on enterkey

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -419,6 +419,7 @@ $.fn.form = function(parameters) {
                   $field.one('keyup' + eventNamespace, module.event.field.keyup);
                   module.submit();
                   module.debug('Enter pressed on input submitting form');
+                  event.preventDefault();
                 }
                 keyHeldDown = true;
               }

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1597,7 +1597,7 @@ $.fn.form.settings = {
   selector : {
     checkbox   : 'input[type="checkbox"], input[type="radio"]',
     clear      : '.clear',
-    field      : 'input:not(.search):not([type="file"]), textarea, select',
+    field      : 'input:not(.search):not([type="file"]):not([type="reset"]):not([type="button"]):not([type="submit"]), textarea, select',
     group      : '.field',
     input      : 'input:not([type="file"])',
     message    : '.error.message',


### PR DESCRIPTION
## Description
Whenever the enter key is pressed inside a form field, it triggers a form submit. However, this is also a browser default behavior, thus the event was called twice. Especially for IE11 this was causing the normal submit to not function anymore. 
I also made sure that native input fields of type "reset", "button" or "submit" are not fetched for input validation anymore (just in case someone would try). A native "reset" button would otherwise also submit the form (when enter is pressed on focussed button)

## Testcase
- Click into the name field and press enter
- Watch console

### Broken
obsubmit is called twice
https://jsfiddle.net/lubber/r4egcLwp/4/

### Fixed
obsubmit is called once
https://jsfiddle.net/lubber/r4egcLwp/2/

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5824

