### PR TITLE
feat(calendar): new default constantheight false

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -1433,7 +1433,7 @@ $.fn.calendar.settings = {
 
   type               : 'datetime', // picker type, can be 'datetime', 'date', 'time', 'month', or 'year'
   firstDayOfWeek     : 0,          // day for first day column (0 = Sunday)
-  constantHeight     : true,       // add rows to shorter months to keep day calendar height consistent (6 rows)
+  constantHeight     : false,      // add rows to shorter months to keep day calendar height consistent (6 rows)
   today              : false,      // show a 'today/now' button at the bottom of the calendar
   closable           : true,       // close the popup after selecting a date/time
   monthFirst         : true,       // month before day when parsing/converting date from/to text


### PR DESCRIPTION
## Description
As proposed in https://github.com/fomantic/Fomantic-UI/discussions/1745#discussioncomment-120894 this PR changes the default value for `constantheight` to `false`.

Whenever the first of a month is shown within the first 5 columns of a calendar, then, according to the months amount of days, a full adjacent row is added to the calendar, which is unnecessary in most cases, so i suggest to turn this setting off by default

As this is a breaking change it is supposed to be part of 2.9

### Screencapture
![calendar-height](https://user-images.githubusercontent.com/127635/128796142-32d391db-febe-4056-8c25-c74f0d1963a9.gif)
