### PR TITLE
Update dependabot badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A community fork of the popular Semantic-UI framework.
 
 [![Package Quality](https://npm.packagequality.com/shield/fomantic-ui.svg?label=package%20quality)](https://packagequality.com/#?package=fomantic-ui)
 [![GitHub contributors](https://img.shields.io/github/contributors/fomantic/Fomantic-UI)](https://github.com/fomantic/Fomantic-UI/graphs/contributors)
-[![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=fomantic/Fomantic-UI)](https://dependabot.com)
+[![Dependabot Status](https://badgen.net/github/dependabot/fomantic/Fomantic-UI/?icon=dependabot)](https://github.com/features/security)
 [![Known Vulnerabilities](https://snyk.io/test/github/fomantic/Fomantic-UI/badge.svg?targetFile=package.json)](https://snyk.io/test/github/fomantic/Fomantic-UI?targetFile=package.json)
 
 ---


### PR DESCRIPTION
## Description
After github has acquired dependabot, the badge is not working anymore

## Screenshot
|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/129543329-43405c8c-863d-4c85-ba83-f6ccf8039373.png)|![image](https://user-images.githubusercontent.com/18379884/129543976-bdc808dc-0bd4-4941-93e3-3ac5da1d7539.png)|