### PR TITLE
fix(checkbox): show pointer on css only linked labels

### DIFF
--- a/src/definitions/modules/checkbox.less
+++ b/src/definitions/modules/checkbox.less
@@ -266,6 +266,7 @@
 }
 
 /* Selectable Label */
+.ui.checkbox input + label[for],
 .ui.checkbox input.hidden + label {
   cursor: pointer;
   user-select: none;


### PR DESCRIPTION
## Description
CSS Only checkboxes without Javascript which have linked labels (`<label for="id">`) to be (un) checked by clicking on its label did not have any pointer indicators and text was selected on dragging.

## Testcase
Hover on the Labels (HTML+CSS Only) 

### Bad
- No pointer indicator
- Dragging selects text

https://jsfiddle.net/lubber/xhrjdu0p/8/

### Good
- Pointer is shown on hover
- Text doesn't get selected

https://jsfiddle.net/lubber/xhrjdu0p/10/

## Screenshots
|Bad|Good|
|-|-|
|![csscheckboxlabel](https://user-images.githubusercontent.com/18379884/129558873-b412cca0-6772-43ff-99f4-b83214a3f98f.gif)|![csscheckboxlabel_fixed](https://user-images.githubusercontent.com/18379884/129558908-305269eb-cd03-4f98-8247-7c27e426f579.gif)|

