### PR TITLE
fix(dropdown): non selection and button upward variant border radius

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -1228,7 +1228,9 @@ select.ui.dropdown {
     top: auto;
     bottom: 100%;
     box-shadow: @upwardMenuBoxShadow;
-    border-radius: @upwardMenuBorderRadius;
+  }
+  .ui.upward.selection.dropdown > .menu {
+    border-radius: @upwardSelectionMenuBorderRadius;
   }
 
   /* Upward Sub Menu */

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -367,8 +367,14 @@
   .ui.dropdown.icon.button > .dropdown.icon {
     margin: 0;
   }
-  .ui.button.dropdown .menu {
+  .ui.dropdown.button .menu {
     min-width: 100%;
+  }
+  .ui.dropdown.button:not(.pointing):not(.floating).active {
+    border-radius: @borderRadius @borderRadius 0 0;
+  }
+  .ui.dropdown.button:not(.pointing):not(.floating) > .menu {
+    border-radius: 0 0 @borderRadius @borderRadius;
   }
 }
 
@@ -1229,9 +1235,6 @@ select.ui.dropdown {
     bottom: 100%;
     box-shadow: @upwardMenuBoxShadow;
   }
-  .ui.upward.selection.dropdown > .menu {
-    border-radius: @upwardSelectionMenuBorderRadius;
-  }
 
   /* Upward Sub Menu */
   .ui.dropdown .upward.menu {
@@ -1239,42 +1242,54 @@ select.ui.dropdown {
     bottom: 0 !important;
   }
 
-  /* Active Upward */
-  .ui.simple.upward.active.dropdown,
-  .ui.simple.upward.dropdown:hover {
-    border-radius: @borderRadius @borderRadius 0 0 !important;
-  }
-  .ui.upward.dropdown.button:not(.pointing):not(.floating).active {
-    border-radius: @borderRadius @borderRadius 0 0;
-  }
-
-  /* Selection */
-  .ui.upward.selection.dropdown .menu {
-    border-top-width: @menuBorderWidth !important;
-    border-bottom-width: 0 !important;
-    box-shadow: @upwardSelectionMenuBoxShadow;
-  }
-  .ui.upward.selection.dropdown:hover {
-    box-shadow: @upwardSelectionHoverBoxShadow;
+  & when (@variationDropdownSimple) {
+    /* Active Upward */
+    .ui.simple.upward.active.dropdown,
+    .ui.simple.upward.dropdown:hover {
+      border-radius: @borderRadius @borderRadius 0 0 !important;
+    }
   }
 
-  /* Active Upward */
-  .ui.active.upward.selection.dropdown {
-    border-radius: @upwardSelectionVisibleBorderRadius !important;
+  & when (@variationDropdownButton) {
+    /* Button */
+    .ui.upward.dropdown.button:not(.pointing):not(.floating).active {
+      border-radius: 0 0 @borderRadius @borderRadius;
+    }
+    .ui.upward.dropdown.button:not(.pointing):not(.floating) > .menu {
+      border-radius: @borderRadius @borderRadius 0 0;
+    }
   }
 
-  /* Visible Upward */
-  .ui.upward.selection.dropdown.visible {
-    box-shadow: @upwardSelectionVisibleBoxShadow;
-    border-radius: @upwardSelectionVisibleBorderRadius !important;
-  }
+  & when (@variationDropdownSelection) {
+    /* Selection */
+    .ui.upward.selection.dropdown .menu {
+      border-top-width: @menuBorderWidth !important;
+      border-bottom-width: 0 !important;
+      box-shadow: @upwardSelectionMenuBoxShadow;
+      border-radius: @upwardSelectionMenuBorderRadius;
+    }
+    .ui.upward.selection.dropdown:hover {
+      box-shadow: @upwardSelectionHoverBoxShadow;
+    }
 
-  /* Visible Hover Upward */
-  .ui.upward.active.selection.dropdown:hover {
-    box-shadow: @upwardSelectionActiveHoverBoxShadow;
-  }
-  .ui.upward.active.selection.dropdown:hover .menu {
-    box-shadow: @upwardSelectionActiveHoverMenuBoxShadow;
+    /* Active Upward */
+    .ui.active.upward.selection.dropdown {
+      border-radius: @upwardSelectionVisibleBorderRadius !important;
+    }
+
+    /* Visible Upward */
+    .ui.upward.selection.dropdown.visible {
+      box-shadow: @upwardSelectionVisibleBoxShadow;
+      border-radius: @upwardSelectionVisibleBorderRadius !important;
+    }
+
+    /* Visible Hover Upward */
+    .ui.upward.active.selection.dropdown:hover {
+      box-shadow: @upwardSelectionActiveHoverBoxShadow;
+    }
+    .ui.upward.active.selection.dropdown:hover .menu {
+      box-shadow: @upwardSelectionActiveHoverMenuBoxShadow;
+    }
   }
 }
 

--- a/src/themes/default/modules/dropdown.variables
+++ b/src/themes/default/modules/dropdown.variables
@@ -345,7 +345,7 @@
 @upwardSelectionVisibleBorderRadius: @selectionVisibleConnectingBorder @selectionVisibleConnectingBorder @borderRadius @borderRadius;
 @upwardMenuBoxShadow: 0 0 3px 0 rgba(0, 0, 0, 0.08);
 @upwardSelectionMenuBoxShadow: 0 -2px 3px 0 rgba(0, 0, 0, 0.08);
-@upwardMenuBorderRadius: @borderRadius @borderRadius 0 0;
+@upwardSelectionMenuBorderRadius: @borderRadius @borderRadius 0 0;
 @upwardSelectionHoverBoxShadow: 0 0 2px 0 rgba(0, 0, 0, 0.05);
 @upwardSelectionVisibleBoxShadow: 0 0 3px 0 rgba(0, 0, 0, 0.08);
 @upwardSelectionActiveHoverBoxShadow: 0 0 3px 0 rgba(0, 0, 0, 0.05);


### PR DESCRIPTION
## Description
A dropdown menu in a non-selection dropdown did not have a rounded bottom border radius (this is only needed for the selection variant)

Tagged as breaking change, because i changed the variable name (it was used only once and is now dedicated to the selection variant)

## Testcase
Watch the bottom corners of the dropdown menu:
#### Broken
No bottom border radius
https://jsfiddle.net/lubber/wa2fo1pq/20/

#### Fixed
border radius
https://jsfiddle.net/lubber/wa2fo1pq/22/

## Screenshot
|Broken|Fixed|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/129742930-cb0ffaed-0c1d-47ea-8a19-a26cf11c5107.png)|![image](https://user-images.githubusercontent.com/18379884/129742985-f671246a-6d38-4c83-b5a6-97f2d7ee6030.png)|

## Fixed `dropdown button` as well
The `dropdown button` was also not correctly styled (not even the downward version)

### Downward/default
|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/129752718-57ac049f-143a-400f-841c-cb1025d4889c.png)|![image](https://user-images.githubusercontent.com/18379884/129752655-a88b1b4a-1da8-406a-b50a-dcea5265dc94.png)|

### Upward
|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/129752291-c2e0cb1c-e19c-4141-8a3a-85a151cc79a8.png)|![image](https://user-images.githubusercontent.com/18379884/129752435-ea5469d4-b9c3-4ee4-8729-d05f950cea9e.png)|

## Closes
#2075 