### PR TITLE
feat(checkbox): detect on as checked and add checkbox string values

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1086,11 +1086,14 @@ $.fn.form = function(parameters) {
                 }
                 else if(isCheckbox) {
                   module.verbose('Setting checkbox value', value, $element);
-                  if(value === true || value === 1) {
+                  if(value === true || value === 1 || value === 'on') {
                     $element.checkbox('check');
                   }
                   else {
                     $element.checkbox('uncheck');
+                  }
+                  if(typeof value === 'string') {
+                    $field.val(value);
                   }
                 }
                 else if(isDropdown) {


### PR DESCRIPTION
## Description
Using `set values` for a checkbox field inside a form will only accept "true" or "1" to recognize the field as checked.
However, the standard value for a checked checkbox (when retrieved by "get values") is "on". 

This PR now accepts a possible "on" value for given checkbox fields to also check the checkbox to have the same bahavior.

In addition, any string value will now be set as value for the checkbox as well. (This is valid specification as of https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input/checkbox#value), but any other string than "on" will not check the checkbox.

## Testcase
Watch the second checkbox at the bottom. It will be given "on" as value.
 
### Before
Not checked
https://jsfiddle.net/lubber/yhzqf9be/11/

### After
Checked
https://jsfiddle.net/lubber/yhzqf9be/12/

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6607#issuecomment-901157734
