### PR TITLE
feat(grid): stretched rows not broken on tablet size

### DIFF
--- a/src/definitions/collections/grid.less
+++ b/src/definitions/collections/grid.less
@@ -1478,11 +1478,14 @@ each(@colors, {
     }
     .ui.grid > .doubling.row > .column,
     .ui.doubling.grid > .row > .column {
-      display: inline-block !important;
       padding-top: (@rowSpacing / 2) !important;
       padding-bottom: (@rowSpacing / 2) !important;
       box-shadow: none !important;
       margin: 0;
+    }
+    .ui.grid:not(.stretched) > .doubling.row:not(.stretched) > .column:not(.stretched),
+    .ui.doubling.grid:not(.stretched) > .row:not(.stretched) > .column:not(.stretched) {
+      display: inline-block !important;
     }
     .ui[class*="two column"].doubling.grid > .row > .column,
     .ui[class*="two column"].doubling.grid > .column:not(.row),


### PR DESCRIPTION
## Description
A `stretched row` inside `doubling grid` was not stretched on tablet size.

Yes, i left the `!important` in because there are many grid selector combinations where it probably breaks other situations which would need much more investigation. As the !important was there before, i decided to leave it in for now.

## Testcase
https://jsfiddle.net/lubber/e97w2g5k/7/

Remove CSS and resize viewport to see issue (as shown below)

## Screenshot
![stretchedrow](https://user-images.githubusercontent.com/18379884/130088800-85cef03c-6174-4dfe-8d98-ee3b0bf943fe.gif)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5989