### PR TITLE
feat(segment):larger margin only for tab attached segment

### DIFF
--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -735,7 +735,7 @@ each(@colors,{
   }
 
   /* Top */
-  .ui[class*="top attached"].segment {
+  .ui.segment[class*="top attached"] {
     bottom: 0;
     margin-bottom: 0;
     top: @attachedTopOffset;
@@ -744,6 +744,9 @@ each(@colors,{
   }
   .ui.segment[class*="top attached"]:first-child {
     margin-top: 0;
+  }
+  .ui.tab.segment[class*="top attached"]:first-child {
+    margin-top: @verticalMargin;
   }
 
   /* Bottom */
@@ -756,6 +759,9 @@ each(@colors,{
     border-radius: 0 0 @borderRadius @borderRadius;
   }
   .ui.segment[class*="bottom attached"]:last-child {
+    margin-bottom: 0;
+  }
+  .ui.tab.segment[class*="bottom attached"]:last-child {
     margin-bottom: @verticalMargin;
   }
 }


### PR DESCRIPTION
## Description
This PR corrects #19 
@hammy2899 already smelled it somehow [by his comment](https://github.com/fomantic/Fomantic-UI/pull/19#issuecomment-396199507) 😄 

[The related issue](https://github.com/Semantic-Org/Semantic-UI/issues/5408) was related to `tab attached segments`, but the fix was applied to all attached segments.
This now had impact in some other (non tab) situations.
Most recognizable when an attached segment is used inside a stretched grid row. (See screenshots below)

I also fixed the same situation for `top attached tab segments` (it was the same issue, but not mentioned/used)

## Testcase

### Before
https://jsfiddle.net/lubber/m1vne69p/25

### After
https://jsfiddle.net/lubber/m1vne69p/26

## Screenshots
Watch three areas
- the bottom margin of the attached segments in the upper area
- the bottom tabs when switching between the first 2 tabs
- the height of the lower stretched column grid

![tabsegmentmargin](https://user-images.githubusercontent.com/18379884/130130753-0a76cd7f-c9ed-4874-bf2d-4d7a9be2bbc0.gif)


## Closes (again)
https://github.com/Semantic-Org/Semantic-UI/issues/5408



