### PR TITLE
feat(menu): centered variant

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -1476,6 +1476,14 @@ each(@colors, {
   }
 }
 
+& when (@variationMenuCentered) {
+  .ui.centered.menu {
+    display: inline-flex;
+    transform: translateX(-50%);
+    margin-left:50%;
+  }
+}
+
 & when (@variationMenuInverted) {
   /*--------------
       Inverted

--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -1477,6 +1477,7 @@ each(@colors, {
 }
 
 & when (@variationMenuCentered) {
+  .ui.center.aligned.menu,
   .ui.centered.menu {
     display: inline-flex;
     transform: translateX(-50%);

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -267,6 +267,7 @@
 @variationMenuLabeled: true;
 @variationMenuStackable: true;
 @variationMenuFloated: true;
+@variationMenuCentered: true;
 @variationMenuFitted: true;
 @variationMenuBorderless: true;
 @variationMenuCompact: true;


### PR DESCRIPTION
## Description

A `centered` variant. I also added the alias `center aligned` as we have both of this wordings already in other elements.

Especially useful for `pagination` menu

## Testcase
https://jsfiddle.net/lubber/r4egcLwp/16/

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/130300253-29b9a30c-e247-482d-80ed-66112f6e1726.png)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/2921