### PR TITLE
fix(menu): attached text menu had borders

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -1861,7 +1861,7 @@ each(@colors, {
   }
 
   /* Tabular Attached */
-  .ui.attached.menu:not(.tabular) {
+  .ui.attached.menu:not(.tabular):not(.text) {
     border: @attachedBorder;
   }
   & when (@variationMenuInverted) {

--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -730,7 +730,7 @@ each(@colors,{
     box-shadow: @attachedBoxShadow;
     border: @attachedBorder;
   }
-  .ui.attached:not(.message) + .ui.attached.segment:not(.top) {
+  .ui.attached:not(.message):not(.text) + .ui.attached.segment:not(.top) {
     border-top: none;
   }
 


### PR DESCRIPTION
## Description

An `attached text menu` still had borders

## Testcase
Remove CSS to see issue
http://jsfiddle.net/lubber/o1dzf6rs/10/
 
## Screenshot
|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/130334796-1ea70e26-c4d5-4f39-9215-82c9fba83232.png)|![image](https://user-images.githubusercontent.com/18379884/130334811-147d530b-345f-437d-aa8f-155522887b97.png)|

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5205
