### PR TITLE
feat(input): support invalid pseudoclass

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -578,7 +578,14 @@
       box-shadow: @formStates[@@state][boxShadow];
     }
     & when (@state=error) {
-      .ui.form .field input:invalid {
+      .ui.form .field input:not(:placeholder-shown):invalid {
+        color: @c;
+        background: @bg;
+        border-color: @formStates[@@state][borderColor];
+        border-radius: @formStates[@@state][borderRadius];
+        box-shadow: @formStates[@@state][boxShadow];
+      }
+      .ui.form .field input:not(:-ms-input-placeholder):invalid {
         color: @c;
         background: @bg;
         border-color: @formStates[@@state][borderColor];

--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -577,6 +577,15 @@
       border-radius: @formStates[@@state][borderRadius];
       box-shadow: @formStates[@@state][boxShadow];
     }
+    & when (@state=error) {
+      .ui.form .field input:invalid {
+        color: @c;
+        background: @bg;
+        border-color: @formStates[@@state][borderColor];
+        border-radius: @formStates[@@state][borderRadius];
+        box-shadow: @formStates[@@state][boxShadow];
+      }
+    }
 
     .ui.form .field.@{state} textarea:focus,
     .ui.form .field.@{state} select:focus,

--- a/src/definitions/elements/input.less
+++ b/src/definitions/elements/input.less
@@ -184,7 +184,13 @@
       box-shadow: @formStates[@@state][boxShadow];
     }
     & when (@state=error) {
-      .ui.input > input:invalid {
+      .ui.input > input:not(:placeholder-shown):invalid {
+        background-color: @formStates[@@state][background];
+        border-color: @formStates[@@state][borderColor];
+        color: @formStates[@@state][color];
+        box-shadow: @formStates[@@state][boxShadow];
+      }
+      .ui.input > input:not(:-ms-input-placeholder):invalid {
         background-color: @formStates[@@state][background];
         border-color: @formStates[@@state][borderColor];
         color: @formStates[@@state][color];

--- a/src/definitions/elements/input.less
+++ b/src/definitions/elements/input.less
@@ -183,6 +183,14 @@
       color: @formStates[@@state][color];
       box-shadow: @formStates[@@state][boxShadow];
     }
+    & when (@state=error) {
+      .ui.input > input:invalid {
+        background-color: @formStates[@@state][background];
+        border-color: @formStates[@@state][borderColor];
+        color: @formStates[@@state][color];
+        box-shadow: @formStates[@@state][boxShadow];
+      }
+    }
 
     /* Placeholder */
     .ui.input.@{state} > input::-webkit-input-placeholder {


### PR DESCRIPTION
## Description
New native input types like "week", "date", "email", "url" etc. have a browser inbuild validation.
When those get invalid the pseudo selector `:invalid` is set. In general all input field types, which have the `required` attribute set and are empty, are considered invalid. 

This PR adds the error class styling to such input elements by default. If nothing has been entered in such fields, those are not considered invalid (as long as they do not also have the `required` attribute set).

I decided to only show the invalid error colors when there is either something entered invalid or no placeholder is given. This way one can decide to not show the error colors on empty fields (initial forms) by defining a placeholder (even a " " works , if somebody does not want a textual placeholder set).

## Testcase
Enter something invalid and the fields get automatically styled, even though no js form validation is triggered
https://jsfiddle.net/lubber/947q8xve/66/

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/130337124-1233f7e6-0ac4-4950-abe6-8bff52f7428a.png)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6618