### PR TITLE
feat(chore): color list for each component separately

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -310,9 +310,9 @@
 /*--------------------
    Types of Messages
 ---------------------*/
-& when (@variationFormStates) {
-  each(@formStates, {
-    @state: replace(@key, '@', '');
+& when not (@variationFormStates = false) {
+  each(@variationFormStates, {
+    @state: @value;
     .ui.form .@{state}.message,
     .ui.form .@{state}.message:empty {
       display: none;
@@ -481,12 +481,12 @@
   -webkit-appearance: none;
 }
 
-& when (@variationFormStates) {
+& when not (@variationFormStates = false) {
   /*--------------------
           States
   ---------------------*/
-  each(@formStates, {
-    @state: replace(@key, '@', '');
+  each(@variationFormStates, {
+    @state: @value;
     @c: @formStates[@@state][color];
     @bg: @formStates[@@state][background];
     @bdc: @formStates[@@state][borderColor];

--- a/src/definitions/collections/grid.less
+++ b/src/definitions/collections/grid.less
@@ -1306,18 +1306,19 @@
 /*----------------------
          Colored
 -----------------------*/
+& when not (@variationGridColors = false) {
+  each(@variationGridColors, {
+    @color: @value;
+    @c: @colors[@@color][color];
 
-each(@colors, {
-  @color: replace(@key, '@', '');
-  @c: @colors[@@color][color];
-
-  .ui.grid > .@{color}.row,
-  .ui.grid > .@{color}.column,
-  .ui.grid > .row > .@{color}.column {
-    background-color: @c;
-    color: @white;
-  }
-})
+    .ui.grid > .@{color}.row,
+    .ui.grid > .@{color}.column,
+    .ui.grid > .row > .@{color}.column {
+      background-color: @c;
+      color: @white;
+    }
+  })
+}
 
 
 /*----------------------

--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -1339,22 +1339,23 @@ Floated Menu / Item
 /*--------------
      Colors
 ---------------*/
+& when not (@variationMenuColors = false) {
+  each(@variationMenuColors, {
+    @color: @value;
+    @c: @colors[@@color][color];
 
-each(@colors, {
-  @color: replace(@key, '@', '');
-  @c: @colors[@@color][color];
-
-  & when not (@color=secondary) {
-    .ui.ui.ui.menu .@{color}.active.item,
-    .ui.ui.@{color}.menu .active.item:hover,
-    .ui.ui.@{color}.menu .active.item {
-      & when not (@secondaryPointingActiveBorderColor = currentColor) {
-        border-color: @c;
+    & when not (@color=secondary) {
+      .ui.ui.ui.menu .@{color}.active.item,
+      .ui.ui.@{color}.menu .active.item:hover,
+      .ui.ui.@{color}.menu .active.item {
+        & when not (@secondaryPointingActiveBorderColor = currentColor) {
+          border-color: @c;
+        }
+        color: @c;
       }
-      color: @c;
     }
-  }
-})
+  })
+}
 
 & when (@variationMenuInverted) {
   /*--------------
@@ -1489,30 +1490,31 @@ each(@colors, {
   /*--------------
       Inverted
   ---------------*/
+  & when not (@variationMenuColors = false) {
+    each(@variationMenuColors, {
+      @color: @value;
+      @c: @colors[@@color][color];
+      @h: @colors[@@color][hover];
 
-  each(@colors, {
-    @color: replace(@key, '@', '');
-    @c: @colors[@@color][color];
-    @h: @colors[@@color][hover];
-
-    & when not (@color=secondary) {
-      .ui.ui.ui.inverted.menu .@{color}.active.item,
-      .ui.ui.inverted.@{color}.menu {
-        background-color: @c;
-      }
-      .ui.inverted.@{color}.menu .item:before {
-        background-color: @invertedColoredDividerBackground;
-      }
-      .ui.ui.inverted.@{color}.menu .active.item {
-        background-color: @invertedColoredActiveBackground;
-      }
-      & when (@variationMenuPointing) {
-        .ui.inverted.pointing.@{color}.menu .active.item {
-          background-color: @h;
+      & when not (@color=secondary) {
+        .ui.ui.ui.inverted.menu .@{color}.active.item,
+        .ui.ui.inverted.@{color}.menu {
+          background-color: @c;
+        }
+        .ui.inverted.@{color}.menu .item:before {
+          background-color: @invertedColoredDividerBackground;
+        }
+        .ui.ui.inverted.@{color}.menu .active.item {
+          background-color: @invertedColoredActiveBackground;
+        }
+        & when (@variationMenuPointing) {
+          .ui.inverted.pointing.@{color}.menu .active.item {
+            background-color: @h;
+          }
         }
       }
-    }
-  })
+    })
+  }
 
   & when (@variationMenuPointing) {
     .ui.ui.ui.inverted.pointing.menu .active.item:after {
@@ -1808,14 +1810,16 @@ each(@colors, {
   }
 }
 
-each(@colors, {
-  @color: replace(@key, '@', '');
-  @c: @colors[@@color][color];
+& when not (@variationMenuColors = false) {
+  each(@variationMenuColors, {
+    @color: @value;
+    @c: @colors[@@color][color];
 
-  .ui.inverted.pointing.menu .@{color}.active.item:after {
-    background-color: @c;
-  }
-})
+    .ui.inverted.pointing.menu .@{color}.active.item:after {
+      background-color: @c;
+    }
+  })
+}
 
 & when (@variationMenuAttached) {
   /*--------------

--- a/src/definitions/collections/message.less
+++ b/src/definitions/collections/message.less
@@ -287,7 +287,7 @@
 /*--------------
      Types
 ---------------*/
-& when (@variationMessageConsequences) {
+& when not (@variationMessageConsequences = false) {
 
   @consequences: {
     @positive: {
@@ -342,8 +342,8 @@
 
   /* Colors */
 
-  each(@consequences, {
-    @color: replace(@key, '@', '');
+  each(@variationMessageConsequences, {
+    @color: @value;
     @bg: @consequences[@@color][background];
     @hd: @consequences[@@color][header];
     @bs: @consequences[@@color][boxShadow];
@@ -376,50 +376,51 @@
     }
   })
 }
+& when not (@variationMessageColors = false) {
+  each(@variationMessageColors, {
+    @color: @value;
+    @bg: @colors[@@color][background];
+    @hd: @colors[@@color][header];
+    @bs: @colors[@@color][boxShadow];
+    @bfs: @colors[@@color][boxFloatShadow];
+    @t: @colors[@@color][text];
+    @isVeryDark: @colors[@@color][isVeryDark];
 
-each(@colors, {
-  @color: replace(@key, '@', '');
-  @bg: @colors[@@color][background];
-  @hd: @colors[@@color][header];
-  @bs: @colors[@@color][boxShadow];
-  @bfs: @colors[@@color][boxFloatShadow];
-  @t: @colors[@@color][text];
-  @isVeryDark: @colors[@@color][isVeryDark];
-
-  .ui.@{color}.message {
-    & when not (@isVeryDark) {
-      background-color: @bg;
-      color: @t;
-    }
-    & when (@isVeryDark) {
-      background-color: @black;
-      color: @invertedTextColor;
-    }
-  }
-
-  .ui.@{color}.message,
-  .ui.attached.@{color}.message {
-    & when not (@isVeryDark) {
-      box-shadow: @bs;
-    }
-  }
-  & when (@variationMessageFloating) {
-    .ui.floating.@{color}.message {
+    .ui.@{color}.message {
       & when not (@isVeryDark) {
-        box-shadow: @bfs;
+        background-color: @bg;
+        color: @t;
+      }
+      & when (@isVeryDark) {
+        background-color: @black;
+        color: @invertedTextColor;
       }
     }
-  }
 
-  .ui.@{color}.message .header {
-    & when not (@isVeryDark) {
-      color: @hd;
+    .ui.@{color}.message,
+    .ui.attached.@{color}.message {
+      & when not (@isVeryDark) {
+        box-shadow: @bs;
+      }
     }
-    & when (@isVeryDark) {
-      color: @invertedTextColor;
+    & when (@variationMessageFloating) {
+      .ui.floating.@{color}.message {
+        & when not (@isVeryDark) {
+          box-shadow: @bfs;
+        }
+      }
     }
-  }
-})
+
+    .ui.@{color}.message .header {
+      & when not (@isVeryDark) {
+        color: @hd;
+      }
+      & when (@isVeryDark) {
+        color: @invertedTextColor;
+      }
+    }
+  })
+}
 
 & when (@variationMessageInverted) {
   .ui.inverted.message {

--- a/src/definitions/collections/table.less
+++ b/src/definitions/collections/table.less
@@ -238,9 +238,9 @@
   .ui.definition.table:not(.unstackable) > thead > tr > th:first-child {
     box-shadow: none !important;
   }
-  & when (@variationTableMarked) {
-    each(@colors, {
-      @color: replace(@key, '@', '');
+  & when (@variationTableMarked) and not (@variationTableColors = false) {
+    each(@variationTableColors, {
+      @color: @value;
       @c: @colors[@@color][color];
       @l: @colors[@@color][light];
       .ui.ui.ui.ui.table:not(.unstackable) tr.marked.@{color} {
@@ -526,9 +526,9 @@
       }
     }
   }
-  & when (@variationTableMarked) {
-    each(@colors, {
-      @color: replace(@key, '@', '');
+  & when (@variationTableMarked) and not (@variationTableColors = false) {
+    each(@variationTableColors, {
+      @color: @value;
       @c: @colors[@@color][color];
       @l: @colors[@@color][light];
       .ui.ui.ui.ui[class*="tablet stackable"].table tr.marked.@{color} {
@@ -778,89 +778,90 @@
 /*-------------------
        Colors
 --------------------*/
+& when not (@variationTableColors = false) {
+  each(@variationTableColors, {
+    @color: @value;
+    @c: @colors[@@color][color];
+    @t: @colors[@@color][text];
+    @ht: @colors[@@color][hoverText];
+    @l: @colors[@@color][light];
+    @lh: @colors[@@color][lightHover];
+    @r: @colors[@@color][ribbon];
+    @b: @colors[@@color][bright];
+    @bh: @colors[@@color][brightHover];
+    @isDark: @colors[@@color][isDark];
+    @isVeryDark: @colors[@@color][isVeryDark];
 
-each(@colors, {
-  @color: replace(@key, '@', '');
-  @c: @colors[@@color][color];
-  @t: @colors[@@color][text];
-  @ht: @colors[@@color][hoverText];
-  @l: @colors[@@color][light];
-  @lh: @colors[@@color][lightHover];
-  @r: @colors[@@color][ribbon];
-  @b: @colors[@@color][bright];
-  @bh: @colors[@@color][brightHover];
-  @isDark: @colors[@@color][isDark];
-  @isVeryDark: @colors[@@color][isVeryDark];
-
-  .ui.@{color}.table {
-    border-top: @coloredBorderSize solid @c;
-  }
-  & when (@variationTableInverted) {
-    .ui.inverted.@{color}.table {
-      background-color: @c;
-      color: @white;
+    .ui.@{color}.table {
+      border-top: @coloredBorderSize solid @c;
     }
-  }
-  .ui.ui.ui.ui.table tr.@{color}:not(.marked),
-  .ui.ui.table td.@{color}:not(.marked) {
-    & when (@stateMarkerWidth > 0) {
-      box-shadow: @stateMarkerWidth 0 0 @r inset;
+    & when (@variationTableInverted) {
+      .ui.inverted.@{color}.table {
+        background-color: @c;
+        color: @white;
+      }
     }
-    & when (@isDark) {
-      background: @l;
-    }
-    & when not (@isDark) {
-      background: @b;
-    }
-    & when (@isVeryDark) {
-      color: @white;
-    }
-    & when not (@isVeryDark) {
-      color: @t;
-    }
-  }
-  & when (@variationTableSelectable) {
-    .ui.ui.selectable.table tr.@{color}:not(.marked):hover,
-    .ui.table tr td.selectable.@{color}:not(.marked):hover,
-    .ui.selectable.table tr:hover td.@{color}:not(.marked) {
+    .ui.ui.ui.ui.table tr.@{color}:not(.marked),
+    .ui.ui.table td.@{color}:not(.marked) {
+      & when (@stateMarkerWidth > 0) {
+        box-shadow: @stateMarkerWidth 0 0 @r inset;
+      }
       & when (@isDark) {
-        background: @lh;
+        background: @l;
       }
       & when not (@isDark) {
-        background: @bh;
+        background: @b;
       }
       & when (@isVeryDark) {
         color: @white;
       }
       & when not (@isVeryDark) {
-        color: @ht;
+        color: @t;
       }
     }
-  }
-  & when (@variationTableMarked) {
-    .ui.table td.marked.@{color},
-    .ui.table tr.marked.@{color} {
-      &.left {
-        box-shadow: @coloredBorderSize 0 0 0 @c inset;
-      }
-      &.right {
-        box-shadow: -@coloredBorderSize 0 0 0 @c inset;
+    & when (@variationTableSelectable) {
+      .ui.ui.selectable.table tr.@{color}:not(.marked):hover,
+      .ui.table tr td.selectable.@{color}:not(.marked):hover,
+      .ui.selectable.table tr:hover td.@{color}:not(.marked) {
+        & when (@isDark) {
+          background: @lh;
+        }
+        & when not (@isDark) {
+          background: @bh;
+        }
+        & when (@isVeryDark) {
+          color: @white;
+        }
+        & when not (@isVeryDark) {
+          color: @ht;
+        }
       }
     }
-    & when (@variationTableInverted) {
-      .ui.inverted.table td.marked.@{color},
-      .ui.inverted.table tr.marked.@{color} {
+    & when (@variationTableMarked) {
+      .ui.table td.marked.@{color},
+      .ui.table tr.marked.@{color} {
         &.left {
-          box-shadow: @coloredBorderSize 0 0 0 @l inset;
+          box-shadow: @coloredBorderSize 0 0 0 @c inset;
         }
         &.right {
-          box-shadow: -@coloredBorderSize 0 0 0 @l inset;
+          box-shadow: -@coloredBorderSize 0 0 0 @c inset;
+        }
+      }
+      & when (@variationTableInverted) {
+        .ui.inverted.table td.marked.@{color},
+        .ui.inverted.table tr.marked.@{color} {
+          &.left {
+            box-shadow: @coloredBorderSize 0 0 0 @l inset;
+          }
+          &.right {
+            box-shadow: -@coloredBorderSize 0 0 0 @l inset;
+          }
         }
       }
     }
-  }
 
-})
+  })
+}
 
 /*--------------
   Column Count

--- a/src/definitions/elements/button.less
+++ b/src/definitions/elements/button.less
@@ -1437,191 +1437,159 @@
        Colors
 --------------------*/
 
-each(@colors, {
-  @color: replace(@key, '@', '');
-  @c: @colors[@@color][color];
-  @h: @colors[@@color][hover];
-  @f: @colors[@@color][focus];
-  @d: @colors[@@color][down];
-  @a: @colors[@@color][active];
-  @t: @colors[@@color][text];
-  @s: @colors[@@color][shadow];
-  @l: @colors[@@color][light];
-  @lh: @colors[@@color][lightHover];
-  @lf: @colors[@@color][lightFocus];
-  @ld: @colors[@@color][lightDown];
-  @la: @colors[@@color][lightActive];
-  @lt: @colors[@@color][lightText];
-  @ls: @colors[@@color][lightShadow];
-  @ty: @colors[@@color][tertiary];
-  @tyh: @colors[@@color][tertiaryHover];
-  @tyf: @colors[@@color][tertiaryFocus];
-  @tya: @colors[@@color][tertiaryActive];
-  @isDark: @colors[@@color][isDark];
-  @isVeryDark: @colors[@@color][isVeryDark];
+& when not (@variationButtonColors = false) {
+  each(@variationButtonColors, {
+    @color: @value;
+    @c: @colors[@@color][color];
+    @h: @colors[@@color][hover];
+    @f: @colors[@@color][focus];
+    @d: @colors[@@color][down];
+    @a: @colors[@@color][active];
+    @t: @colors[@@color][text];
+    @s: @colors[@@color][shadow];
+    @l: @colors[@@color][light];
+    @lh: @colors[@@color][lightHover];
+    @lf: @colors[@@color][lightFocus];
+    @ld: @colors[@@color][lightDown];
+    @la: @colors[@@color][lightActive];
+    @lt: @colors[@@color][lightText];
+    @ls: @colors[@@color][lightShadow];
+    @ty: @colors[@@color][tertiary];
+    @tyh: @colors[@@color][tertiaryHover];
+    @tyf: @colors[@@color][tertiaryFocus];
+    @tya: @colors[@@color][tertiaryActive];
+    @isDark: @colors[@@color][isDark];
+    @isVeryDark: @colors[@@color][isVeryDark];
 
-  .ui.@{color}.buttons .button,
-  .ui.@{color}.button {
-    background-color: @c;
-    color: @t;
-    text-shadow: @s;
-    background-image: @coloredBackgroundImage;
-  }
-  .ui.@{color}.button {
-    box-shadow: @coloredBoxShadow;
-  }
-  .ui.@{color}.buttons .button:hover,
-  .ui.@{color}.button:hover {
-    background-color: @h;
-    color: @t;
-    text-shadow: @s;
-  }
-  .ui.@{color}.buttons .button:focus,
-  .ui.@{color}.button:focus {
-    background-color: @f;
-    color: @t;
-    text-shadow: @s;
-  }
-  .ui.@{color}.buttons .button:active,
-  .ui.@{color}.button:active {
-    background-color: @d;
-    color: @t;
-    text-shadow: @s;
-  }
-  .ui.@{color}.buttons .active.button,
-  .ui.@{color}.buttons .active.button:active,
-  .ui.@{color}.active.button,
-  .ui.@{color}.button .active.button:active {
-    background-color: @a;
-    color: @t;
-    text-shadow: @s;
-  }
-
-  & when (@variationButtonBasic) {
-    /* Basic */
-    .ui.basic.@{color}.buttons .button,
-    .ui.basic.@{color}.button {
-      background: transparent;
-      box-shadow: 0 0 0 @basicBorderSize @c inset ;
-      color: @c ;
+    .ui.@{color}.buttons .button,
+    .ui.@{color}.button {
+      background-color: @c;
+      color: @t;
+      text-shadow: @s;
+      background-image: @coloredBackgroundImage;
     }
-    .ui.basic.@{color}.buttons .button:hover,
-    .ui.basic.@{color}.button:hover {
-      background: transparent ;
-      box-shadow: 0 0 0 @basicColoredBorderSize @h inset ;
-      color: @h ;
+    .ui.@{color}.button {
+      box-shadow: @coloredBoxShadow;
     }
-    .ui.basic.@{color}.buttons .button:focus,
-    .ui.basic.@{color}.button:focus {
-      background: transparent ;
-      box-shadow: 0 0 0 @basicColoredBorderSize @f inset ;
-      color: @h ;
+    .ui.@{color}.buttons .button:hover,
+    .ui.@{color}.button:hover {
+      background-color: @h;
+      color: @t;
+      text-shadow: @s;
     }
-    .ui.basic.@{color}.buttons .active.button,
-    .ui.basic.@{color}.active.button {
-      background: transparent ;
-      box-shadow: 0 0 0 @basicColoredBorderSize @a inset ;
-      color: @d ;
+    .ui.@{color}.buttons .button:focus,
+    .ui.@{color}.button:focus {
+      background-color: @f;
+      color: @t;
+      text-shadow: @s;
     }
-    .ui.basic.@{color}.buttons .button:active,
-    .ui.basic.@{color}.button:active {
-      box-shadow: 0 0 0 @basicColoredBorderSize @d inset ;
-      color: @d ;
+    .ui.@{color}.buttons .button:active,
+    .ui.@{color}.button:active {
+      background-color: @d;
+      color: @t;
+      text-shadow: @s;
+    }
+    .ui.@{color}.buttons .active.button,
+    .ui.@{color}.buttons .active.button:active,
+    .ui.@{color}.active.button,
+    .ui.@{color}.button .active.button:active {
+      background-color: @a;
+      color: @t;
+      text-shadow: @s;
     }
 
-    .ui.buttons:not(.vertical) > .basic.@{color}.button:not(:first-child) {
-      margin-left: -@basicColoredBorderSize;
-    }
-  }
-  & when (@variationButtonInverted) {
-  /* Inverted */
-    .ui.inverted.@{color}.buttons .button,
-    .ui.inverted.@{color}.button {
-      background-color: transparent;
-
-      & when (@isDark) {
-        box-shadow: 0 0 0 @invertedBorderSize @solidBorderColor inset ;
-        color: @invertedTextColor;
-      }
-
-      & when not (@isDark) {
-        box-shadow: 0 0 0 @invertedBorderSize @l inset ;
-        color: @l;
-      }
-    }
-    .ui.inverted.@{color}.buttons .button:hover,
-    .ui.inverted.@{color}.button:hover,
-    .ui.inverted.@{color}.buttons .button:focus,
-    .ui.inverted.@{color}.button:focus,
-    .ui.inverted.@{color}.buttons .button.active,
-    .ui.inverted.@{color}.button.active,
-    .ui.inverted.@{color}.buttons .button:active,
-    .ui.inverted.@{color}.button:active {
-      box-shadow: none ;
-      color: @lt;
-    }
-    .ui.inverted.@{color}.buttons .button:hover,
-    .ui.inverted.@{color}.button:hover {
-      background-color: @lh;
-    }
-    .ui.inverted.@{color}.buttons .button:focus,
-    .ui.inverted.@{color}.button:focus {
-      background-color: @lf;
-    }
-    .ui.inverted.@{color}.buttons .active.button,
-    .ui.inverted.@{color}.active.button {
-      background-color: @la;
-    }
-    .ui.inverted.@{color}.buttons .button:active,
-    .ui.inverted.@{color}.button:active {
-      background-color: @ld;
-    }
-
-    /* Inverted Basic */
-    .ui.inverted.@{color}.basic.buttons .button,
-    .ui.inverted.@{color}.buttons .basic.button,
-    .ui.inverted.@{color}.basic.button {
-      background-color: transparent;
-      box-shadow: @basicInvertedBoxShadow ;
-      color: @white ;
-    }
-    .ui.inverted.@{color}.basic.buttons .button:hover,
-    .ui.inverted.@{color}.buttons .basic.button:hover,
-    .ui.inverted.@{color}.basic.button:hover {
-      box-shadow: 0 0 0 @invertedBorderSize @lh inset ;
-
-      & when (@isDark) {
-        color: @white ;
-      }
-
-      & when not (@isDark) {
-        color: @l ;
-      }
-    }
-    .ui.inverted.@{color}.basic.buttons .button:focus,
-    .ui.inverted.@{color}.basic.buttons .button:focus,
-    .ui.inverted.@{color}.basic.button:focus {
-      box-shadow: 0 0 0 @invertedBorderSize @lf inset ;
-      color: @l ;
-    }
-    .ui.inverted.@{color}.basic.buttons .active.button,
-    .ui.inverted.@{color}.buttons .basic.active.button,
-    .ui.inverted.@{color}.basic.active.button {
-      box-shadow: 0 0 0 @invertedBorderSize @la inset ;
-
-      & when (@isDark) {
-        color: @white ;
-      }
-
-      & when not (@isDark) {
-        color: @l ;
-      }
-    }
     & when (@variationButtonBasic) {
-      .ui.inverted.@{color}.basic.buttons .button:active,
-      .ui.inverted.@{color}.buttons .basic.button:active,
-      .ui.inverted.@{color}.basic.button:active {
-        box-shadow: 0 0 0 @invertedBorderSize @ld inset;
+      /* Basic */
+      .ui.basic.@{color}.buttons .button,
+      .ui.basic.@{color}.button {
+        background: transparent;
+        box-shadow: 0 0 0 @basicBorderSize @c inset;
+        color: @c;
+      }
+      .ui.basic.@{color}.buttons .button:hover,
+      .ui.basic.@{color}.button:hover {
+        background: transparent;
+        box-shadow: 0 0 0 @basicColoredBorderSize @h inset;
+        color: @h;
+      }
+      .ui.basic.@{color}.buttons .button:focus,
+      .ui.basic.@{color}.button:focus {
+        background: transparent;
+        box-shadow: 0 0 0 @basicColoredBorderSize @f inset;
+        color: @h;
+      }
+      .ui.basic.@{color}.buttons .active.button,
+      .ui.basic.@{color}.active.button {
+        background: transparent;
+        box-shadow: 0 0 0 @basicColoredBorderSize @a inset;
+        color: @d;
+      }
+      .ui.basic.@{color}.buttons .button:active,
+      .ui.basic.@{color}.button:active {
+        box-shadow: 0 0 0 @basicColoredBorderSize @d inset;
+        color: @d;
+      }
+
+      .ui.buttons:not(.vertical) > .basic.@{color}.button:not(:first-child) {
+        margin-left: -@basicColoredBorderSize;
+      }
+    }
+    & when (@variationButtonInverted) {
+      /* Inverted */
+      .ui.inverted.@{color}.buttons .button,
+      .ui.inverted.@{color}.button {
+        background-color: transparent;
+
+        & when (@isDark) {
+          box-shadow: 0 0 0 @invertedBorderSize @solidBorderColor inset;
+          color: @invertedTextColor;
+        }
+
+        & when not (@isDark) {
+          box-shadow: 0 0 0 @invertedBorderSize @l inset;
+          color: @l;
+        }
+      }
+      .ui.inverted.@{color}.buttons .button:hover,
+      .ui.inverted.@{color}.button:hover,
+      .ui.inverted.@{color}.buttons .button:focus,
+      .ui.inverted.@{color}.button:focus,
+      .ui.inverted.@{color}.buttons .button.active,
+      .ui.inverted.@{color}.button.active,
+      .ui.inverted.@{color}.buttons .button:active,
+      .ui.inverted.@{color}.button:active {
+        box-shadow: none;
+        color: @lt;
+      }
+      .ui.inverted.@{color}.buttons .button:hover,
+      .ui.inverted.@{color}.button:hover {
+        background-color: @lh;
+      }
+      .ui.inverted.@{color}.buttons .button:focus,
+      .ui.inverted.@{color}.button:focus {
+        background-color: @lf;
+      }
+      .ui.inverted.@{color}.buttons .active.button,
+      .ui.inverted.@{color}.active.button {
+        background-color: @la;
+      }
+      .ui.inverted.@{color}.buttons .button:active,
+      .ui.inverted.@{color}.button:active {
+        background-color: @ld;
+      }
+
+      /* Inverted Basic */
+      .ui.inverted.@{color}.basic.buttons .button,
+      .ui.inverted.@{color}.buttons .basic.button,
+      .ui.inverted.@{color}.basic.button {
+        background-color: transparent;
+        box-shadow: @basicInvertedBoxShadow;
+        color: @white;
+      }
+      .ui.inverted.@{color}.basic.buttons .button:hover,
+      .ui.inverted.@{color}.buttons .basic.button:hover,
+      .ui.inverted.@{color}.basic.button:hover {
+        box-shadow: 0 0 0 @invertedBorderSize @lh inset;
 
         & when (@isDark) {
           color: @white;
@@ -1631,104 +1599,138 @@ each(@colors, {
           color: @l;
         }
       }
+      .ui.inverted.@{color}.basic.buttons .button:focus,
+      .ui.inverted.@{color}.basic.buttons .button:focus,
+      .ui.inverted.@{color}.basic.button:focus {
+        box-shadow: 0 0 0 @invertedBorderSize @lf inset;
+        color: @l;
+      }
+      .ui.inverted.@{color}.basic.buttons .active.button,
+      .ui.inverted.@{color}.buttons .basic.active.button,
+      .ui.inverted.@{color}.basic.active.button {
+        box-shadow: 0 0 0 @invertedBorderSize @la inset;
+
+        & when (@isDark) {
+          color: @white;
+        }
+
+        & when not (@isDark) {
+          color: @l;
+        }
+      }
+      & when (@variationButtonBasic) {
+        .ui.inverted.@{color}.basic.buttons .button:active,
+        .ui.inverted.@{color}.buttons .basic.button:active,
+        .ui.inverted.@{color}.basic.button:active {
+          box-shadow: 0 0 0 @invertedBorderSize @ld inset;
+
+          & when (@isDark) {
+            color: @white;
+          }
+
+          & when not (@isDark) {
+            color: @l;
+          }
+        }
+      }
     }
-  }
 
-  & when (@variationButtonTertiary) {
-    /* Tertiary */
+    & when (@variationButtonTertiary) {
+      /* Tertiary */
 
-    .ui.tertiary.@{color}.buttons .button,
-    .ui.tertiary.@{color}.buttons .tertiary.button,
-    .ui.tertiary.@{color}.button {
-      background: transparent;
-
+      .ui.tertiary.@{color}.buttons .button,
+      .ui.tertiary.@{color}.buttons .tertiary.button,
+      .ui.tertiary.@{color}.button {
+        background: transparent;
 
 
-      & when (@tertiaryWithUnderline = true) {
-        box-shadow: inset 0 -@tertiaryLineHeight 0 @ty;
+
+        & when (@tertiaryWithUnderline = true) {
+          box-shadow: inset 0 -@tertiaryLineHeight 0 @ty;
+        }
+
+        & when (@tertiaryWithOverline = true) {
+          box-shadow: inset 0 @tertiaryLineHeight 0 @ty;
+        }
+
+        & when (@tertiaryWithUnderline = false) and (@tertiaryWithOverline = false){
+          box-shadow: none;
+        }
+
+        color: @c;
       }
 
-      & when (@tertiaryWithOverline = true) {
-        box-shadow: inset 0 @tertiaryLineHeight 0 @ty;
-      }
-
-      & when (@tertiaryWithUnderline = false) and (@tertiaryWithOverline = false){
-        box-shadow: none;
-      }
-
-      color: @c;
-    }
-
-    .ui.tertiary.@{color}.buttons .button:hover,
-    .ui.tertiary.@{color}.buttons button:hover,
-    .ui.tertiary.@{color}.button:hover {
+      .ui.tertiary.@{color}.buttons .button:hover,
+      .ui.tertiary.@{color}.buttons button:hover,
+      .ui.tertiary.@{color}.button:hover {
 
 
 
-      & when (@tertiaryHoverWithUnderline = true) {
-        box-shadow: inset 0 -@tertiaryLineHeight 0 @tyh;
-      }
+        & when (@tertiaryHoverWithUnderline = true) {
+          box-shadow: inset 0 -@tertiaryLineHeight 0 @tyh;
+        }
 
-      & when (@tertiaryHoverWithOverline = true) {
-        box-shadow: inset 0 @tertiaryLineHeight 0 @tyh;
-      }
+        & when (@tertiaryHoverWithOverline = true) {
+          box-shadow: inset 0 @tertiaryLineHeight 0 @tyh;
+        }
 
-      & when (@tertiaryHoverWithUnderline = false) and (@tertiaryHoverWithOverline = false) {
-        box-shadow: none;
-      }
+        & when (@tertiaryHoverWithUnderline = false) and (@tertiaryHoverWithOverline = false) {
+          box-shadow: none;
+        }
 
 
         color: @tyh;
-    }
-
-    .ui.tertiary.@{color}.buttons .button:focus,
-    .ui.tertiary.@{color}.buttons .tertiary.button:focus,
-    .ui.tertiary.@{color}.button:focus {
-
-
-
-
-      & when (@tertiaryFocusWithUnderline = true) {
-        box-shadow: inset 0 -@tertiaryLineHeight 0 @tyf;
       }
 
-      & when (@tertiaryFocusWithOverline = true) {
-        box-shadow: inset 0 @tertiaryLineHeight 0 @tyf;
-      }
+      .ui.tertiary.@{color}.buttons .button:focus,
+      .ui.tertiary.@{color}.buttons .tertiary.button:focus,
+      .ui.tertiary.@{color}.button:focus {
 
-      & when (@tertiaryFocusWithUnderline = false) and (@tertiaryFocusWithOverline = false) {
-        box-shadow: none;
-      }
+
+
+
+        & when (@tertiaryFocusWithUnderline = true) {
+          box-shadow: inset 0 -@tertiaryLineHeight 0 @tyf;
+        }
+
+        & when (@tertiaryFocusWithOverline = true) {
+          box-shadow: inset 0 @tertiaryLineHeight 0 @tyf;
+        }
+
+        & when (@tertiaryFocusWithUnderline = false) and (@tertiaryFocusWithOverline = false) {
+          box-shadow: none;
+        }
 
 
         color: @tyf;
+      }
+
+      .ui.tertiary.@{color}.buttons .active.button,
+      .ui.tertiary.@{color}.buttons .tertiary.active.button,
+      .ui.tertiary.@{color}.active.button,
+      .ui.tertiary.@{color}.buttons .button:active,
+      .ui.tertiary.@{color}.buttons .tertiary.button:active,
+      .ui.tertiary.@{color}.button:active {
+
+
+
+        & when (@tertiaryActiveWithUnderline = true) {
+          box-shadow: inset 0 -@tertiaryLineHeight 0 @tya;
+        }
+
+        & when (@tertiaryActiveWithOverline = true) {
+          box-shadow: inset 0 @tertiaryLineHeight 0 @tya;
+        }
+
+        & when (@tertiaryActiveWithUnderline = false) and (@tertiaryActiveWithOverline = false) {
+          box-shadow: none;
+        }
+
+        color: @a;
+      }
     }
-
-    .ui.tertiary.@{color}.buttons .active.button,
-    .ui.tertiary.@{color}.buttons .tertiary.active.button,
-    .ui.tertiary.@{color}.active.button,
-    .ui.tertiary.@{color}.buttons .button:active,
-    .ui.tertiary.@{color}.buttons .tertiary.button:active,
-    .ui.tertiary.@{color}.button:active {
-
-
-
-      & when (@tertiaryActiveWithUnderline = true) {
-        box-shadow: inset 0 -@tertiaryLineHeight 0 @tya;
-      }
-
-      & when (@tertiaryActiveWithOverline = true) {
-        box-shadow: inset 0 @tertiaryLineHeight 0 @tya;
-      }
-
-      & when (@tertiaryActiveWithUnderline = false) and (@tertiaryActiveWithOverline = false) {
-        box-shadow: none;
-      }
-
-      color: @a;
-    }
-  }
-})
+  })
+}
 
 .addConsequence(@consequence) {
 

--- a/src/definitions/elements/header.less
+++ b/src/definitions/elements/header.less
@@ -306,37 +306,38 @@
 /*-------------------
        Colors
 --------------------*/
+& when not (@variationHeaderColors = false) {
+  each(@variationHeaderColors, {
+    @color: @value;
+    @c: @colors[@@color][color];
+    @l: @colors[@@color][light];
+    @h: @colors[@@color][hover];
+    @lh: @colors[@@color][lightHover];
 
-each(@colors, {
-  @color: replace(@key, '@', '');
-  @c: @colors[@@color][color];
-  @l: @colors[@@color][light];
-  @h: @colors[@@color][hover];
-  @lh: @colors[@@color][lightHover];
-
-  .ui.@{color}.header {
-    color: @c;
-  }
-  a.ui.@{color}.header:hover {
-    color: @h;
-  }
-  & when (@variationHeaderDividing) {
-    .ui.@{color}.dividing.header {
-      border-bottom: @dividedColoredBorderWidth solid @c;
+    .ui.@{color}.header {
+      color: @c;
     }
-  }
-  & when (@variationHeaderInverted) {
-    .ui.inverted.@{color}.header.header.header {
-      color: @l;
+    a.ui.@{color}.header:hover {
+      color: @h;
     }
-    a.ui.inverted.@{color}.header.header.header:hover {
-      color: @lh;
+    & when (@variationHeaderDividing) {
+      .ui.@{color}.dividing.header {
+        border-bottom: @dividedColoredBorderWidth solid @c;
+      }
     }
-    .ui.inverted.@{color}.dividing.header {
-      border-bottom: @dividedColoredBorderWidth solid @l;
+    & when (@variationHeaderInverted) {
+      .ui.inverted.@{color}.header.header.header {
+        color: @l;
+      }
+      a.ui.inverted.@{color}.header.header.header:hover {
+        color: @lh;
+      }
+      .ui.inverted.@{color}.dividing.header {
+        border-bottom: @dividedColoredBorderWidth solid @l;
+      }
     }
-  }
-})
+  })
+}
 
 & when (@variationHeaderAligned) {
   /*-------------------

--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -320,30 +320,31 @@ i.emphasized.icon:not(.disabled), i.emphasized.icons:not(.disabled) {
 /*-------------------
        Colors
 --------------------*/
+& when not (@variationIconColors = false) {
+  each(@variationIconColors, {
+    @color: @value;
+    @c: @colors[@@color][color];
+    @l: @colors[@@color][light];
 
-each(@colors, {
-  @color: replace(@key, '@', '');
-  @c: @colors[@@color][color];
-  @l: @colors[@@color][light];
-
-  i.@{color}.icon.icon.icon.icon.icon {
-    color: @c;
-  }
-  & when (@variationIconInverted) {
-    i.inverted.@{color}.icon.icon.icon.icon.icon {
-      color: @l;
+    i.@{color}.icon.icon.icon.icon.icon {
+      color: @c;
     }
-    & when (@variationIconBordered) or (@variationIconCircular) {
-      i.inverted.bordered.@{color}.icon.icon.icon.icon.icon,
-      i.inverted.circular.@{color}.icon.icon.icon.icon.icon,
-      i.inverted.bordered.@{color}.icons,
-      i.inverted.circular.@{color}.icons {
-        background-color: @c;
-        color: @white;
+    & when (@variationIconInverted) {
+      i.inverted.@{color}.icon.icon.icon.icon.icon {
+        color: @l;
+      }
+      & when (@variationIconBordered) or (@variationIconCircular) {
+        i.inverted.bordered.@{color}.icon.icon.icon.icon.icon,
+        i.inverted.circular.@{color}.icon.icon.icon.icon.icon,
+        i.inverted.bordered.@{color}.icons,
+        i.inverted.circular.@{color}.icons {
+          background-color: @c;
+          color: @white;
+        }
       }
     }
-  }
-})
+  })
+}
 
 
 /*-------------------

--- a/src/definitions/elements/input.less
+++ b/src/definitions/elements/input.less
@@ -170,12 +170,12 @@
 }
 
 
-& when (@variationInputStates) {
+& when not (@variationInputStates = false) {
   /*--------------------
           States
   ---------------------*/
-  each(@formStates, {
-    @state: replace(@key, '@', '');
+  each(@variationInputStates, {
+    @state: @value;
 
     .ui.input.@{state} > input {
       background-color: @formStates[@@state][background];
@@ -434,10 +434,10 @@
   }
 }
 
-& when (@variationInputLabeled)  or (@variationInputAction) {
+& when ((@variationInputLabeled) or (@variationInputAction)) and not (@variationInputStates = false) {
   /* Labeled and action input states */
-  each(@formStates, {
-    @state: replace(@key, '@', '');
+  each(@variationInputStates, {
+    @state: @value;
     @borderColor: @formStates[@@state][borderColor];
 
     .ui.form .field.@{state} > .ui.action.input > .ui.button,

--- a/src/definitions/elements/label.less
+++ b/src/definitions/elements/label.less
@@ -714,118 +714,119 @@ a.ui.active.label:hover:before {
 /*-------------------
        Colors
 --------------------*/
+& when not (@variationLabelColors = false) {
+  each(@variationLabelColors, {
+    @color: @value;
+    @isDark: @colors[@@color][isDark];
+    @_labelColor: @colors[@@color][color];
+    @_labelInvertedColor: @colors[@@color][light];
+    @_labelTextColor: @colors[@@color][text];
+    @_labelHover: @colors[@@color][hover];
+    @_labelInvertedHover: @colors[@@color][lightHover];
+    @_labelHoverTextColor: @colors[@@color][hoverText];
+    @_labelRibbonShadow: @colors[@@color][ribbon];
+    @_labelInvertedRibbonShadow: @colors[@@color][invertedRibbon];
 
-each(@colors,{
-  @color                      : replace(@key,'@','');
-  @isDark                     : @colors[@@color][isDark];
-  @_labelColor                : @colors[@@color][color];
-  @_labelInvertedColor        : @colors[@@color][light];
-  @_labelTextColor            : @colors[@@color][text];
-  @_labelHover                : @colors[@@color][hover];
-  @_labelInvertedHover        : @colors[@@color][lightHover];
-  @_labelHoverTextColor       : @colors[@@color][hoverText];
-  @_labelRibbonShadow         : @colors[@@color][ribbon];
-  @_labelInvertedRibbonShadow : @colors[@@color][invertedRibbon];
-
-  .ui.@{color}.labels .label,
-  .ui.ui.ui.@{color}.label {
-    background-color: @_labelColor;
-    border-color: @_labelColor;
-    color: @_labelTextColor;
-  }
-  /* Link */
-  .ui.@{color}.labels a.label:hover,
-  a.ui.ui.ui.@{color}.label:hover{
-    background-color: @_labelHover;
-    border-color: @_labelHover;
-    color: @_labelHoverTextColor;
-  }
-  & when (@variationLabelRibbon) {
-    /* Ribbon */
-    .ui.ui.ui.@{color}.ribbon.label {
-      border-color: @_labelRibbonShadow;
-    }
-  }
-  & when (@variationLabelBasic) {
-    /* Basic */
-    .ui.basic.labels .@{color}.label,
-    .ui.ui.ui.basic.@{color}.label {
-      background: @basicBackground;
+    .ui.@{color}.labels .label,
+    .ui.ui.ui.@{color}.label {
+      background-color: @_labelColor;
       border-color: @_labelColor;
-      color: @_labelColor;
+      color: @_labelTextColor;
     }
-    .ui.basic.labels a.@{color}.label:hover,
-    a.ui.ui.ui.basic.@{color}.label:hover {
-      background: @basicBackground;
+    /* Link */
+    .ui.@{color}.labels a.label:hover,
+    a.ui.ui.ui.@{color}.label:hover {
+      background-color: @_labelHover;
       border-color: @_labelHover;
-      color: @_labelHover;
-    }
-  }
-  & when (@variationLabelInverted) {
-    /* Inverted */
-    .ui.inverted.labels .@{color}.label,
-    .ui.ui.ui.inverted.@{color}.label {
-      background-color: @_labelInvertedColor;
-      border-color: @_labelInvertedColor;
-      color: @black;
-    }
-    /* Inverted Link */
-    .ui.inverted.labels a.@{color}.label:hover,
-    a.ui.ui.ui.inverted.@{color}.label:hover{
-      background-color: @_labelInvertedHover;
-      border-color: @_labelInvertedHover;
-      & when not (@isDark) {
-        color: @black;
-      }
-      & when (@isDark) {
-        color: @_labelTextColor;
-      }
+      color: @_labelHoverTextColor;
     }
     & when (@variationLabelRibbon) {
-      /* Inverted Ribbon */
-      .ui.ui.ui.inverted.@{color}.ribbon.label {
-        border-color: @_labelInvertedRibbonShadow;
+      /* Ribbon */
+      .ui.ui.ui.@{color}.ribbon.label {
+        border-color: @_labelRibbonShadow;
       }
     }
     & when (@variationLabelBasic) {
-      /* Inverted Basic */
-      .ui.inverted.basic.labels .@{color}.label,
-      .ui.ui.ui.inverted.basic.@{color}.label {
-        background-color: @invertedBackground;
+      /* Basic */
+      .ui.basic.labels .@{color}.label,
+      .ui.ui.ui.basic.@{color}.label {
+        background: @basicBackground;
+        border-color: @_labelColor;
+        color: @_labelColor;
+      }
+      .ui.basic.labels a.@{color}.label:hover,
+      a.ui.ui.ui.basic.@{color}.label:hover {
+        background: @basicBackground;
+        border-color: @_labelHover;
+        color: @_labelHover;
+      }
+    }
+    & when (@variationLabelInverted) {
+      /* Inverted */
+      .ui.inverted.labels .@{color}.label,
+      .ui.ui.ui.inverted.@{color}.label {
+        background-color: @_labelInvertedColor;
         border-color: @_labelInvertedColor;
+        color: @black;
+      }
+      /* Inverted Link */
+      .ui.inverted.labels a.@{color}.label:hover,
+      a.ui.ui.ui.inverted.@{color}.label:hover {
+        background-color: @_labelInvertedHover;
+        border-color: @_labelInvertedHover;
         & when not (@isDark) {
-          color: @_labelInvertedColor;
+          color: @black;
         }
         & when (@isDark) {
-          color: @invertedTextColor;
+          color: @_labelTextColor;
         }
       }
-      .ui.inverted.basic.labels a.@{color}.label:hover,
-      a.ui.ui.ui.inverted.basic.@{color}.label:hover {
-        border-color: @_labelInvertedHover;
-        background-color: @invertedBackground;
-        & when not (@isDark) {
-          color: @_labelInvertedHover;
+      & when (@variationLabelRibbon) {
+        /* Inverted Ribbon */
+        .ui.ui.ui.inverted.@{color}.ribbon.label {
+          border-color: @_labelInvertedRibbonShadow;
         }
       }
-      & when (@variationLabelTag) {
-        /* Inverted Basic Tags */
-        .ui.inverted.basic.tag.labels .@{color}.label,
-        .ui.ui.ui.inverted.@{color}.basic.tag.label {
-          border: @invertedBorderSize solid @_labelInvertedColor;
-        }
-        .ui.inverted.basic.tag.labels .@{color}.label:before,
-        .ui.ui.ui.inverted.@{color}.basic.tag.label:before {
-          border-color: inherit;
-          border-width: @invertedBorderSize 0 0 @invertedBorderSize;
-          border-style: inherit;
+      & when (@variationLabelBasic) {
+        /* Inverted Basic */
+        .ui.inverted.basic.labels .@{color}.label,
+        .ui.ui.ui.inverted.basic.@{color}.label {
           background-color: @invertedBackground;
-          right: e(%("calc(100%% + %d)", @invertedBorderSize));
+          border-color: @_labelInvertedColor;
+          & when not (@isDark) {
+            color: @_labelInvertedColor;
+          }
+          & when (@isDark) {
+            color: @invertedTextColor;
+          }
+        }
+        .ui.inverted.basic.labels a.@{color}.label:hover,
+        a.ui.ui.ui.inverted.basic.@{color}.label:hover {
+          border-color: @_labelInvertedHover;
+          background-color: @invertedBackground;
+          & when not (@isDark) {
+            color: @_labelInvertedHover;
+          }
+        }
+        & when (@variationLabelTag) {
+          /* Inverted Basic Tags */
+          .ui.inverted.basic.tag.labels .@{color}.label,
+          .ui.ui.ui.inverted.@{color}.basic.tag.label {
+            border: @invertedBorderSize solid @_labelInvertedColor;
+          }
+          .ui.inverted.basic.tag.labels .@{color}.label:before,
+          .ui.ui.ui.inverted.@{color}.basic.tag.label:before {
+            border-color: inherit;
+            border-width: @invertedBorderSize 0 0 @invertedBorderSize;
+            border-style: inherit;
+            background-color: @invertedBackground;
+            right: e(%("calc(100%% + %d)", @invertedBorderSize));
+          }
         }
       }
     }
-  }
-})
+  })
+}
 
 /*-------------------
      Horizontal

--- a/src/definitions/elements/loader.less
+++ b/src/definitions/elements/loader.less
@@ -203,35 +203,36 @@
 /*-------------------
        Colors
 --------------------*/
+& when not (@variationLoaderColors = false) {
+  each(@variationLoaderColors, {
+    @color: @value;
+    @c: @colors[@@color][color];
+    @l: @colors[@@color][light];
 
-each(@colors, {
-  @color: replace(@key, '@', '');
-  @c: @colors[@@color][color];
-  @l: @colors[@@color][light];
-
-  .ui.@{color}.elastic.loader.loader:before,
-  .ui.@{color}.basic.elastic.loading.button:before,
-  .ui.@{color}.basic.elastic.loading.button:after,
-  .ui.@{color}.elastic.loading.loading.loading:not(.segment):not(.segments):not(.card):before,
-  .ui.@{color}.elastic.loading.loading.loading .input > i.icon:before,
-  .ui.@{color}.elastic.loading.loading.loading.loading > i.icon:before,
-  .ui.@{color}.loading.loading.loading.loading:not(.usual):not(.button):after,
-  .ui.@{color}.loading.loading.loading.loading .input > i.icon:after,
-  .ui.@{color}.loading.loading.loading.loading > i.icon:after,
-  .ui.@{color}.loader.loader.loader:after {
-    color: @c;
-  }
-  .ui.inverted.@{color}.elastic.loader:before,
-  .ui.inverted.@{color}.elastic.loading.loading.loading:not(.segment):not(.segments):not(.card):before,
-  .ui.inverted.@{color}.elastic.loading.loading.loading .input > i.icon:before,
-  .ui.inverted.@{color}.elastic.loading.loading.loading > i.icon:before,
-  .ui.inverted.@{color}.loading.loading.loading.loading:not(.usual):after,
-  .ui.inverted.@{color}.loading.loading.loading.loading .input > i.icon:after,
-  .ui.inverted.@{color}.loading.loading.loading.loading > i.icon:after,
-  .ui.inverted.@{color}.loader.loader.loader:after {
-    color: @l;
-  }
-})
+    .ui.@{color}.elastic.loader.loader:before,
+    .ui.@{color}.basic.elastic.loading.button:before,
+    .ui.@{color}.basic.elastic.loading.button:after,
+    .ui.@{color}.elastic.loading.loading.loading:not(.segment):not(.segments):not(.card):before,
+    .ui.@{color}.elastic.loading.loading.loading .input > i.icon:before,
+    .ui.@{color}.elastic.loading.loading.loading.loading > i.icon:before,
+    .ui.@{color}.loading.loading.loading.loading:not(.usual):not(.button):after,
+    .ui.@{color}.loading.loading.loading.loading .input > i.icon:after,
+    .ui.@{color}.loading.loading.loading.loading > i.icon:after,
+    .ui.@{color}.loader.loader.loader:after {
+      color: @c;
+    }
+    .ui.inverted.@{color}.elastic.loader:before,
+    .ui.inverted.@{color}.elastic.loading.loading.loading:not(.segment):not(.segments):not(.card):before,
+    .ui.inverted.@{color}.elastic.loading.loading.loading .input > i.icon:before,
+    .ui.inverted.@{color}.elastic.loading.loading.loading > i.icon:before,
+    .ui.inverted.@{color}.loading.loading.loading.loading:not(.usual):after,
+    .ui.inverted.@{color}.loading.loading.loading.loading .input > i.icon:after,
+    .ui.inverted.@{color}.loading.loading.loading.loading > i.icon:after,
+    .ui.inverted.@{color}.loader.loader.loader:after {
+      color: @l;
+    }
+  })
+}
 
 .ui.elastic.loader.loader:before,
 .ui.elastic.loading.loading.loading:before,

--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -591,22 +591,23 @@
 /*-------------------
        Colors
 --------------------*/
-
-each(@colors,{
-  @color: replace(@key,'@','');
-  @c: @colors[@@color][color];
-  & when not (@color=primary) and not (@color=secondary) {
-    .ui.@{color}.segment.segment.segment.segment.segment:not(.inverted) {
-      border-top: @coloredBorderSize solid @c;
-    }
-    & when (@variationSegmentInverted) {
-      .ui.inverted.@{color}.segment.segment.segment.segment.segment {
-        background-color: @c;
-        color: @white;
+& when not (@variationSegmentColors = false) {
+  each(@variationSegmentColors, {
+    @color: @value;
+    @c: @colors[@@color][color];
+    & when not (@color=primary) and not (@color=secondary) {
+      .ui.@{color}.segment.segment.segment.segment.segment:not(.inverted) {
+        border-top: @coloredBorderSize solid @c;
+      }
+      & when (@variationSegmentInverted) {
+        .ui.inverted.@{color}.segment.segment.segment.segment.segment {
+          background-color: @c;
+          color: @white;
+        }
       }
     }
-  }
-})
+  })
+}
 
 & when (@variationSegmentAligned) {
   /*-------------------

--- a/src/definitions/elements/text.less
+++ b/src/definitions/elements/text.less
@@ -26,24 +26,26 @@ span.ui.text {
   line-height: @lineHeight;
 }
 
-each(@colors, {
-  @color: replace(@key, '@', '');
-  @c: @colors[@@color][color];
-  @l: @colors[@@color][light];
+& when not (@variationTextColors = false) {
+  each(@variationTextColors, {
+    @color: @value;
+    @c: @colors[@@color][color];
+    @l: @colors[@@color][light];
 
-  span.ui.@{color}.text {
-    color: @c;
-  }
-  & when (@variationTextInverted) {
-    span.ui.inverted.@{color}.text {
-      color: @l;
+    span.ui.@{color}.text {
+      color: @c;
     }
-  }
-})
+    & when (@variationTextInverted) {
+      span.ui.inverted.@{color}.text {
+        color: @l;
+      }
+    }
+  })
+}
 
-& when (@variationTextStates) {
-  each(@textStates, {
-    @state: replace(@key, '@', '');
+& when not (@variationTextStates = false) {
+  each(@variationTextStates, {
+    @state: @value;
     @c: @textStates[@@state][color];
 
     span.ui.@{state}.text {

--- a/src/definitions/modules/checkbox.less
+++ b/src/definitions/modules/checkbox.less
@@ -677,43 +677,44 @@
 /*--------------------
         Size
 ---------------------*/
+& when not (@variationCheckboxSizes = false) {
+  each(@variationCheckboxSizes, {
+    @raw: @{value}Raw;
+    @size: @{value}CheckboxSize;
+    @circleScale: @{value}CheckboxCircleScale;
+    @circleLeft: @{value}CheckboxCircleLeft;
 
-each(@variationCheckboxSizes, {
-  @raw: @{value}Raw;
-  @size: @{value}CheckboxSize;
-  @circleScale: @{value}CheckboxCircleScale;
-  @circleLeft: @{value}CheckboxCircleLeft;
-
-  .ui.@{value}.checkbox {
-    font-size: @@size;
-  }
-
-  & when (@@raw > 1) {
-    .ui.@{value}.form .checkbox,
     .ui.@{value}.checkbox {
-      &:not(.slider):not(.toggle):not(.radio) {
-        &
-        label:after,
-        label:before {
-          transform: scale(@@raw);
-          transform-origin:left;
+      font-size: @@size;
+    }
+
+    & when (@@raw > 1) {
+      .ui.@{value}.form .checkbox,
+      .ui.@{value}.checkbox {
+        &:not(.slider):not(.toggle):not(.radio) {
+          &
+          label:after,
+          label:before {
+            transform: scale(@@raw);
+            transform-origin: left;
+          }
         }
-      }
-      &.radio when (@variationCheckboxRadio) {
-        &
-        label:before {
-          transform: scale(@@raw);
-          transform-origin:left;
-        }
-        &
-        label:after {
-          transform:scale(@@circleScale);
-          transform-origin:left;
-          left: @@circleLeft;
+        &.radio when (@variationCheckboxRadio) {
+          &
+          label:before {
+            transform: scale(@@raw);
+            transform-origin: left;
+          }
+          &
+          label:after {
+            transform: scale(@@circleScale);
+            transform-origin: left;
+            left: @@circleLeft;
+          }
         }
       }
     }
-  }
-})
+  })
+}
 
 .loadUIOverrides();

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -1079,12 +1079,12 @@ select.ui.dropdown {
   display: none !important;
 }
 
-& when (@variationDropdownStates) {
+& when not (@variationDropdownStates = false) {
   /*--------------------
           States
   ----------------------*/
-  each(@formStates, {
-    @state: replace(@key, '@', '');
+  each(@variationDropdownStates, {
+    @state: @value;
     @c: @formStates[@@state][dropdownLabelColor];
     @bdc: @formStates[@@state][borderColor];
 

--- a/src/definitions/modules/nag.less
+++ b/src/definitions/modules/nag.less
@@ -169,28 +169,29 @@ a.ui.nag {
 /*--------------
      Colors
 -------------- */
+& when not (@variationNagColors = false) {
+  each(@variationNagColors, {
+    @color: @value;
+    @c: @colors[@@color][color];
+    @l: @colors[@@color][light];
+    @isVeryDark: @colors[@@color][isVeryDark];
 
-each(@colors, {
-  @color: replace(@key, '@', '');
-  @c: @colors[@@color][color];
-  @l: @colors[@@color][light];
-  @isVeryDark: @colors[@@color][isVeryDark];
-
-  .ui.@{color}.nag {
-    background-color: @c;
-    & when (@isVeryDark) {
-      color: @invertedTextColor;
-    }
-  }
-  & when (@variationNagInverted) {
-    .ui.inverted.@{color}.nag {
-      background-color: @l;
-      & .title when (@isVeryDark) {
-        color: @titleColor;
+    .ui.@{color}.nag {
+      background-color: @c;
+      & when (@isVeryDark) {
+        color: @invertedTextColor;
       }
     }
-  }
-})
+    & when (@variationNagInverted) {
+      .ui.inverted.@{color}.nag {
+        background-color: @l;
+        & .title when (@isVeryDark) {
+          color: @titleColor;
+        }
+      }
+    }
+  })
+}
 
 & when (@variationNagGroups) {
 /*******************************

--- a/src/definitions/modules/progress.less
+++ b/src/definitions/modules/progress.less
@@ -446,25 +446,26 @@
 /*--------------
      Colors
 ---------------*/
+& when not (@variationProgressColors = false) {
+  each(@variationProgressColors, {
+    @color: @value;
+    @c: @colors[@@color][color];
+    @l: @colors[@@color][light];
 
-each(@colors, {
-  @color: replace(@key, '@', '');
-  @c: @colors[@@color][color];
-  @l: @colors[@@color][light];
-
-  .ui.indeterminate.@{color}.progress .bar::before,
-  .ui.@{color}.progress .bar,
-  .ui.progress .@{color}.bar {
-    background-color: @c;
-  }
-  & when (@variationProgressInverted) {
-    .ui.inverted.indeterminate.@{color}.progress .bar::before,
-    .ui.@{color}.inverted.progress .bar,
-    .ui.inverted.progress .@{color}.bar {
-      background-color: @l;
+    .ui.indeterminate.@{color}.progress .bar::before,
+    .ui.@{color}.progress .bar,
+    .ui.progress .@{color}.bar {
+      background-color: @c;
     }
-  }
-})
+    & when (@variationProgressInverted) {
+      .ui.inverted.indeterminate.@{color}.progress .bar::before,
+      .ui.@{color}.inverted.progress .bar,
+      .ui.inverted.progress .@{color}.bar {
+        background-color: @l;
+      }
+    }
+  })
+}
 
 /*--------------
      Sizes

--- a/src/definitions/modules/rating.less
+++ b/src/definitions/modules/rating.less
@@ -95,41 +95,42 @@
 /*--------------
      Colors
 -------------- */
+& when not (@variationRatingColors = false) {
+  each(@variationRatingColors, {
+    @color: @value;
+    @c: @colors[@@color][color];
+    @l: @colors[@@color][light];
+    @h: @colors[@@color][hover];
+    @lh: @colors[@@color][lightHover];
 
-each(@colors, {
-  @color: replace(@key, '@', '');
-  @c: @colors[@@color][color];
-  @l: @colors[@@color][light];
-  @h: @colors[@@color][hover];
-  @lh: @colors[@@color][lightHover];
-
-  .ui.@{color}.rating .active.icon {
-    color: @l;
-    text-shadow: 0px -@shadowWidth 0px @c,
-                 -@shadowWidth 0px 0px @c,
-                 0px @shadowWidth 0px @c,
-                 @shadowWidth 0px 0px @c;
-  }
-  .ui.@{color}.rating .icon.selected,
-  .ui.@{color}.rating .icon.selected.active,
-  .ui.@{color}.rating .icon.selected.partial.active {
-    background: inherit;
-    color: @lh;
-    text-shadow: 0px -@shadowWidth 0px @h,
-                 -@shadowWidth 0px 0px @h,
-                 0px @shadowWidth 0px @h,
-                 @shadowWidth 0px 0px @h;
-
-    -webkit-text-stroke: unset;
-    background-clip: unset;
-  }
-  & when (@variationRatingPartial) {
-    .ui.@{color}.rating .icon.partial.active {
-      background: linear-gradient(to right, @l 0% var(--full), @inactiveColor var(--full) 100%);
-      -webkit-text-stroke: @c 0.78px;
+    .ui.@{color}.rating .active.icon {
+      color: @l;
+      text-shadow: 0px -@shadowWidth 0px @c,
+      -@shadowWidth 0px 0px @c,
+      0px @shadowWidth 0px @c,
+      @shadowWidth 0px 0px @c;
     }
-  }
-})
+    .ui.@{color}.rating .icon.selected,
+    .ui.@{color}.rating .icon.selected.active,
+    .ui.@{color}.rating .icon.selected.partial.active {
+      background: inherit;
+      color: @lh;
+      text-shadow: 0px -@shadowWidth 0px @h,
+      -@shadowWidth 0px 0px @h,
+      0px @shadowWidth 0px @h,
+      @shadowWidth 0px 0px @h;
+
+      -webkit-text-stroke: unset;
+      background-clip: unset;
+    }
+    & when (@variationRatingPartial) {
+      .ui.@{color}.rating .icon.partial.active {
+        background: linear-gradient(to right, @l 0% var(--full), @inactiveColor var(--full) 100%);
+        -webkit-text-stroke: @c 0.78px;
+      }
+    }
+  })
+}
 
 
 /*******************************

--- a/src/definitions/modules/slider.less
+++ b/src/definitions/modules/slider.less
@@ -291,46 +291,47 @@
 /*--------------
      Colors
 ---------------*/
+& when not (@variationSliderColors = false) {
+   each(@variationSliderColors, {
+     @color: @value;
+     @c: @colors[@@color][color];
+     @l: @colors[@@color][light];
+     @h: @colors[@@color][hover];
+     @lh: @colors[@@color][lightHover];
 
-each(@colors, {
-  @color: replace(@key, '@', '');
-  @c: @colors[@@color][color];
-  @l: @colors[@@color][light];
-  @h: @colors[@@color][hover];
-  @lh: @colors[@@color][lightHover];
+     /* Standard */
+     .ui.@{color}.slider .inner .track-fill {
+       background-color: @c;
+     }
+     & when (@variationSliderInverted) {
+       .ui.@{color}.inverted.slider .inner .track-fill {
+         background-color: @l;
+       }
+     }
 
-  /* Standard */
-  .ui.@{color}.slider .inner .track-fill {
-    background-color: @c;
-  }
-  & when (@variationSliderInverted) {
-    .ui.@{color}.inverted.slider .inner .track-fill {
-      background-color: @l;
-    }
-  }
+     & when (@variationSliderBasic) {
+       /* Basic */
+       .ui.@{color}.slider.basic .inner .thumb {
+         background-color: @c;
+       }
+       .ui.@{color}.slider.basic .inner .thumb:hover,
+       .ui.@{color}.slider.basic:focus .inner .thumb {
+         background-color: @h;
+       }
+       & when (@variationSliderInverted) {
+         /* Basic Inverted */
+         .ui.@{color}.inverted.slider.basic .inner .thumb {
+           background-color: @l;
+         }
+         .ui.@{color}.inverted.slider.basic .inner .thumb:hover,
+         .ui.@{color}.inverted.slider.basic:focus .inner .thumb {
+           background-color: @lh;
+         }
+       }
+     }
 
-  & when (@variationSliderBasic) {
-    /* Basic */
-    .ui.@{color}.slider.basic .inner .thumb {
-      background-color: @c;
-    }
-    .ui.@{color}.slider.basic .inner .thumb:hover,
-    .ui.@{color}.slider.basic:focus .inner .thumb {
-      background-color: @h;
-    }
-    & when (@variationSliderInverted) {
-      /* Basic Inverted */
-      .ui.@{color}.inverted.slider.basic .inner .thumb {
-        background-color: @l;
-      }
-      .ui.@{color}.inverted.slider.basic .inner .thumb:hover,
-      .ui.@{color}.inverted.slider.basic:focus .inner .thumb {
-        background-color: @lh;
-      }
-    }
-  }
-
-})
+   })
+}
 
 & when (@variationSliderBasic) {
   /*--------------

--- a/src/definitions/modules/toast.less
+++ b/src/definitions/modules/toast.less
@@ -603,24 +603,25 @@
 /*--------------
      Colors
 -------------- */
+& when not (@variationToastColors = false) {
+  each(@variationToastColors, {
+    @color: @value;
+    @c: @colors[@@color][color];
+    @l: @colors[@@color][light];
 
-each(@colors, {
-  @color: replace(@key, '@', '');
-  @c: @colors[@@color][color];
-  @l: @colors[@@color][light];
-
-  .ui.@{color}.toast {
-    background-color: @c;
-    color: @toastTextColor;
-  }
-  & when (@variationToastInverted) {
-    .ui.inverted.@{color}.toast,
-    .ui.toast-container .toast-box > .inverted.@{color}.attached.progress .bar {
-      background-color: @l;
-      color: @toastInvertedTextColor;
+    .ui.@{color}.toast {
+      background-color: @c;
+      color: @toastTextColor;
     }
-  }
-})
+    & when (@variationToastInverted) {
+      .ui.inverted.@{color}.toast,
+      .ui.toast-container .toast-box > .inverted.@{color}.attached.progress .bar {
+        background-color: @l;
+        color: @toastInvertedTextColor;
+      }
+    }
+  })
+}
 
 & when (@variationToastInverted) {
   .ui.inverted.toast {

--- a/src/definitions/views/card.less
+++ b/src/definitions/views/card.less
@@ -602,49 +602,50 @@
 /*-------------------
        Colors
 --------------------*/
+& when not (@variationCardColors = false) {
+  each(@variationCardColors, {
+    @color: @value;
+    @c: @colors[@@color][color];
+    @h: @colors[@@color][hover];
+    @l: @colors[@@color][light];
+    @lh: @colors[@@color][lightHover];
 
-each(@colors,{
-  @color: replace(@key,'@','');
-  @c: @colors[@@color][color];
-  @h: @colors[@@color][hover];
-  @l: @colors[@@color][light];
-  @lh: @colors[@@color][lightHover];
-
-  .ui.@{color}.cards > .card,
-  .ui.cards > .@{color}.card,
-  .ui.@{color}.card {
-    box-shadow:
+    .ui.@{color}.cards > .card,
+    .ui.cards > .@{color}.card,
+    .ui.@{color}.card {
+      box-shadow:
             @borderShadow,
             0 @coloredShadowDistance 0 0 @c,
             @shadowBoxShadow
-  ;
-    &:hover {
-    box-shadow:
+      ;
+      &:hover {
+      box-shadow:
             @borderShadow,
             0 @coloredShadowDistance 0 0 @h,
             @shadowHoverBoxShadow
-    ;
-    }
-  }
-  & when (@variationCardInverted) {
-    .ui.inverted.@{color}.cards > .card,
-    .ui.inverted.cards > .@{color}.card,
-    .ui.inverted.@{color}.card {
-      box-shadow:
-              0 @shadowDistance 3px 0 @solidWhiteBorderColor,
-              0 @coloredShadowDistance 0 0 @l,
-              0 0 0 @borderWidth @solidWhiteBorderColor
-    ;
-      &:hover {
-      box-shadow:
-              0 @shadowDistance 3px 0 @solidWhiteBorderColor,
-              0 @coloredShadowDistance 0 0 @lh,
-              0 0 0 @borderWidth @solidWhiteBorderColor
       ;
       }
     }
-  }
-})
+    & when (@variationCardInverted) {
+      .ui.inverted.@{color}.cards > .card,
+      .ui.inverted.cards > .@{color}.card,
+      .ui.inverted.@{color}.card {
+        box-shadow:
+              0 @shadowDistance 3px 0 @solidWhiteBorderColor,
+              0 @coloredShadowDistance 0 0 @l,
+              0 0 0 @borderWidth @solidWhiteBorderColor
+        ;
+        &:hover {
+        box-shadow:
+              0 @shadowDistance 3px 0 @solidWhiteBorderColor,
+              0 @coloredShadowDistance 0 0 @lh,
+              0 0 0 @borderWidth @solidWhiteBorderColor
+        ;
+        }
+      }
+    }
+  })
+}
 
 /*--------------
    Card Count

--- a/src/definitions/views/statistic.less
+++ b/src/definitions/views/statistic.less
@@ -323,25 +323,26 @@
 /*--------------
      Colors
 ---------------*/
+& when not (@variationStatisticColors = false) {
+  each(@variationStatisticColors, {
+    @color: @value;
+    @c: @colors[@@color][color];
+    @l: @colors[@@color][light];
 
-each(@colors,{
-  @color: replace(@key,'@','');
-  @c: @colors[@@color][color];
-  @l: @colors[@@color][light];
-
-  .ui.@{color}.statistics .statistic > .value,
-  .ui.statistics .@{color}.statistic > .value,
-  .ui.@{color}.statistic > .value {
-    color: @c;
-  }
-  & when (@variationStatisticInverted) {
-    .ui.inverted.@{color}.statistics .statistic > .value,
-    .ui.statistics .inverted.@{color}.statistic > .value,
-    .ui.inverted.@{color}.statistic > .value {
-      color: @l;
+    .ui.@{color}.statistics .statistic > .value,
+    .ui.statistics .@{color}.statistic > .value,
+    .ui.@{color}.statistic > .value {
+      color: @c;
     }
-  }
-})
+    & when (@variationStatisticInverted) {
+      .ui.inverted.@{color}.statistics .statistic > .value,
+      .ui.statistics .inverted.@{color}.statistic > .value,
+      .ui.inverted.@{color}.statistic > .value {
+        color: @l;
+      }
+    }
+  })
+}
 
 & when (@variationStatisticFloated) {
   /*--------------

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -4,6 +4,9 @@
 
 /* General */
 @variationAllSizes: mini, tiny, small, large, big, huge, massive;
+@variationAllColors: primary, secondary, red, orange, yellow, olive, green, teal, blue, violet, purple, pink, brown, grey, black;
+@variationAllStates: error, info, success, warning;
+@variationAllConsequences: positive, negative, error, info, success, warning;
 
 /*******************************
            Elements
@@ -28,6 +31,7 @@
 @variationButtonGroups: true;
 @variationButtonStackable: true;
 @variationButtonSizes: @variationAllSizes;
+@variationButtonColors: @variationAllColors;
 
 /* Container */
 @variationContainerGrid: true;
@@ -47,6 +51,7 @@
 @variationDividerClearing: true;
 @variationDividerSection: true;
 @variationDividerSizes: @variationAllSizes;
+@variationDividerColors: @variationAllColors;
 
 /* Header */
 @variationHeaderDisabled: true;
@@ -62,6 +67,7 @@
 @variationHeaderAttached: true;
 @variationHeaderTags: h1, h2, h3, h4, h5, h6;
 @variationHeaderSizes: @variationAllSizes;
+@variationHeaderColors: @variationAllColors;
 
 /* Icon */
 @variationIconDeprecated: true;
@@ -83,6 +89,7 @@
 @variationIconCorner: true;
 @variationIconGroups: true;
 @variationIconSizes: @variationAllSizes;
+@variationIconColors: @variationAllColors;
 
 /* Image */
 @variationImageDisabled: true;
@@ -102,7 +109,7 @@
 /* Input */
 @variationInputDisabled: true;
 @variationInputInverted: true;
-@variationInputStates: true;
+@variationInputStates: @variationAllStates;
 @variationInputTransparent: true;
 @variationInputCorner: true;
 @variationInputLoading: true;
@@ -126,6 +133,7 @@
 @variationLabelAttached: true;
 @variationLabelFluid: true;
 @variationLabelSizes: @variationAllSizes;
+@variationLabelColors: @variationAllColors;
 
 /* List */
 @variationListInverted: true;
@@ -154,6 +162,7 @@
 @variationLoaderInline: true;
 @variationLoaderElastic: true;
 @variationLoaderSizes: @variationAllSizes;
+@variationLoaderColors: @variationAllColors;
 
 /* Placeholder */
 @variationPlaceholderInverted: true;
@@ -201,6 +210,7 @@
 @variationSegmentAttached: true;
 @variationSegmentFitted: true;
 @variationSegmentSizes: @variationAllSizes;
+@variationSegmentColors: @variationAllColors;
 
 /* Step */
 @variationStepInverted: true;
@@ -215,8 +225,9 @@
 /* Text */
 @variationTextInverted: true;
 @variationTextDisabled: true;
-@variationTextStates: true;
+@variationTextStates: @variationAllStates;
 @variationTextSizes: @variationAllSizes;
+@variationTextColors: @variationAllColors;
 
 
 /*******************************
@@ -232,7 +243,7 @@
 @variationFormDisabled: true;
 @variationFormTransparent: true;
 @variationFormLoading: true;
-@variationFormStates: true;
+@variationFormStates: @variationAllStates;
 @variationFormRequired: true;
 @variationFormInline: true;
 @variationFormGrouped: true;
@@ -254,6 +265,7 @@
 @variationGridDoubling: true;
 @variationGridStackable: true;
 @variationGridCompact: true;
+@variationGridColors: @variationAllColors;
 
 /* Menu */
 @variationMenuInverted: true;
@@ -274,6 +286,7 @@
 @variationMenuFixed: true;
 @variationMenuAttached: true;
 @variationMenuSizes: @variationAllSizes;
+@variationMenuColors: @variationAllColors;
 
 /* Message */
 @variationMessageInverted: true;
@@ -281,10 +294,11 @@
 @variationMessageAttached: true;
 @variationMessageIcon: true;
 @variationMessageFloating: true;
-@variationMessageConsequences: true;
+@variationMessageConsequences: @variationAllConsequences;
 @variationMessageCentered: true;
 @variationMessageRightAligned: true;
 @variationMessageSizes: @variationAllSizes;
+@variationMessageColors: @variationAllColors;
 
 /* Table */
 @variationTableInverted: true;
@@ -310,6 +324,7 @@
 @variationTableCompact: true;
 @variationTableMarked: true;
 @variationTableSizes: @variationAllSizes;
+@variationTableColors: @variationAllColors;
 
 
 /*******************************
@@ -342,12 +357,14 @@
 @variationCardDoubling: true;
 @variationCardStackable: true;
 @variationCardSizes: @variationAllSizes;
+@variationCardColors: @variationAllColors;
 
 /* Comment */
 @variationCommentInverted: true;
 @variationCommentThreaded: true;
 @variationCommentMinimal: true;
 @variationCommentSizes: @variationAllSizes;
+@variationCommentColors: @variationAllColors;
 
 /* Feed */
 @variationFeedInverted: true;
@@ -368,6 +385,7 @@
 @variationStatisticFloated: true;
 @variationStatisticHorizontal: true;
 @variationStatisticSizes: @variationAllSizes;
+@variationStatisticColors: @variationAllColors;
 
 
 /*******************************
@@ -395,6 +413,7 @@
 @variationCheckboxFitted: true;
 @variationCheckboxRightAligned: true;
 @variationCheckboxSizes: @variationAllSizes;
+@variationCheckboxColors: @variationAllColors;
 
 /* Dimmer */
 @variationDimmerInverted: true;
@@ -421,7 +440,7 @@
 @variationDropdownMultiple: true;
 @variationDropdownInline: true;
 @variationDropdownLoading: true;
-@variationDropdownStates: true;
+@variationDropdownStates: @variationAllStates;
 @variationDropdownClear: true;
 @variationDropdownLeft: true;
 @variationDropdownUpward: true;
@@ -454,6 +473,7 @@
 @variationNagFixed: true;
 @variationNagGroups: true;
 @variationNagSizes: @variationAllSizes;
+@variationNagColors: @variationAllColors;
 
 /* Popup */
 @variationPopupInverted: true;
@@ -471,6 +491,7 @@
 @variationPopupFlowing: true;
 @variationPopupFixed: true;
 @variationPopupSizes: @variationAllSizes;
+@variationPopupColors: @variationAllColors;
 
 /* Progress */
 @variationProgressInverted: true;
@@ -489,11 +510,13 @@
 @variationProgressSpeeds: true;
 @variationProgressRightAligned: true;
 @variationProgressSizes: @variationAllSizes;
+@variationProgressColors: @variationAllColors;
 
 /* Rating */
 @variationRatingDisabled: true;
 @variationRatingPartial: true;
 @variationRatingSizes: @variationAllSizes;
+@variationRatingColors: @variationAllColors;
 
 /* Search */
 @variationSearchDisabled: true;
@@ -535,6 +558,7 @@
 @variationSliderVertical: true;
 @variationSliderBasic: true;
 @variationSliderSizes: small, large, big;
+@variationSliderColors: @variationAllColors;
 
 /* Tab */
 @variationTabLoading: true;
@@ -564,6 +588,7 @@
 @variationToastAttached: true;
 @variationToastCompact: true;
 @variationToastCentered: true;
+@variationToastColors: @variationAllColors;
 
 /* Transition */
 @variationTransitionDisabled: true;


### PR DESCRIPTION
## Description

This PR allows to define a color list for each component individually out of the central `colors.less` file.

For example, now it is possible to have only red, blue and orange buttons, but only yellow labels and no colors for message at all. See example below.

All of this can be defined in the central `variation.variables` file as before (or in custom theme file)

Before this change you were only able to reduce the whole color list by modifying the colors.less file and change the available colors for all components at once.

> ### Tip for reviewers: 
> For an easier overview add `?w=1` to the review URL which will ignore all the whitespace changes. github also has an  option for this via the gear icon
![image](https://user-images.githubusercontent.com/18379884/131321933-e7d0d8f5-355d-49a8-abe6-d032ee65de46.png)

## Testcase
### Example config for the above mentioned different colors per component
```less
// Only red, blue and orange buttons
@variationMessageColors: red, blue, orange;
// Only yellow labels
@variationLabelColors: yellow;
// No colors for message at all
@variationMessageColors: false;
```

### Example to reduce the colors in all components inside the `variation.variables` file only without the need to modify the `colors.less` (unless one needs totally new color names of course)

```less
// Simply adjust the central variable
// only green and black for all components
@variationAllColors: green, black;
```

#### I also applied the same logic for states and consequences:
```less
// Only info and warning textstates
@variationTextStates: info, warning;

// only Error form states
@variationFormStates: error;

// No dropdrop formstates
@variationDropdownStates: false;

// only positive and negative message consequences
@variationMessageConsequences: positive, negative;
```

The default theme will still build all colors into every component as before.