### PR TITLE
fix(form): keep a compact dropdown compact

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -245,7 +245,7 @@
 ---------------------*/
 
 /* Block */
-.ui.form .field > .selection.dropdown {
+.ui.form .field > .selection.dropdown:not(.compact) {
   min-width: auto;
   width: 100%;
 }


### PR DESCRIPTION
## Description
If one declares a selection dropdown as `compact`, this was overridden when such dropdown was used inside a form.

## Testcase
https://jsfiddle.net/lubber/weLpsajc/7/
Remove CSS to see the difference

## Screenshot
Watch the left dropdown field. This is an explicite `compact` dropdown.
### Before
![image](https://user-images.githubusercontent.com/18379884/131121875-dbafcf8b-af87-4b54-ac3b-ffbe230e2369.png)

### After
![image](https://user-images.githubusercontent.com/18379884/131121822-1ab020f6-b8b2-4d14-b002-a4d0fe4334a2.png)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5011