### PR TITLE
fix(table): links in compact selectable table cell get wrong padding

### DIFF
--- a/src/definitions/collections/table.less
+++ b/src/definitions/collections/table.less
@@ -642,6 +642,8 @@
   .ui.table tbody tr td.selectable > a:not(.ui) {
     display: block;
     color: inherit;
+  }
+  .ui.table:not(compact) tbody tr td.selectable > a:not(.ui) {
     padding: @cellVerticalPadding @cellHorizontalPadding;
   }
   .ui.table > tr > td.selectable,

--- a/src/definitions/collections/table.less
+++ b/src/definitions/collections/table.less
@@ -643,7 +643,7 @@
     display: block;
     color: inherit;
   }
-  .ui.table:not(compact) tbody tr td.selectable > a:not(.ui) {
+  .ui.table:not(.compact) tbody tr td.selectable > a:not(.ui) {
     padding: @cellVerticalPadding @cellHorizontalPadding;
   }
   .ui.table > tr > td.selectable,


### PR DESCRIPTION
## Description

Links in (very) compact selectable tables got a wrong padding, and reverted the compact padding.

## Testcase
Remove CSS to see the issue
https://jsfiddle.net/lubber/ensmy25b/7/

## Screenshot
The table is `compact`, but contains a link which was adding padding again.
|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/131183801-5dee803b-3992-422c-95fd-b91c6113da1c.png)|![image](https://user-images.githubusercontent.com/18379884/131183774-db5d3e79-157c-4425-a11e-51babedbf1d1.png)|


## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5293