### PR TITLE
fix(sidebar): make overflow hidden optional to support sticky

### DIFF
--- a/src/definitions/modules/sidebar.less
+++ b/src/definitions/modules/sidebar.less
@@ -141,13 +141,15 @@ body.pushable {
 .pushable > .pusher {
   position: relative;
   backface-visibility: hidden;
-  overflow: hidden;
   min-height: 100%;
   transition: transform @duration @easing;
   z-index: @middleLayer;
 
   /* Pusher should inherit background from context */
   background: inherit;
+  &:not(.overflowing) {
+    overflow: hidden;
+  }
 }
 
 body.pushable > .pusher {


### PR DESCRIPTION
## Description
The `pusher` element disables overflowing by default since https://github.com/Semantic-Org/Semantic-UI/issues/1655
In my tests that is only necessary in the mentioned particular testcase (a grid was used and the content is smaller than the sidebar)
However, there are still situations where that setting prevents other techniques inside the pusher like `native sticky` (where a parent node cannot have overflowing to be hidden to function properly)

This PR now allows to prevent the overflow:hidden setting if the pusher gets an additional `overflowing` class added.
This way previous codebases stay completely backward compatible by default.

## Testcase
- Scroll down, the Table header gets sticky
- Open the sidebar via provided button
- Close the Sidebar by clicking inside the dimmer
- Scroll the page again
- Watch the table(header)

https://jsfiddle.net/lubber/q8d5tuzy/14/

### Before
Remove the CSS to see that:
Table header is not sticky anymore

### After
Table header stays sticky

## Screenshot
### Before
![pushersticky_broken](https://user-images.githubusercontent.com/18379884/131316165-3b0bbe98-79c4-406e-a6fd-3026bd148444.gif)

### After
![pushersticky_fixed](https://user-images.githubusercontent.com/18379884/131316185-52f564b5-f161-4f59-94ae-c385cbd8d028.gif)


