### PR TITLE
feat(dimmer): use modern blurring to improve performance

### DIFF
--- a/src/definitions/modules/dimmer.less
+++ b/src/definitions/modules/dimmer.less
@@ -171,17 +171,21 @@ body.dimmable > .dimmer {
       Blurring
   ---------------*/
 
-  .blurring.dimmable > :not(.dimmer) {
-    filter: @blurredStartFilter;
-    transition: @blurredTransition;
-  }
-  .blurring.dimmed.dimmable > :not(.dimmer):not(.popup) {
-    filter: @blurredEndFilter;
+  @supports (not (-webkit-backdrop-filter: none)) and (not (backdrop-filter: none)) {
+    .blurring.dimmable > :not(.dimmer) {
+      filter: @blurredStartFilter;
+      transition: @blurredTransition;
+    }
+    .blurring.dimmed.dimmable > :not(.dimmer):not(.popup) {
+      filter: @blurredEndFilter;
+    }
   }
 
   /* Dimmer Color */
   .blurring.dimmable > .dimmer {
     background: @blurredBackgroundColor;
+    -webkit-backdrop-filter: @blurredEndFilter;
+    backdrop-filter: @blurredEndFilter;
   }
   .blurring.dimmable > .inverted.dimmer {
     background: @blurredInvertedBackgroundColor;

--- a/src/themes/default/modules/dimmer.variables
+++ b/src/themes/default/modules/dimmer.variables
@@ -12,7 +12,7 @@
 
 @duration: 0.5s;
 @transition:
-  background-color @duration linear
+  all @duration linear
 ;
 @zIndex: 1000;
 @textAlign: center;


### PR DESCRIPTION
## Description
The `blurring` dimmer is inperformant because every single node inside the dimmable context is blurred separately which takes lots of time. 
It also causes positioning glitches when applied (Try the blurring example at https://fomantic-ui.com/modules/modal.html#dimmer-variations and see the sidebar suddenly vanishes!) 
Additionally when used in modals it is not nicely animated when the modal hides.

This PR switches from the old filter approach on each single node to the modern backdrop-filer approach on the dimmer itself only which is much more performant and nicely animates now.
For each browser not supporting this technique, the old behavior will still apply as before.

## Testcase
Remove CSS to see the difference
https://jsfiddle.net/lubber/egzbcoL2/35/

## Screenshot
|Before|After|
|-|-|
|![oldblur](https://user-images.githubusercontent.com/18379884/132106250-f140c67a-281b-4729-bd96-15b929649632.gif)|![newblur](https://user-images.githubusercontent.com/18379884/132106254-cb1b40fd-a5ea-4d23-8f40-ca296fb792ea.gif)|

## Fixes
https://github.com/Semantic-Org/Semantic-UI/issues/5932
This PR fixes the mentioned issue in chrome.
One has to enable the backdrop-filter in the firefox settings and it will be fixed in firefox as well.