### PR TITLE
feat(chore): same custom scrollbars in chrome, FF and IE

### DIFF
--- a/src/definitions/globals/site.less
+++ b/src/definitions/globals/site.less
@@ -128,7 +128,7 @@ a:hover {
          Scrollbars
 *******************************/
 
-.addScrollbars() when (@useCustomScrollbars) {
+& when (@useCustomScrollbars) {
 
   /* Force Simple Scrollbars */
   body ::-webkit-scrollbar {
@@ -152,6 +152,17 @@ a:hover {
   body ::-webkit-scrollbar-thumb:hover {
     background: @thumbHoverBackground;
   }
+  body .ui {
+    /* IE11 */
+    scrollbar-face-color: @thumbBackgroundHex;
+    scrollbar-shadow-color: @thumbBackgroundHex;
+    scrollbar-track-color: @trackBackgroundHex;
+    scrollbar-arrow-color: @trackBackgroundHex;
+
+    /* firefox : first color thumb, second track*/
+    scrollbar-color:  @thumbBackground @trackBackground;
+    scrollbar-width: thin;
+  }
 
   /* Inverted UI */
   body .ui.inverted:not(.dimmer)::-webkit-scrollbar-track {
@@ -165,6 +176,17 @@ a:hover {
   }
   body .ui.inverted:not(.dimmer)::-webkit-scrollbar-thumb:hover {
     background: @thumbInvertedHoverBackground;
+  }
+
+  body .ui.inverted:not(.dimmer) {
+    /* IE11 */
+    scrollbar-face-color: @thumbInvertedBackgroundHex;
+    scrollbar-shadow-color: @thumbInvertedBackgroundHex;
+    scrollbar-track-color: @trackInvertedBackgroundHex;
+    scrollbar-arrow-color: @trackInvertedBackgroundHex;
+
+    /* firefox : first color thumb, second track */
+    scrollbar-color:  @thumbInvertedBackground @trackInvertedBackground;
   }
 }
 
@@ -203,5 +225,4 @@ input::selection {
   color: @inputHighlightColor;
 }
 
-.addScrollbars();
 .loadUIOverrides();

--- a/src/definitions/modules/dimmer.less
+++ b/src/definitions/modules/dimmer.less
@@ -68,7 +68,7 @@
 }
 
 /* Scrollbars */
-.addScrollbars() when (@useCustomScrollbars) {
+& when (@useCustomScrollbars) {
   .ui.dimmer:not(.inverted)::-webkit-scrollbar-track {
     background: @trackInvertedBackground;
   }
@@ -92,7 +92,6 @@
     scrollbar-color:  @thumbInvertedBackground @trackInvertedBackground;
   }
 }
-.addScrollbars();
 
 /*******************************
             States

--- a/src/definitions/modules/dimmer.less
+++ b/src/definitions/modules/dimmer.less
@@ -81,6 +81,16 @@
   .ui.dimmer:not(.inverted)::-webkit-scrollbar-thumb:hover {
     background: @thumbInvertedHoverBackground;
   }
+  .ui.dimmer:not(.inverted) {
+    /* IE11 */
+    scrollbar-face-color: @thumbInvertedBackgroundHex;
+    scrollbar-shadow-color: @thumbInvertedBackgroundHex;
+    scrollbar-track-color: @trackInvertedBackgroundHex;
+    scrollbar-arrow-color: @trackInvertedBackgroundHex;
+
+    /* firefox : first color thumb, second track */
+    scrollbar-color:  @thumbInvertedBackground @trackInvertedBackground;
+  }
 }
 .addScrollbars();
 

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -1912,21 +1912,34 @@ select.ui.dropdown {
   }
 
   /* Scrollbars */
-  .ui.dropdown .inverted.menu::-webkit-scrollbar-track,
-  .ui.inverted.dropdown .menu::-webkit-scrollbar-track {
-    background: @trackInvertedBackground;
-  }
-  .ui.dropdown .inverted.menu::-webkit-scrollbar-thumb,
-  .ui.inverted.dropdown .menu::-webkit-scrollbar-thumb {
-    background: @thumbInvertedBackground;
-  }
-  .ui.dropdown .inverted.menu::-webkit-scrollbar-thumb:window-inactive,
-  .ui.inverted.dropdown .menu::-webkit-scrollbar-thumb:window-inactive {
-    background: @thumbInvertedInactiveBackground;
-  }
-  .ui.dropdown .inverted.menu::-webkit-scrollbar-thumb:hover,
-  .ui.inverted.dropdown .menu::-webkit-scrollbar-thumb:hover {
-    background: @thumbInvertedHoverBackground;
+  & when (@useCustomScrollbars) {
+    .ui.dropdown .inverted.menu::-webkit-scrollbar-track,
+    .ui.inverted.dropdown .menu::-webkit-scrollbar-track {
+      background: @trackInvertedBackground;
+    }
+    .ui.dropdown .inverted.menu::-webkit-scrollbar-thumb,
+    .ui.inverted.dropdown .menu::-webkit-scrollbar-thumb {
+      background: @thumbInvertedBackground;
+    }
+    .ui.dropdown .inverted.menu::-webkit-scrollbar-thumb:window-inactive,
+    .ui.inverted.dropdown .menu::-webkit-scrollbar-thumb:window-inactive {
+      background: @thumbInvertedInactiveBackground;
+    }
+    .ui.dropdown .inverted.menu::-webkit-scrollbar-thumb:hover,
+    .ui.inverted.dropdown .menu::-webkit-scrollbar-thumb:hover {
+      background: @thumbInvertedHoverBackground;
+    }
+    .ui.dropdown .inverted.menu,
+    .ui.inverted.dropdown .menu {
+      /* IE11 */
+      scrollbar-face-color: @thumbInvertedBackgroundHex;
+      scrollbar-shadow-color: @thumbInvertedBackgroundHex;
+      scrollbar-track-color: @trackInvertedBackgroundHex;
+      scrollbar-arrow-color: @trackInvertedBackgroundHex;
+
+      /* firefox : first color thumb, second track */
+      scrollbar-color:  @thumbInvertedBackground @trackInvertedBackground;
+    }
   }
   & when (@variationDropdownPointing) {
     .ui.pointing.dropdown > .inverted.menu:after,

--- a/src/themes/default/globals/site.variables
+++ b/src/themes/default/globals/site.variables
@@ -174,6 +174,12 @@
 @thumbInvertedInactiveBackground: rgba(255, 255, 255, 0.15);
 @thumbInvertedHoverBackground: rgba(255, 255, 255, 0.35);
 
+/* IE needs hex values */
+@trackBackgroundHex: #e6e6e6;
+@thumbBackgroundHex: #bfbfbf;
+@trackInvertedBackgroundHex: #323232;
+@thumbInvertedBackgroundHex: #656565;
+
 /*-------------------
   Highlighted Text
 --------------------*/


### PR DESCRIPTION
## Description

Custom scrollbars are already implemented since a long time for non body elements.
However, only webit based browsers were targeted.

This PR now adds the same look and feel to firefox and IE as well (as far, as those browsers support it)

## Testcase
https://jsfiddle.net/lubber/h0n7bur6/3/
Remove CSS to see the behavior before.

## Screenshot
|webkit before|firefox before|IE before|webkit AFTER|firefox AFTER|IE AFTER|
|-|-|-|-|-|-|
|![image](https://user-images.githubusercontent.com/18379884/132592891-b6eefc3d-9f0c-4363-b127-f18fd2738099.png)|![image](https://user-images.githubusercontent.com/18379884/132593214-98788bef-fb93-4a50-8d3f-4c89653d2cc0.png)|![image](https://user-images.githubusercontent.com/18379884/132593330-04ccb227-eb33-40f5-896e-e06135c27c3a.png)|![image](https://user-images.githubusercontent.com/18379884/132592891-b6eefc3d-9f0c-4363-b127-f18fd2738099.png)|![image](https://user-images.githubusercontent.com/18379884/132593011-54dec315-3746-4f5b-94ac-43d77896ed38.png)|![image](https://user-images.githubusercontent.com/18379884/132593068-ead0ec0b-f9ad-4b19-9848-a2f547746d54.png)|

