### PR TITLE
fix(modal): respect approve deny callback on js modals

### DIFF
--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -127,7 +127,8 @@ $.fn.modal = function(parameters) {
                 'aria-label': $('<div>'+(el[fields.text] || el[fields.icon] || '')+'</div>').text(),
                 class: className.button + ' ' + cls,
                 click: function () {
-                  if (click.call(element, $module) === false) {
+                  var button = $(this);
+                  if (button.is(selector.approve) || button.is(selector.deny) || click.call(element, $module) === false) {
                     return;
                   }
                   module.hide();
@@ -772,7 +773,7 @@ $.fn.modal = function(parameters) {
               $module
                   .off('mousedown' + elementEventNamespace)
               ;
-            }           
+            }
             $dimmer
               .off('mousedown' + elementEventNamespace)
             ;
@@ -1042,7 +1043,7 @@ $.fn.modal = function(parameters) {
                       ? $(document).scrollTop() + settings.padding
                       : $(document).scrollTop() + (module.cache.contextHeight - module.cache.height - settings.padding),
                   marginLeft: -(module.cache.width / 2)
-                }) 
+                })
               ;
             } else {
               $module
@@ -1051,7 +1052,7 @@ $.fn.modal = function(parameters) {
                     ? -(module.cache.height / 2)
                     : settings.padding / 2,
                   marginLeft: -(module.cache.width / 2)
-                }) 
+                })
               ;
             }
             module.verbose('Setting modal offset for legacy mode');


### PR DESCRIPTION
## Description
When using modals via JS properties only having any approve/deny buttons declared as actions, those did not respect the `onApprove` or `onDeny` callbacks returning a possible false to prevent hiding the modal.

## Testcase
Try to click on either buttons. Both should _not_ hide the modal as the onApprove and onDeny callbacks return false.

### Broken
https://jsfiddle.net/lubber/np2bdLew/14/

### Fixed
https://jsfiddle.net/lubber/np2bdLew/15/

## Closes
#2105 