### PR TITLE
fix(icon): adjust icons width to match single icon 

### DIFF
--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -376,6 +376,8 @@ i.icons {
     display: inline-block;
     position: relative;
     line-height: 1;
+    min-width: @width;
+    min-height: @height;
   }
 
   i.icons .icon {

--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -105,6 +105,7 @@ i.emphasized.icon:not(.disabled), i.emphasized.icons:not(.disabled) {
           Fitted
   --------------------*/
 
+  i.fitted.icons,
   i.fitted.icon {
     width: auto;
     margin: 0 !important;

--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -378,6 +378,8 @@ i.icons {
     line-height: 1;
     min-width: @width;
     min-height: @height;
+    margin: 0em @distanceFromText 0em 0em;
+    text-align: center;
   }
 
   i.icons .icon {

--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -379,7 +379,7 @@ i.icons {
     line-height: 1;
     min-width: @width;
     min-height: @height;
-    margin: 0em @distanceFromText 0em 0em;
+    margin: 0 @distanceFromText 0 0;
     text-align: center;
   }
 


### PR DESCRIPTION
## Description
I have a dropdown with two items

The first item has a simple icon

`<i class="blue file excel outline icon"></i>`

The second one has two grouped icons

```html
<i class="icons">
    <i class="red file excel outline icon"></i>
    <i class="red bottom right corner key icon"></i>
</i>
```

Because the `.icon` has a width and the `.icons` does not visually they look off. The grouped icons has a smaller width then the simple icon

This PR adds a min-width to the `.icons` to make sure that the .icons group will be at least the same size of the `.icon`
I didn't want to use `width` because in some cases maybe the grouped icons need more space.

For the same reason i added a min-width i added also a min-height.
the height is not the cause of my problem, but i think it's best to add it as well.

## Testcase
https://jsfiddle.net/xoaj6kgh/

## Screenshot (if possible)

![image](https://user-images.githubusercontent.com/1449151/133763847-2123a80e-b300-489b-a71c-fd6edd47d38a.png)
