### PR TITLE
fix(toast): respect approve deny callbacks in actions

### DIFF
--- a/src/definitions/modules/toast.js
+++ b/src/definitions/modules/toast.js
@@ -229,7 +229,8 @@ $.fn.toast = function(parameters) {
                   html: icon + text,
                   class: className.button + ' ' + cls,
                   click: function () {
-                    if (click.call(element, $module) === false) {
+                    var button = $(this);
+                    if (button.is(selector.approve) || button.is(selector.deny) || click.call(element, $module) === false) {
                       return;
                     }
                     module.close();


### PR DESCRIPTION
## Description
Just as in #2108 , if an action button has a approve/deny class, a possible returned false in the `onApprove` and/or `onDeny` callback did not prevent to hide the toast.
The bug and therefore the fix is exactly the same for toast as it was for modal before.

## Testcase
Try to click on the action buttons on the opened toast.

### Broken
They close the toast
https://jsfiddle.net/lubber/np2bdLew/16/

### Fixed
They do not close the toast
https://jsfiddle.net/lubber/np2bdLew/18/
