### PR TITLE
feat(toast): image variant, a11y support, title html, click support

### DIFF
--- a/src/definitions/modules/toast.js
+++ b/src/definitions/modules/toast.js
@@ -85,7 +85,7 @@ $.fn.toast = function(parameters) {
               settings.showProgress = false;
             }
             module.create.toast();
-            if(settings.closeOnClick && ($($toast).find(selector.input).length > 0 || module.has.configActions())){
+            if(settings.closeOnClick && (settings.closeIcon || $($toast).find(selector.input).length > 0 || module.has.configActions())){
               settings.closeOnClick = false;
             }
             if(!settings.closeOnClick) {

--- a/src/definitions/modules/toast.js
+++ b/src/definitions/modules/toast.js
@@ -355,7 +355,7 @@ $.fn.toast = function(parameters) {
             }
             $toast.on('click' + eventNamespace, module.event.click);
             if($animationObject) {
-              $animationObject.on('animationend' + eventNamespace, module.close);
+              $animationObject.on('animationend' + eventNamespace, module.event.close);
             }
             $toastBox
               .on('click' + eventNamespace, selector.approve, module.event.approve)
@@ -367,9 +367,10 @@ $.fn.toast = function(parameters) {
         unbind: {
           events: function() {
             module.debug('Unbinding events to toast');
-            (settings.closeIcon ? $close : $toast)
-                .off('click' + eventNamespace)
-            ;
+            if(settings.closeIcon) {
+              $close.off('click' + eventNamespace);
+            }
+            $toast.off('click' + eventNamespace);
             if($animationObject) {
               $animationObject.off('animationend' + eventNamespace);
             }

--- a/src/definitions/modules/toast.less
+++ b/src/definitions/modules/toast.less
@@ -523,6 +523,12 @@
     }
   }
   &.vertical when (@variationToastVertical) {
+    & > .content {
+      flex-grow: 1;
+    }
+    &.attached when (@variationToastAttached){
+      flex-grow: 1;
+    }
     & > .close.icon + .content when (@variationToastClose){
       padding-left: @toastCloseDistanceVertical;
     }
@@ -552,6 +558,25 @@
     &.top {
       border-bottom-left-radius: 0;
       border-bottom-right-radius: 0;
+    }
+  }
+
+  &.ui.ui.ui.image when (@variationToastImage) {
+    padding: 0;
+    & > .content {
+      padding-top: @inputVerticalPadding;
+      padding-bottom: @inputVerticalPadding;
+      padding-right: @inputHorizontalPadding;
+    }
+    & > .actions when (@variationToastActions) {
+      margin: 0;
+    }
+    & > .ui.mini.image {
+      min-width: @toastImageMiniImageSize;
+      & + .content {
+        min-height: @toastImageMiniImageAdjustment;
+        padding-left: @toastImageMiniImagePadding;
+      }
     }
   }
 }

--- a/src/definitions/modules/toast.less
+++ b/src/definitions/modules/toast.less
@@ -572,7 +572,7 @@
       margin: 0;
     }
     & > .ui.mini.image {
-      min-width: @toastImageMiniImageSize;
+      min-width: @toastImageMiniImageAdjustment;
       & + .content {
         min-height: @toastImageMiniImageAdjustment;
         padding-left: @toastImageMiniImagePadding;

--- a/src/definitions/modules/toast.less
+++ b/src/definitions/modules/toast.less
@@ -571,11 +571,15 @@
     & > .actions when (@variationToastActions) {
       margin: 0;
     }
-    & > .ui.mini.image {
-      min-width: @toastImageMiniImageAdjustment;
-      & + .content {
-        min-height: @toastImageMiniImageAdjustment;
-        padding-left: @toastImageMiniImagePadding;
+    & > .ui.image {
+      border-top-left-radius: @defaultBorderRadius;
+      border-bottom-left-radius: @defaultBorderRadius;
+      &.mini {
+        min-width: @toastImageMiniImageAdjustment;
+        & + .content {
+          min-height: @toastImageMiniImageAdjustment;
+          padding-left: @toastImageMiniImagePadding;
+        }
       }
     }
   }

--- a/src/themes/default/modules/toast.variables
+++ b/src/themes/default/modules/toast.variables
@@ -58,7 +58,7 @@
 @toastIconCenteredAdjustment: 1.2em;
 @toastImageCenteredAdjustment: 2em;
 
-@toastImageMiniImageAdjustment: e(%("calc(%d + %d)", @inputVerticalPadding, @toastMiniImageHeight));//calc(.78571429rem + );
+@toastImageMiniImageAdjustment: e(%("calc(%d + %d)", @inputVerticalPadding, @toastMiniImageHeight));
 @toastImageMiniImagePadding: 4.4em;
 
 /* Progressbar Colors */

--- a/src/themes/default/modules/toast.variables
+++ b/src/themes/default/modules/toast.variables
@@ -58,6 +58,9 @@
 @toastIconCenteredAdjustment: 1.2em;
 @toastImageCenteredAdjustment: 2em;
 
+@toastImageMiniImageAdjustment: e(%("calc(%d + %d)", @inputVerticalPadding, @toastMiniImageHeight));//calc(.78571429rem + );
+@toastImageMiniImagePadding: 4.4em;
+
 /* Progressbar Colors */
 @toastInfoProgressColor: darken(@toastInfoColor,15);
 @toastWarningProgressColor: darken(@toastWarningColor,15);


### PR DESCRIPTION
## Description
Once again: Another year, another toast enhancement 🙂 

This PR

- adds accessibility support using aria labels to toasts just like we did for modals in #2036 
- adds a `ui image toast` variant to show images without any padding
- fixes missing html support in titles
- fixes wrong placement of vertical actions when the message was too short
- supports the `onClick` handler in any case now even if `closeOnClick` is set to false 
  - onClick can now also return false to prevent closing the toast
  - the close icon gets a dedicated event now independent of the onClick event

## Testcase
https://jsfiddle.net/lubber/xym8qg9j/37/

## Screenshots
#### ui image toast
![image](https://user-images.githubusercontent.com/18379884/135754095-3db9538f-dbd4-431b-8f47-825628811121.png)

### wrong placement of actions
|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/135695861-ab15784f-41ea-43b0-9c0f-89f785fca86d.png)|![image](https://user-images.githubusercontent.com/18379884/135695778-796f8371-6f0a-4cdc-a65d-4d1f18ca607a.png)|

### html titles
|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/135695847-e5255f99-ae19-48e5-80b8-7b1e36c04ff4.png)|![image](https://user-images.githubusercontent.com/18379884/135695800-42cabb9b-67eb-454a-a371-991a87823b9d.png)|


## Closes
#2125 
