### PR TITLE
fix(form): fetch range input prompt for numeric values only

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -544,7 +544,7 @@ $.fn.form = function(parameters) {
               parts,
               suffixPrompt
             ;
-            if(ancillary && ancillary.indexOf('..') >= 0) {
+            if(ancillary && ['integer', 'decimal', 'number'].indexOf(ruleName) >= 0 && ancillary.indexOf('..') >= 0) {
               parts = ancillary.split('..', 2);
               if(!rule.prompt) {
                 suffixPrompt = (


### PR DESCRIPTION
## Description
The check in the prompt assumed the rule value is a string, but it may also be a regex, which throws an exception.
Additionally, it can be a normal string with two dots, e.g. `type: "contains[hello..world]"` which shouldn't be treated as a range.
So I changed the check to also verify the type can contain a range, rather than just check if the value has two dots inside.

## Testcase
[JSFiddle testcase](https://jsfiddle.net/7uz5jtrf/)

Given the rule `{ type: 'contains[hello...]' }` the resulting prompt is `Please enter a valid value and must be in a range from hello to .` which is nonsense, since it checks whether the text contains the literal `hello...`.

Given the rule `{ type: 'regExp', value: /hello/ }` we get an exception `Uncaught TypeError: ancillary.indexOf is not a function` because `ancillary` is a `RegExp` and not a string, so doesn't have `indexOf`. Validation is then entirely broken.