### PR TITLE
[list] fix styling of multi-digit ordered lists (#1130)

### DIFF
--- a/src/definitions/elements/list.less
+++ b/src/definitions/elements/list.less
@@ -703,6 +703,7 @@ ol.ui.list ol li,
     left: auto;
     user-select: none;
     pointer-events: none;
+    transform: translateX(-100%);
     margin-left: -(@orderedCountDistance);
     counter-increment: @orderedCountName;
     content: @orderedCountContent;

--- a/src/themes/default/elements/list.variables
+++ b/src/themes/default/elements/list.variables
@@ -179,7 +179,7 @@
 @orderedCountContent: counters(@orderedCountName, @orderedCountSeparator) " ";
 @orderedCountContentSuffixed: counters(@orderedCountName, @orderedCountSeparator) @orderedCountSuffix;
 @orderedCountColor: @textColor;
-@orderedCountDistance: 1.25rem;
+@orderedCountDistance: 0.65rem;
 @orderedCountOpacity: 0.8;
 @orderedCountTextAlign: right;
 @orderedCountVerticalAlign: middle;


### PR DESCRIPTION
## Description
Fixes styling of multi-digit ordered lists - made the number aligned to the right of the text, so that when more digits are required they will be added on the left and the right edge of the number will stay in place.

I used `translateX(-100%)` to keep the right edge in a constant position, and adjusted the margin a bit since it previously accounted for the width of the number itself. The number I adjusted it to is to keep the look of numbers with single digits the same.

## Testcase
https://jsfiddle.net/futybd2v/

## Screenshot
Current (left) vs fixed (right)
![image](https://user-images.githubusercontent.com/26556598/138567700-4a676896-cf20-49c7-9abf-c7d35184f3ea.png)


## Closes
Fixes #1130