### PR TITLE
fix(tab): initializing active tab with historytype 'state'

### DIFF
--- a/src/definitions/modules/tab.js
+++ b/src/definitions/modules/tab.js
@@ -100,10 +100,18 @@ $.fn.tab = function(parameters) {
             initializedHistory = true;
           }
 
-          if(settings.autoTabActivation && instance === undefined && module.determine.activeTab() == null) {
-            module.debug('No active tab detected, setting first tab active', module.get.initialPath());
-            module.changeTab(settings.autoTabActivation === true ? module.get.initialPath() : settings.autoTabActivation);
-          };
+          var activeTab = module.determine.activeTab();
+          if(settings.autoTabActivation && instance === undefined && activeTab == null) {
+            activeTab = settings.autoTabActivation === true ? module.get.initialPath() : settings.autoTabActivation;
+            module.debug('No active tab detected, setting tab active', activeTab);
+            module.changeTab(activeTab);
+          }
+          if(activeTab != null && settings.history) {
+            var autoUpdate = $.address.autoUpdate();
+            $.address.autoUpdate(false);
+            $.address.value(activeTab);
+            $.address.autoUpdate(autoUpdate);
+          }
 
           module.instantiate();
         },
@@ -203,6 +211,7 @@ $.fn.tab = function(parameters) {
                   .history(true)
                   .state(settings.path)
                 ;
+                $(window).trigger('popstate');
               }
               else {
                 module.error(error.path);


### PR DESCRIPTION
If I initialize the active tab with the name of second tab in the property `autoTabActivation` and set the property `historyType` to `state`, the active tab is not set to the right tab (the second).

If I set the property `historyType` to `hash`, that's work !

## Broken
https://jsfiddle.net/dutrieux/p3oru58t/ 

## Fixed
https://jsfiddle.net/dutrieux/b4r8n7hg/

## Closes
#2154
