### PR TITLE
fix(dropdown): onChange is fired on menu openeing when reselection=true

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -848,7 +848,7 @@ $.fn.dropdown = function(parameters) {
                   var value = module.is.multiple() ? module.get.values() : module.get.value();
                   if (value !== '') {
                     module.verbose('Value(s) present after click icon, select value(s) in items');
-                    module.set.selected(value, null, null, true);
+                    module.set.selected(value, null, true, true);
                   }
                 }
                 iconClicked = false;


### PR DESCRIPTION
# Description
onChange event is fire when the menu of dropdown is open when allowReselection=true and with remote content

This problem is only when dropdown use remote content and is not multiple.

## Steps to reproduce
1. select a item on the **first** dropdown
2. click on the **first** dropdown to display the menu, on show on console

## Broken
https://jsfiddle.net/dutrieux/p5k83jL6/

## Fixed
https://jsfiddle.net/dutrieux/hfLby8d9/

## Screenshot (if possible)
![dropdown](https://user-images.githubusercontent.com/1622751/142733991-0fcf7f3f-8551-494f-883b-ff7e7c0a70c0.gif)
## Version
<!-- Include the version of the library you are using (required). -->
2.8.8

## Closes
#2161
