### PR TITLE
fix(segment): ignore attached border when basic

### DIFF
--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -730,7 +730,9 @@
     width: @attachedWidth;
     max-width: @attachedWidth;
     box-shadow: @attachedBoxShadow;
-    border: @attachedBorder;
+    &:not(.basic) {
+      border: @attachedBorder;
+    }
   }
   .ui.attached:not(.message):not(.text) + .ui.attached.segment:not(.top) {
     border-top: none;


### PR DESCRIPTION
## Description

A `basic attached segment` should not have borders.

## Testcase
https://jsfiddle.net/lubber/ywo3fbnz/6/

## Closes
#330