### PR TITLE
fix(dropdown): split delimiter values on paste

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -629,6 +629,11 @@ $.fn.dropdown = function(parameters) {
             $module
               .on('change' + eventNamespace, selector.input, module.event.change)
             ;
+            if(module.is.multiple() && module.is.searchSelection()) {
+              $module
+                  .on('paste' + eventNamespace, selector.search, module.event.paste)
+              ;
+            }
           },
           mouseEvents: function() {
             module.verbose('Binding mouse events');
@@ -1077,6 +1082,15 @@ $.fn.dropdown = function(parameters) {
         },
 
         event: {
+          paste: function(event) {
+            var pasteValue = (event.originalEvent.clipboardData || window.clipboardData).getData('text'),
+                tokens = pasteValue.split(settings.delimiter)
+            ;
+            tokens.forEach(function(value){
+              module.set.selected(module.escape.htmlEntities(value.trim()), null, true, true);
+            });
+            event.preventDefault();
+          },
           change: function() {
             if(!internalChange) {
               module.debug('Input changed, updating selection');
@@ -1535,7 +1549,7 @@ $.fn.dropdown = function(parameters) {
                 hasSubMenu            = ($subMenu.length> 0),
                 hasSelectedItem       = ($selectedItem.length > 0),
                 selectedIsSelectable  = ($selectedItem.not(selector.unselectable).length > 0),
-                delimiterPressed      = (pressedKey == keys.delimiter && settings.allowAdditions && module.is.multiple()),
+                delimiterPressed      = (pressedKey == keys.delimiter && module.is.multiple()),
                 isAdditionWithoutMenu = (settings.allowAdditions && settings.hideAdditions && (pressedKey == keys.enter || delimiterPressed) && selectedIsSelectable),
                 $nextItem,
                 isSubMenuItem,


### PR DESCRIPTION
## Description
When pasting a string inside a `search selection dropdown` existing comma values (the default delimiter) is ignored. Even worse, when pressing enter afterwards the whole pasted string, containing delimiter values is used as a value itself.
This MR now supports the paste event and splits the pasted string into separate values and adds them when either `allowAdditions:true` or if the value exists in the dropdown menu.
Therefore the delimiter key is now also supported on multiple dropdowns which do not allow additions for consistency

## Testcase
https://jsfiddle.net/lubber/jc3xtshd 

##  Screenshot
### Before
![pastedelimiterwrong](https://user-images.githubusercontent.com/18379884/144315491-84a38cc8-0224-4328-9598-3ad3b33bd857.gif)

### After
![pastedelimiterright](https://user-images.githubusercontent.com/18379884/144315458-65c88176-3a05-4574-a984-57357b8945f0.gif)

## Closes
#2166 
https://github.com/Semantic-Org/Semantic-UI/issues/5897
https://github.com/Semantic-Org/Semantic-UI/issues/3521
