### PR TITLE
fix(api): reset existing formdata for proper renewing

### DIFF
--- a/src/definitions/behaviors/api.js
+++ b/src/definitions/behaviors/api.js
@@ -443,6 +443,9 @@ $.api = $.fn.api = function(parameters) {
               } else {
                 formData[element.name] = element.value;
               }
+              if(hasOtherData && data[element.name]) {
+                delete data[element.name];
+              }
             });
 
             if(hasOtherData) {


### PR DESCRIPTION
## Desctiption
The apis `formData` collections always extended an already existing data value. If this however already contained properties of the same names as the formfields those were extended as well.
This led into situations where you want to reuse the same api several times. Especially for multiple name form fields like dropdown those always kept the previous values when submitted multiple times

## Testcase
- Open console
- Select three languages (English + French + Dutch)
- submit
- console show all three selected languages
- remove one (for example French)
- submit again.
 
### Broken
console again shows all three languages 
https://jsfiddle.net/lubber/05msby9h

### Fixed
console only shows the two languages
https://jsfiddle.net/lubber/05msby9h/5/

## Closes
#2174 