### PR TITLE
feat(progress): onsuccess was not triggered on reset

### DIFF
--- a/src/definitions/modules/progress.js
+++ b/src/definitions/modules/progress.js
@@ -607,6 +607,9 @@ $.fn.progress = function(parameters) {
             }
             else {
               module.remove.active();
+              module.remove.warning();
+              module.remove.error();
+              module.remove.success();
               module.set.label(settings.text.active);
             }
           },


### PR DESCRIPTION
## Description
Whenever a progress was (re)set to 0 any previously existing class states were not removed. This led into the success callback  not being called again when it was already triggered once

## Testcase
1. click on reset button
2. click on 100% button 
3. check the console, the onSuccess event is triggered
4. click on reset button
5. click on 100% button

### Broken
6. check the console, the onSuccess event is **not** triggered
https://jsfiddle.net/dutrieux/v85om3t1/

### Fixed
6. check the console, the onSuccess event is triggered again
https://jsfiddle.net/lubber/aqb5zjuo/

## Closes
#2177 
