### PR TITLE
fix(themes): less3/4 needs font import interpreted as raw css

### DIFF
--- a/src/themes/bookish/elements/header.overrides
+++ b/src/themes/bookish/elements/header.overrides
@@ -2,7 +2,7 @@
            Overrides
 *******************************/
 
-@import url(https://fonts.googleapis.com/css?family=Karma);
+@import (css) url('https://fonts.googleapis.com/css2?family=Karma');
 
 h1.ui.header,
 .ui.huge.header {

--- a/src/themes/chubby/elements/button.overrides
+++ b/src/themes/chubby/elements/button.overrides
@@ -2,7 +2,7 @@
            Overrides
 *******************************/
 
-@import url(https://fonts.googleapis.com/css?family=Source+Sans+Pro);
+@import (css) url('https://fonts.googleapis.com/css2?family=Source+Sans+Pro');
 
 .ui.labeled.icon.buttons > .button > .icon,
 .ui.labeled.icon.button > .icon {

--- a/src/themes/chubby/elements/header.overrides
+++ b/src/themes/chubby/elements/header.overrides
@@ -2,4 +2,4 @@
            Overrides
 *******************************/
 
-@import url(https://fonts.googleapis.com/css?family=Source+Sans+Pro);
+@import (css) url('https://fonts.googleapis.com/css2?family=Source+Sans+Pro');

--- a/src/themes/instagram/views/card.overrides
+++ b/src/themes/instagram/views/card.overrides
@@ -3,7 +3,7 @@
 *******************************/
 
 
-@import url(https://fonts.googleapis.com/css?family=Montserrat:700,400);
+@import (css) url('https://fonts.googleapis.com/css2?family=Montserrat');
 
 .ui.cards > .card,
 .ui.card {

--- a/src/themes/material/collections/menu.overrides
+++ b/src/themes/material/collections/menu.overrides
@@ -1,1 +1,1 @@
-@import url(https://fonts.googleapis.com/css?family=Roboto);
+@import (css) url('https://fonts.googleapis.com/css2?family=Roboto');

--- a/src/themes/material/elements/button.overrides
+++ b/src/themes/material/elements/button.overrides
@@ -1,4 +1,4 @@
-@import url(https://fonts.googleapis.com/css?family=Roboto);
+@import (css) url('https://fonts.googleapis.com/css2?family=Roboto');
 
 .ui.primary.button:hover {
   box-shadow:

--- a/src/themes/material/elements/header.overrides
+++ b/src/themes/material/elements/header.overrides
@@ -2,7 +2,7 @@
            Overrides
 *******************************/
 
-@import url(https://fonts.googleapis.com/css?family=Roboto);
+@import (css) url('https://fonts.googleapis.com/css2?family=Roboto');
 
 h1.ui.header,
 .ui.huge.header {

--- a/src/themes/material/modules/dropdown.overrides
+++ b/src/themes/material/modules/dropdown.overrides
@@ -1,4 +1,4 @@
-@import url(https://fonts.googleapis.com/css?family=Roboto:400,700);
+@import (css) url('https://fonts.googleapis.com/css2?family=Roboto');
 
 .ui.dropdown {
   font-family: 'Roboto';

--- a/src/themes/material/modules/modal.overrides
+++ b/src/themes/material/modules/modal.overrides
@@ -1,4 +1,4 @@
-@import url(https://fonts.googleapis.com/css?family=Roboto);
+@import (css) url('https://fonts.googleapis.com/css2?family=Roboto');
 
 .ui.modal .header {
   font-family: "Roboto", Arial, Sans-serif !important;

--- a/src/themes/rtl/globals/site.overrides
+++ b/src/themes/rtl/globals/site.overrides
@@ -3,4 +3,4 @@
 *******************************/
 
 /* Import Droid Arabic Kufi */
-@import 'https://fonts.googleapis.com/earlyaccess/droidarabickufi.css';
+@import (css) url('https://fonts.googleapis.com/css2?family=Droid+Arabic+Kufi');


### PR DESCRIPTION
## Description

When using webpack 4+ and LESS 3/4 the font imports have to be interpreted as raw CSS, otherwise the build breaks.
This is already fixed for the default theme since 3 years, but any of the included optional themes will fail.

I also updated the google font api usage to v2