### PR TITLE
fix(checkbox): wrong variable usage

### DIFF
--- a/src/themes/default/modules/checkbox.variables
+++ b/src/themes/default/modules/checkbox.variables
@@ -149,7 +149,7 @@
 /* Toggle */
 @toggleLaneWidth: 3.5rem;
 @toggleHandleSize: 1.5rem;
-@toggleTransitionDuration: 0.2s;
+@toggleTransitionDuration: 0.3s;
 
 @toggleWidth: @toggleLaneWidth;
 @toggleHeight: @toggleHandleSize;
@@ -157,12 +157,12 @@
 @toggleHandleRadius: @circularRadius;
 @toggleHandleOffset: 0;
 @toggleHandleTransition:
-  background @sliderTransitionDuration @defaultEasing,
-  left @sliderTransitionDuration @defaultEasing
+  background @toggleTransitionDuration @defaultEasing,
+  left @toggleTransitionDuration @defaultEasing
 ;
 @toggleHandleTransitionRightAligned:
-  background @sliderTransitionDuration @defaultEasing,
-  right @sliderTransitionDuration @defaultEasing
+  background @toggleTransitionDuration @defaultEasing,
+  right @toggleTransitionDuration @defaultEasing
 ;
 
 @toggleLaneBackground: @transparentBlack;


### PR DESCRIPTION
## Description
The toggle Checkbox LESS code accidently uses the slider variables for transition duration (obviously copy paste issue). 
For consistency, and this obvioulsy was the origin intention, a dedicated, already existing but never used, variable should be used.
For backward compatibility i changed the value to the same as for the slider variant, so the resulting css remains the same.

Thanks to @ghedsouza for [the original PR ](https://github.com/Semantic-Org/Semantic-UI-LESS/pull/23)