### PR TITLE
fix(segment): horizontal should use group variables

### DIFF
--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -438,10 +438,10 @@
       flex-direction: row;
       background-color: transparent;
       padding: 0;
-      box-shadow: @boxShadow;
-      margin: @margin;
-      border-radius: @borderRadius;
-      border: @border;
+      box-shadow: @groupedBoxShadow;
+      margin: @groupedMargin;
+      border-radius: @groupedBorderRadius;
+      border: @groupedBorder;
     }
     .ui.stackable.horizontal.segments {
       flex-wrap: wrap;


### PR DESCRIPTION
## Description
Horizontal segments should use their respective group variables (those however still contain the same values as for the single segment variabels used before)

## Closes
https://github.com/Semantic-Org/Semantic-UI-LESS/issues/49