### PR TITLE
feat(accordion): pure css, inverted, basic, right, tree, nested fixes

### DIFF
--- a/src/definitions/modules/accordion.less
+++ b/src/definitions/modules/accordion.less
@@ -31,18 +31,16 @@
 }
 
 /* Title */
-.ui.accordion .title,
-.ui.accordion .accordion .title {
+.ui.accordion.menu .item > .title,
+.ui.accordion > .title,
+.ui.accordion .accordion > .title {
   cursor: pointer;
-}
-
-/* Default Styling */
-.ui.accordion .title {
   padding: @titlePadding;
   font-family: @titleFont;
   font-size: @titleFontSize;
   color: @titleColor;
   list-style: none;
+  line-height: @titleLineHeight;
 }
 
 /* Default Styling */
@@ -71,7 +69,7 @@
   transform: @iconTransform;
   &.right when (@variationAccordionRightDropdown) {
     float:right;
-    margin: @iconMarginRight;
+    transform: @iconTransformRight;
   }
 }
 
@@ -105,9 +103,6 @@
 .ui.accordion .active.title .dropdown.icon,
 .ui.accordion .accordion .active.title .dropdown.icon {
   transform: @activeIconTransform;
-  &.right when (@variationAccordionRightDropdown) {
-    transform: @activeIconTransformRight;
-  }
 }
 
 .ui.accordion.menu .item .active.title > .dropdown.icon {
@@ -133,8 +128,8 @@
     background: @styledBackground;
     box-shadow: @styledBoxShadow;
   }
-  .ui.styled.accordion .title,
-  .ui.styled.accordion .accordion .title {
+  .ui.styled.accordion > .title,
+  .ui.styled.accordion .accordion > .title {
     margin: @styledTitleMargin;
     padding: @styledTitlePadding;
     color: @styledTitleColor;
@@ -143,7 +138,7 @@
     transition: @styledTitleTransition;
   }
   .ui.styled.accordion > .title:first-child,
-  .ui.styled.accordion .accordion .title:first-child {
+  .ui.styled.accordion .accordion > .title:first-child {
     border-top: none;
   }
 
@@ -160,11 +155,11 @@
 
 
   /* Hover */
-  .ui.styled.accordion .title:hover {
+  .ui.styled.accordion > .title:hover {
     background: @styledTitleHoverBackground;
     color: @styledTitleHoverColor;
   }
-  .ui.styled.accordion .accordion .title:hover {
+  .ui.styled.accordion .accordion > .title:hover {
     background: @styledHoverChildTitleBackground;
     color: @styledHoverChildTitleColor;
   }
@@ -189,7 +184,9 @@
   ---------------*/
 
   /* Default Styling */
-  .ui.compact.accordion:not(.styled) .title {
+
+  .ui.compact.accordion:not(.styled) > .title,
+  .ui.compact.accordion:not(.styled) .accordion > .title {
     padding: @titlePaddingCompact;
   }
 
@@ -199,8 +196,9 @@
   }
 
   /* Styled */
-  .ui.compact.styled.accordion .title,
-  .ui.compact.styled.accordion .accordion .title {
+
+  .ui.compact.styled.accordion > .title,
+  .ui.compact.styled.accordion .accordion > .title {
     padding: @styledTitlePaddingCompact;
   }
 
@@ -208,12 +206,14 @@
   .ui.compact.styled.accordion .accordion .title ~ .content {
     padding: @styledContentPaddingCompact;
   }
-
+}
   /*--------------
     Very Compact
   ---------------*/
 
-  .ui[class*="very compact"].accordion:not(.styled) .title {
+& when (@variationAccordionVeryCompact) {
+  .ui[class*="very compact"].accordion:not(.styled) > .title,
+  .ui[class*="very compact"].accordion:not(.styled) .accordion > .title {
     padding: @titlePaddingVeryCompact;
   }
 
@@ -222,8 +222,8 @@
     padding: @contentPaddingVeryCompact;
   }
 
-  .ui[class*="very compact"].styled.accordion .title,
-  .ui[class*="very compact"].styled.accordion .accordion .title {
+  .ui[class*="very compact"].styled.accordion > .title,
+  .ui[class*="very compact"].styled.accordion .accordion > .title {
     padding: @styledTitlePaddingVeryCompact;
   }
 
@@ -267,7 +267,9 @@
        Inverted
   ---------------*/
 
-  .ui.inverted.accordion .title {
+  .ui.inverted.accordion.menu .item > .title,
+  .ui.inverted.accordion > .title,
+  .ui.inverted.accordion .accordion > .title {
     color: @invertedTitleColor;
   }
   & when (@variationAccordionStyled) {
@@ -276,18 +278,18 @@
       background: @invertedStyledBackground;
       box-shadow: @invertedStyledBoxShadow;
     }
-    .ui.inverted.styled.accordion .title,
-    .ui.inverted.styled.accordion .accordion .title {
+    .ui.inverted.styled.accordion > .title,
+    .ui.inverted.styled.accordion .accordion > .title {
       color: @invertedStyledTitleColor;
       border-top: @invertedStyledTitleBorder;
     }
 
     /* Hover */
-    .ui.inverted.styled.accordion .title:hover {
+    .ui.inverted.styled.accordion > .title:hover {
       background: @invertedStyledTitleHoverBackground;
       color: @invertedStyledTitleHoverColor;
     }
-    .ui.inverted.styled.accordion .accordion .title:hover {
+    .ui.inverted.styled.accordion .accordion > .title:hover {
       background: @invertedStyledHoverChildTitleBackground;
       color: @invertedStyledHoverChildTitleColor;
     }

--- a/src/definitions/modules/accordion.less
+++ b/src/definitions/modules/accordion.less
@@ -269,6 +269,40 @@
   .ui.inverted.accordion .title {
     color: @invertedTitleColor;
   }
+  & when (@variationAccordionStyled) {
+    .ui.inverted.styled.accordion,
+    .ui.inverted.styled.accordion .accordion {
+      background: @invertedStyledBackground;
+      box-shadow: @invertedStyledBoxShadow;
+    }
+    .ui.inverted.styled.accordion .title,
+    .ui.inverted.styled.accordion .accordion .title {
+      color: @invertedStyledTitleColor;
+      border-top: @invertedStyledTitleBorder;
+    }
+
+    /* Hover */
+    .ui.inverted.styled.accordion .title:hover {
+      background: @invertedStyledTitleHoverBackground;
+      color: @invertedStyledTitleHoverColor;
+    }
+    .ui.inverted.styled.accordion .accordion .title:hover {
+      background: @invertedStyledHoverChildTitleBackground;
+      color: @invertedStyledHoverChildTitleColor;
+    }
+
+    /* Active */
+    .ui.inverted.styled.accordion[open] > .title,
+    .ui.inverted.styled.accordion .active.title {
+      background: @invertedStyledActiveTitleBackground;
+      color: @invertedStyledActiveTitleColor;
+    }
+    .ui.inverted.styled.accordion .accordion[open] > .title,
+    .ui.inverted.styled.accordion .accordion .active.title {
+      background: @invertedStyledActiveChildTitleBackground;
+      color: @invertedStyledActiveChildTitleColor;
+    }
+  }
 }
 
 .loadUIOverrides();

--- a/src/definitions/modules/accordion.less
+++ b/src/definitions/modules/accordion.less
@@ -308,6 +308,50 @@
   }
 }
 
+& when (@variationAccordionBasicStyled) {
+  .ui.basic.styled.accordion,
+  .ui.basic.styled.accordion .accordion {
+    background: transparent;
+    box-shadow: none;
+  }
+  .ui.basic.styled.accordion > .title,
+  .ui.basic.styled.accordion .accordion > .title {
+    border: none;
+    color: @basicStyledTitleColor;
+  }
+  .ui.basic.styled.accordion > .title:hover,
+  .ui.basic.styled.accordion .accordion > .title:hover {
+    background: transparent;
+    color: @basicStyledTitleHoverColor;
+  }
+  .ui.basic.styled.accordion[open] > .title,
+  .ui.basic.styled.accordion .active.title,
+  .ui.basic.styled.accordion .accordion[open] > .title,
+  .ui.basic.styled.accordion .accordion .active.title {
+    background: transparent;
+    color: @basicStyledActiveTitleColor;
+  }
+  & when (@variationAccordionInverted) {
+    .ui.inverted.basic.styled.accordion > .title,
+    .ui.inverted.basic.styled.accordion .accordion > .title {
+      background: transparent;
+      color: @invertedBasicStyledTitleColor;
+    }
+    .ui.inverted.basic.styled.accordion > .title:hover,
+    .ui.inverted.basic.styled.accordion .accordion > .title:hover {
+      background: transparent;
+      color: @invertedBasicStyledTitleHoverColor;
+    }
+    .ui.inverted.basic.styled.accordion[open] > .title,
+    .ui.inverted.basic.styled.accordion .active.title,
+    .ui.inverted.basic.styled.accordion .accordion[open] > .title,
+    .ui.inverted.basic.styled.accordion .accordion .active.title {
+      background: transparent;
+      color: @invertedBasicStyledActiveTitleColor;
+    }
+  }
+}
+
 & when (@variationAccordionTree) {
   .ui.tree.accordion:not(.styled) .title ~ .content,
   .ui.tree.accordion:not(.styled) .accordion .title ~ .content {

--- a/src/definitions/modules/accordion.less
+++ b/src/definitions/modules/accordion.less
@@ -42,6 +42,7 @@
   font-family: @titleFont;
   font-size: @titleFontSize;
   color: @titleColor;
+  list-style: none;
 }
 
 /* Default Styling */
@@ -68,6 +69,9 @@
   transition: @iconTransition;
   vertical-align: @iconVerticalAlign;
   transform: @iconTransform;
+  &.right when (@variationAccordionRightDropdown) {
+    float:right;
+  }
 }
 
 /*--------------
@@ -95,9 +99,14 @@
             States
 *******************************/
 
+.ui.accordion[open] > .title .dropdown.icon,
+.ui.accordion .accordion[open] > .title .dropdown.icon,
 .ui.accordion .active.title .dropdown.icon,
 .ui.accordion .accordion .active.title .dropdown.icon {
   transform: @activeIconTransform;
+  &.right when (@variationAccordionRightDropdown) {
+    transform: @activeIconTransformRight;
+  }
 }
 
 .ui.accordion.menu .item .active.title > .dropdown.icon {
@@ -139,8 +148,7 @@
 
 
   /* Content */
-  .ui.styled.accordion .content,
-  .ui.styled.accordion .accordion .content {
+  .ui.styled.accordion .content {
     margin: @styledContentMargin;
     padding: @styledContentPadding;
   }
@@ -151,25 +159,23 @@
 
 
   /* Hover */
-  .ui.styled.accordion .title:hover,
-  .ui.styled.accordion .active.title,
-  .ui.styled.accordion .accordion .title:hover,
-  .ui.styled.accordion .accordion .active.title {
+  .ui.styled.accordion .title:hover {
     background: @styledTitleHoverBackground;
     color: @styledTitleHoverColor;
   }
-  .ui.styled.accordion .accordion .title:hover,
-  .ui.styled.accordion .accordion .active.title {
+  .ui.styled.accordion .accordion .title:hover {
     background: @styledHoverChildTitleBackground;
     color: @styledHoverChildTitleColor;
   }
 
 
   /* Active */
+  .ui.styled.accordion[open] > .title,
   .ui.styled.accordion .active.title {
     background: @styledActiveTitleBackground;
     color: @styledActiveTitleColor;
   }
+  .ui.styled.accordion .accordion[open] > .title,
   .ui.styled.accordion .accordion .active.title {
     background: @styledActiveChildTitleBackground;
     color: @styledActiveChildTitleColor;
@@ -235,8 +241,8 @@
    Not Active
 ---------------*/
 
-.ui.accordion .title ~ .content:not(.active),
-.ui.accordion .accordion .title ~ .content:not(.active) {
+.ui.accordion:not(details) .title ~ .content:not(.active),
+.ui.accordion .accordion:not(details) .title ~ .content:not(.active) {
   display: none;
 }
 

--- a/src/definitions/modules/accordion.less
+++ b/src/definitions/modules/accordion.less
@@ -71,6 +71,7 @@
   transform: @iconTransform;
   &.right when (@variationAccordionRightDropdown) {
     float:right;
+    margin: @iconMarginRight;
   }
 }
 
@@ -148,11 +149,11 @@
 
 
   /* Content */
-  .ui.styled.accordion .content {
+  .ui.styled.accordion > .content {
     margin: @styledContentMargin;
     padding: @styledContentPadding;
   }
-  .ui.styled.accordion .accordion .content {
+  .ui.styled.accordion .accordion > .content {
     margin: @styledChildContentMargin;
     padding: @styledChildContentPadding;
   }
@@ -310,8 +311,8 @@
   .ui.tree.accordion:not(.styled) .accordion .title ~ .content {
     padding:@treeContentPadding;
   }
-  .ui.tree.accordion .content,
-  .ui.tree.accordion .accordion .content {
+  .ui.tree.accordion > .content,
+  .ui.tree.accordion .accordion > .content {
     margin-left: @treeContentLeftMargin;
   }
   .ui.tree.accordion .accordion {

--- a/src/definitions/modules/accordion.less
+++ b/src/definitions/modules/accordion.less
@@ -305,5 +305,19 @@
   }
 }
 
+& when (@variationAccordionTree) {
+  .ui.tree.accordion:not(.styled) .title ~ .content,
+  .ui.tree.accordion:not(.styled) .accordion .title ~ .content {
+    padding:@treeContentPadding;
+  }
+  .ui.tree.accordion .content,
+  .ui.tree.accordion .accordion .content {
+    margin-left: @treeContentLeftMargin;
+  }
+  .ui.tree.accordion .accordion {
+    margin-top: @treeContentTopMargin;
+  }
+}
+
 .loadUIOverrides();
 

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -480,6 +480,7 @@
 @variationAccordionStyled: true;
 @variationAccordionFluid: true;
 @variationAccordionCompact: true;
+@variationAccordionRightDropdown: true;
 
 /* Calendar */
 @variationCalendarInverted: true;

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -480,6 +480,7 @@
 @variationAccordionStyled: true;
 @variationAccordionFluid: true;
 @variationAccordionCompact: true;
+@variationAccordionVeryCompact: true;
 @variationAccordionRightDropdown: true;
 @variationAccordionTree: true;
 

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -478,6 +478,7 @@
 /* Accordion */
 @variationAccordionInverted: true;
 @variationAccordionStyled: true;
+@variationAccordionBasicStyled: true;
 @variationAccordionFluid: true;
 @variationAccordionCompact: true;
 @variationAccordionVeryCompact: true;

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -481,6 +481,7 @@
 @variationAccordionFluid: true;
 @variationAccordionCompact: true;
 @variationAccordionRightDropdown: true;
+@variationAccordionTree: true;
 
 /* Calendar */
 @variationCalendarInverted: true;

--- a/src/themes/default/modules/accordion.overrides
+++ b/src/themes/default/modules/accordion.overrides
@@ -26,7 +26,3 @@
 .ui.accordion .accordion .title .dropdown.icon:before {
   content: '\f0da'/*rtl:'\f0d9'*/;
 }
-.ui.accordion .title .right.dropdown.icon:before,
-.ui.accordion .accordion .title .right.dropdown.icon:before {
-  content: '\f0d9'/*rtl:'\f0da'*/;
-}

--- a/src/themes/default/modules/accordion.overrides
+++ b/src/themes/default/modules/accordion.overrides
@@ -26,3 +26,7 @@
 .ui.accordion .accordion .title .dropdown.icon:before {
   content: '\f0da'/*rtl:'\f0d9'*/;
 }
+.ui.accordion .title .right.dropdown.icon:before,
+.ui.accordion .accordion .title .right.dropdown.icon:before {
+  content: '\f0d9'/*rtl:'\f0da'*/;
+}

--- a/src/themes/default/modules/accordion.variables
+++ b/src/themes/default/modules/accordion.variables
@@ -98,6 +98,22 @@
 
 /* Inverted */
 @invertedTitleColor: @invertedTextColor;
+@invertedStyledTitleColor: @invertedUnselectedTextColor;
+@invertedStyledBackground: @black;
+@invertedStyledTitleBorder: 1px solid @whiteBorderColor;
+@invertedStyledBoxShadow:
+        @subtleShadow,
+        0 0 0 1px @whiteBorderColor
+;
+@invertedStyledTitleHoverBackground: transparent;
+@invertedStyledTitleHoverColor: @invertedTextColor;
+@invertedStyledActiveTitleBackground: transparent;
+@invertedStyledActiveTitleColor: @invertedSelectedTextColor;
+
+@invertedStyledHoverChildTitleBackground: @invertedStyledTitleHoverBackground;
+@invertedStyledHoverChildTitleColor: @invertedStyledTitleHoverColor;
+@invertedStyledActiveChildTitleBackground: @invertedStyledActiveTitleBackground;
+@invertedStyledActiveChildTitleColor: @invertedStyledActiveTitleColor;
 
 /* Compact */
 @titlePaddingCompact: 0.25em 0;

--- a/src/themes/default/modules/accordion.variables
+++ b/src/themes/default/modules/accordion.variables
@@ -9,6 +9,7 @@
 @titlePadding: 0.5em 0;
 @titleFontSize: 1em;
 @titleColor: @textColor;
+@titleLineHeight: 1;
 
 /* Icon */
 @iconOpacity: 1;
@@ -18,7 +19,6 @@
 @iconHeight: 1em;
 @iconDisplay: inline-block;
 @iconMargin: 0 0.25rem 0 0;
-@iconMarginRight: 0.17rem 0 0 0.25rem;
 @iconPadding: 0;
 @iconTransition:
   transform @defaultDuration @defaultEasing,
@@ -26,6 +26,7 @@
 ;
 @iconVerticalAlign: baseline;
 @iconTransform: none;
+@iconTransformRight: @menuIconTransform;
 
 /* Child Accordion */
 @childAccordionMargin: 1em 0 0;
@@ -41,7 +42,7 @@
 
 @menuTitlePadding: 0;
 @menuIconFloat: right;
-@menuIconMargin: @lineHeightOffset 0 0 1em;
+@menuIconMargin: @iconMargin;
 @menuIconTransform: rotate(180deg);
 
 
@@ -50,7 +51,6 @@
 --------------------*/
 
 @activeIconTransform: rotate(90deg);
-@activeIconTransformRight: rotate(-90deg);
 
 /*-------------------
       Variations

--- a/src/themes/default/modules/accordion.variables
+++ b/src/themes/default/modules/accordion.variables
@@ -130,3 +130,8 @@
 /* Styled Very Compact */
 @styledTitlePaddingVeryCompact: 0.1875em 0.25em;
 @styledContentPaddingVeryCompact: 0.125em 0.25em 0.375em;
+
+/* Tree */
+@treeContentPadding: 0;
+@treeContentTopMargin: 0;
+@treeContentLeftMargin: 1.7em;

--- a/src/themes/default/modules/accordion.variables
+++ b/src/themes/default/modules/accordion.variables
@@ -18,6 +18,7 @@
 @iconHeight: 1em;
 @iconDisplay: inline-block;
 @iconMargin: 0 0.25rem 0 0;
+@iconMarginRight: 0.1rem 0 0 0.25rem;
 @iconPadding: 0;
 @iconTransition:
   transform @defaultDuration @defaultEasing,

--- a/src/themes/default/modules/accordion.variables
+++ b/src/themes/default/modules/accordion.variables
@@ -49,6 +49,7 @@
 --------------------*/
 
 @activeIconTransform: rotate(90deg);
+@activeIconTransformRight: rotate(-90deg);
 
 /*-------------------
       Variations

--- a/src/themes/default/modules/accordion.variables
+++ b/src/themes/default/modules/accordion.variables
@@ -18,7 +18,7 @@
 @iconHeight: 1em;
 @iconDisplay: inline-block;
 @iconMargin: 0 0.25rem 0 0;
-@iconMarginRight: 0.1rem 0 0 0.25rem;
+@iconMarginRight: 0.17rem 0 0 0.25rem;
 @iconPadding: 0;
 @iconTransition:
   transform @defaultDuration @defaultEasing,

--- a/src/themes/default/modules/accordion.variables
+++ b/src/themes/default/modules/accordion.variables
@@ -132,6 +132,15 @@
 @styledTitlePaddingVeryCompact: 0.1875em 0.25em;
 @styledContentPaddingVeryCompact: 0.125em 0.25em 0.375em;
 
+/* Basic Styled */
+@basicStyledTitleColor: @mutedTextColor;
+@basicStyledTitleHoverColor: @textColor;
+@basicStyledActiveTitleColor: @selectedTextColor;
+
+@invertedBasicStyledTitleColor: @invertedMutedTextColor;
+@invertedBasicStyledTitleHoverColor: @invertedTextColor;
+@invertedBasicStyledActiveTitleColor: @invertedSelectedTextColor;
+
 /* Tree */
 @treeContentPadding: 0;
 @treeContentTopMargin: 0;


### PR DESCRIPTION
## Description
This MR enhances the accordion module:

- Pure CSS variant now possible using the[ details/summary tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details) (yes, IE/old Edge do not support that, that's ok for 2.9.0 and 2022 and you can still use the JS version which works there) 😉 . 
- `inverted` styled variant
- `tree` variant (for proper indentation which a tree view needs) (also works as CSS only!)
- new `right dropdown icon` variant, to be able to place the dropdown icon to the right (just as in accordion menu already). Usefull for example when used inside `message`
- fixed the right dropdown icon (also in accordion menu)
- fixed possible usage of `title` or `content` elements inside an accordion which are supposed to be parts of different elements
- `basic styled` variant which is equal to styled for title handling only (so no borders and always transparent background)

## Testcase
https://jsfiddle.net/lubber/4k5y0cjL/38/

## Screenshots
![accordiontree](https://user-images.githubusercontent.com/18379884/148531466-8a6cdfc8-670a-457e-b36f-55c8cc229b4d.gif)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/2790
https://github.com/Semantic-Org/Semantic-UI/issues/4928
https://github.com/Semantic-Org/Semantic-UI/issues/5238
https://github.com/Semantic-Org/Semantic-UI/issues/5330
https://github.com/Semantic-Org/Semantic-UI/issues/6578
https://github.com/Semantic-Org/Semantic-UI/issues/7048


