### PR TITLE
feat(toast): allow clickable items without closing

### DIFF
--- a/src/definitions/modules/toast.js
+++ b/src/definitions/modules/toast.js
@@ -511,7 +511,7 @@ $.fn.toast = function(parameters) {
             module.close();
           },
           click: function(event) {
-            if($(event.target).closest('a').length === 0) {
+            if($(event.target).closest(selector.clickable).length === 0) {
               if(settings.onClick.call($toastBox, element) === false || !settings.closeOnClick) {
                 module.verbose('Click callback returned false or close denied by setting cancelling close');
                 return;
@@ -876,6 +876,7 @@ $.fn.toast.settings = {
     image        : '> img.image, > .image > img',
     icon         : '> i.icon',
     input        : 'input:not([type="hidden"]), textarea, select, button, .ui.button, ui.dropdown',
+    clickable    : 'a, details, .ui.accordion',
     approve      : '.actions .positive, .actions .approve, .actions .ok',
     deny         : '.actions .negative, .actions .deny, .actions .cancel'
   },


### PR DESCRIPTION
## Description
Some content inside toasts should remain clickable without closing the toast. (even if `closeOnClick` is true)
While this was already hardcoded for `a` tags if fails for possible other tags like `accordion` or `details` (Especially when used together with the new #2197 😉 )
The previously hardcoded selector is not a customizable classname setting.

Btw: `input` is not needed to be set here, because any kind of input inside a toast will already set the whole toast to not closing when clicked (because it is expected to be clicked into the input fields).
The new setting here is supposed for elements which _can_ be clicked, but are not expected to.

## Testcase
https://jsfiddle.net/lubber/fd8Lx9u2/24/
> This also shows how to nicely use the new `ui basic inverted styled accordion` inside the toast

## Screenshot
![clickabletoast](https://user-images.githubusercontent.com/18379884/148604826-4b57fa58-6adb-41b9-999c-c2ac3dd4762a.gif)

