### PR TITLE
feat(chore): automatic npm releases, ci fix and add node 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,15 +2,15 @@ name: CI
 on: [pull_request]
 jobs:
   test:
-    name: Test build process on node ${{ matrix.node_version }}
+    name: Test build process on node ${{ matrix.node-version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version: [8, 10, 11, 12, 13, 14]
+        node-version: [12, 14, 16]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
     - name: pre-install

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,5 +28,5 @@ jobs:
         npm config set //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN
         npm publish --tag nightly
       env:
-        NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
+        NODE_AUTH_TOKEN: ${{secrets.NPM_AUTOMATION}}
         CI: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,16 @@
-name: Nightly
+name: Release
 on:
-  schedule:
-  - cron: 00 23 * * *
+  release:
+    types: [released]
 jobs:
   publish:
-    name: Build nightly distribution
+    name: Build new Release
     runs-on: ubuntu-latest
     if: github.repository == 'fomantic/Fomantic-UI'
     steps:
     - uses: actions/checkout@v2
       with:
-        ref: develop
+        ref: master
     - uses: actions/setup-node@v2
       with:
         node-version: 14
@@ -19,14 +19,12 @@ jobs:
       run: sh ./scripts/preinstall.sh
     - name: install dependencies
       run: npm install --ignore-scripts
-    - name: update nightly version
-      run: node ./scripts/nightly-version.js
     - name: fomantic install & build
       run: npx gulp install
     - name: publish to npm
       run: |
         npm config set //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN
-        npm publish --tag nightly
+        npm publish
       env:
         NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
         CI: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,5 +26,5 @@ jobs:
         npm config set //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN
         npm publish
       env:
-        NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
+        NODE_AUTH_TOKEN: ${{secrets.NPM_AUTOMATION}}
         CI: true


### PR DESCRIPTION
## Description
I would like to automate the npm publishing of new releases, so this PR adds another github workflow which publishes to npm ONLY when a new github release is published.

@hammy2899 
#### As you are the direct owner of the npm package (we dont have an npm org account) and to reduce the need to give me an NPM auth token to myself, this workflow uses the already existing NPM AUTH secret (used for nightly builds), so i dont have to know that 😉 

I would like to setup this release workflow for the Fomantic-UI-CSS and Fomantic-UI-LESS repos as well, so could you please upload a/the NPM secret to the fomantic-organization as well (and/or to the respective single repositories)
Otherwise i always have to bother you to create the releases manually yourself 😉 

I intentionally did not implement a version-adjustment inside package.json within the workflow script to avoid publishing wrong releases in case one of us does something wrong while adding tags . So unless we manually change the version number inside package json a possible npm publish will fail (because the old version already exists on npm)

This PR also fixes the CI script, because the node version was _always_ the latest LTS (16) because of a typo in the yml (you could check the CI logs to confirm. So at least this means FUI build well with node16/npm 8 :D (which i also tested manually)

That said, i also increased the node version for the workflows to 14 (not 16, because that is active and could have impact by changes) as node 12 becomes unsupported in april this year


