### PR TITLE
fix(header): image icon support again

### DIFF
--- a/src/definitions/elements/header.less
+++ b/src/definitions/elements/header.less
@@ -223,6 +223,7 @@
   .ui.icon.header:first-child {
     margin-top: @iconHeaderFirstMargin;
   }
+  .ui.icon.header > .image.icon,
   .ui.icon.header > .icons,
   .ui.icon.header > i.icon {
     float: none;
@@ -249,6 +250,7 @@
     font-size: @squareHeaderIconSize;
   }
   & when (@variationHeaderBlock) {
+    .ui.block.icon.header > .image.icon,
     .ui.block.icon.header > .icons,
     .ui.block.icon.header > i.icon {
       margin-bottom: 0;


### PR DESCRIPTION
## Description
An `.image.icon` (used by a `<img>`) inside a `.ui.icon.header` was not working anymore (misaligned), which was used on the homepage a lot.

## Testcase
https://jsfiddle.net/lubber/o0gtx196/22/
https://fomantic-ui.com

Remove CSS to see the issue

## Screenshots
### Broken
![image](https://user-images.githubusercontent.com/18379884/150650607-8eba564e-c12f-4c6f-9645-3166aaa35c63.png)

### Fixed
![image](https://user-images.githubusercontent.com/18379884/150650621-87382439-df35-457a-a13e-d026be286b0a.png)

## Closes
#2208 