### PR TITLE
feat(docs): limit/clarify IE, old edge, old mobile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Fomantic includes an interactive installer to help setup your project.
 * IE 11[^2]
 * Microsoft Edge 12-44[^2]
 
-[^1]: Fomantic-UI should basically still work in iOS Safari 7+, Android 4.4+, but, starting from v2.9.0, we won't support them anymore if anything works different as the recent versions.
+[^1]: Fomantic-UI should basically still work in iOS Safari 7+, Android 4.4+, but, starting from v2.9.0, we won't support them anymore if anything works different than in recent versions.
 [^2]: Fomantic-UI should basically still work in IE11 / old Edge, but, starting from v2.9.0, we won't support them anymore in terms of dedicated bugfixes.
 
 ---

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Fomantic includes an interactive installer to help setup your project.
 
 ### 💻 Browser Support
 
-* Last 2 Versions Firefox, Chrome, Safari Mac, Edge
+* Last 2 Versions of Firefox, Chrome, Safari Mac, Edge
 * Last 4 Versions of Android, Chrome for Android, iOS Safari[^1]
 * IE 11[^2]
 * Microsoft Edge 12-44[^2]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Fomantic Logo](https://fomantic-ui.com/images/logo.png#128)
 
 # Fomantic-UI
-A community fork of the popular Semantic-UI framework.
+The official community fork of the popular Semantic-UI framework.
 
 [![GitHub Actions Status](https://github.com/fomantic/Fomantic-UI/workflows/CI/badge.svg)](https://github.com/fomantic/Fomantic-UI/actions)
 [![last commit (develop)](https://img.shields.io/github/last-commit/fomantic/Fomantic-UI/develop.svg?label=last%20commit%20%28develop%29)](https://github.com/fomantic/Fomantic-UI/commits/develop)
@@ -52,13 +52,13 @@ Fomantic includes an interactive installer to help setup your project.
 
 ### 💻 Browser Support
 
-* Last 2 Versions FF, Chrome, Safari Mac
-* IE 11+
-* Android 4.4+, Chrome for Android 44+
-* iOS Safari 7+
-* Microsoft Edge 12+
+* Last 2 Versions Firefox, Chrome, Safari Mac, Edge
+* Last 4 Versions of Android, Chrome for Android, iOS Safari[^1]
+* IE 11[^2]
+* Microsoft Edge 12-44[^2]
 
-Although some components will work in IE9, [grids](http://semantic-ui.com/collections/grid.html) and other [flexbox](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Flexible_boxes) components are not supported by IE9 and may not appear correctly.
+[^1]: Fomantic-UI should basically still work in iOS Safari 7+, Android 4.4+, but, starting from v2.9.0, we won't support them anymore if anything works different as the recent versions.
+[^2]: Fomantic-UI should basically still work in IE11 / old Edge, but, starting from v2.9.0, we won't support them anymore in terms of dedicated bugfixes.
 
 ---
 


### PR DESCRIPTION
## Description
Starting from v2.9.0 i would like to reduce IE11/old Edge and old mobile platform support.

Fomantic will still work in those browsers in general, but in case there are dedicated bugs, we will not spent time into trying to fix them for those ancient browsers/platforms anymore. 

## Screenshots
As i used markdown footnotes for detailed explanation such footnotes are found at the end of the readme as follows:

* Last 2 Versions Firefox, Chrome, Safari Mac, Edge
* Last 4 Versions of Android, Chrome for Android, iOS Safari[^1]
* IE 11[^2]
* Microsoft Edge 12-44[^2]

[^1]: Fomantic-UI should basically still work in iOS Safari 7+, Android 4.4+, but, starting from v2.9.0, we won't support them anymore if anything works different than in recent versions.
[^2]: Fomantic-UI should basically still work in IE11 / old Edge, but, starting from v2.9.0, we won't support them anymore in terms of dedicated bugfixes.

> here comes lots of other readme text ...

> until the readme reaches the end


