### PR TITLE
feat(api): dont convert array response to object by default

### DIFF
--- a/src/definitions/behaviors/api.js
+++ b/src/definitions/behaviors/api.js
@@ -1110,7 +1110,7 @@ $.api.settings = {
   responseAsync     : false,
 
 // whether onResponse should work with response value without force converting into an object
-  rawResponse       : false,
+  rawResponse       : true,
 
   // callbacks before request
   beforeSend  : function(settings) { return settings; },


### PR DESCRIPTION
## Description
It seems a more common case people are sending JSON array instead of JSON objects for their api response.
We already supported that since 2.7.0 #294 by the `rawResponse` setting, but people have to actively enable it.

This PR changes the default value so json arrays are not converted to objects anymore by default.

I am still against always forcing json arrays no to be converted, because it is a valid conversion by `$.extend` and probably still needed for some projects.

## Closes
#2220 