### PR TITLE
fix(chore): replace deprecated .substr() with .slice()

### DIFF
--- a/examples/assets/library/iframe-content.js
+++ b/examples/assets/library/iframe-content.js
@@ -185,7 +185,7 @@
       return 'true' === str ? true : false;
     }
 
-    var data = initMsg.substr(msgIdLen).split(':');
+    var data = initMsg.slice(msgIdLen).split(':');
 
     myID               = data[0];
     bodyMargin         = (undefined !== data[1]) ? Number(data[1])   : bodyMargin; //For V1 compatibility
@@ -1048,7 +1048,7 @@
     };
 
     function isMessageForUs() {
-      return msgID === (''+event.data).substr(0,msgIdLen); //''+ Protects against non-string messages
+      return msgID === (''+event.data).slice(0,msgIdLen); //''+ Protects against non-string messages
     }
 
     function getMessageType() {
@@ -1056,7 +1056,7 @@
     }
 
     function getData() {
-      return event.data.substr(event.data.indexOf(':')+1);
+      return event.data.slice(event.data.indexOf(':')+1);
     }
 
     function isMiddleTier() {

--- a/examples/assets/library/iframe.js
+++ b/examples/assets/library/iframe.js
@@ -148,7 +148,7 @@
     }
 
     function processMsg() {
-      var data = msg.substr(msgIdLen).split(':');
+      var data = msg.slice(msgIdLen).split(':');
 
       return {
         iframe: settings[data[0]] && settings[data[0]].iframe,
@@ -226,7 +226,7 @@
     }
 
     function isMessageForUs() {
-      return msgId === (('' + msg).substr(0,msgIdLen)) && (msg.substr(msgIdLen).split(':')[0] in settings); //''+Protects against non-string msg
+      return msgId === (('' + msg).slice(0,msgIdLen)) && (msg.slice(msgIdLen).split(':')[0] in settings); //''+Protects against non-string msg
     }
 
     function isMessageFromMetaParent() {
@@ -242,7 +242,7 @@
     }
 
     function getMsgBody(offset) {
-      return msg.substr(msg.indexOf(':')+msgHeaderLen+offset);
+      return msg.slice(msg.indexOf(':')+msgHeaderLen+offset);
     }
 
     function forwardMsgFromIFrame(msgBody) {

--- a/src/definitions/behaviors/api.js
+++ b/src/definitions/behaviors/api.js
@@ -363,8 +363,8 @@ $.api = $.fn.api = function(parameters) {
                   var
                     // allow legacy {$var} style
                     variable = (templatedString.indexOf('$') !== -1)
-                      ? templatedString.substr(2, templatedString.length - 3)
-                      : templatedString.substr(1, templatedString.length - 2),
+                      ? templatedString.slice(2, -1)
+                      : templatedString.slice(1, -1),
                     value   = ($.isPlainObject(urlData) && urlData[variable] !== undefined)
                       ? urlData[variable]
                       : ($module.data(variable) !== undefined)
@@ -395,8 +395,8 @@ $.api = $.fn.api = function(parameters) {
                   var
                     // allow legacy {/$var} style
                     variable = (templatedString.indexOf('$') !== -1)
-                      ? templatedString.substr(3, templatedString.length - 4)
-                      : templatedString.substr(2, templatedString.length - 3),
+                      ? templatedString.slice(3, -1)
+                      : templatedString.slice(2, -1),
                     value   = ($.isPlainObject(urlData) && urlData[variable] !== undefined)
                       ? urlData[variable]
                       : ($module.data(variable) !== undefined)

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -225,7 +225,7 @@ $.fn.dropdown = function(parameters) {
 
         create: {
           id: function() {
-            id = (Math.random().toString(16) + '000000000').substr(2, 8);
+            id = (Math.random().toString(16) + '000000000').slice(2, 10);
             elementNamespace = '.' + id;
             module.verbose('Creating unique id for element', id);
           },
@@ -2528,7 +2528,7 @@ $.fn.dropdown = function(parameters) {
             var
               length = module.get.query().length
             ;
-            $search.val( text.substr(0, length));
+            $search.val( text.slice(0, length));
           },
           scrollPosition: function($item, forceScroll) {
             var

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -211,7 +211,7 @@ $.fn.modal = function(parameters) {
             $dimmer = $dimmable.dimmer('get dimmer');
           },
           id: function() {
-            id = (Math.random().toString(16) + '000000000').substr(2, 8);
+            id = (Math.random().toString(16) + '000000000').slice(2, 10);
             elementEventNamespace = '.' + id;
             module.verbose('Creating unique id for element', id);
           },

--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -309,7 +309,7 @@ $.fn.popup = function(parameters) {
         },
 
         createID: function() {
-          id = (Math.random().toString(16) + '000000000').substr(2, 8);
+          id = (Math.random().toString(16) + '000000000').slice(2, 10);
           elementNamespace = '.' + id;
           module.verbose('Creating unique id for element', id);
         },

--- a/src/definitions/modules/sidebar.js
+++ b/src/definitions/modules/sidebar.js
@@ -118,7 +118,7 @@ $.fn.sidebar = function(parameters) {
 
         create: {
           id: function() {
-            id = (Math.random().toString(16) + '000000000').substr(2,8);
+            id = (Math.random().toString(16) + '000000000').slice(2, 10);
             elementNamespace = '.' + id;
             module.verbose('Creating unique id for element', id);
           }

--- a/src/definitions/modules/toast.js
+++ b/src/definitions/modules/toast.js
@@ -154,7 +154,7 @@ $.fn.toast = function(parameters) {
             $context.append($('<div/>',{class: settings.position + ' ' + className.container + ' ' +(settings.horizontal ? className.horizontal : '')}));
           },
           id: function() {
-            id = (Math.random().toString(16) + '000000000').substr(2, 8);
+            id = (Math.random().toString(16) + '000000000').slice(2, 10);
             module.verbose('Creating unique id for element', id);
           },
           toast: function() {

--- a/test/helpers/sinon.js
+++ b/test/helpers/sinon.js
@@ -580,7 +580,7 @@ define.amd = true;
         var content = element.innerHTML;
 
         if (content.length > 20) {
-            content = content.substr(0, 20) + "[...]";
+            content = content.slice(0, 20) + "[...]";
         }
 
         var res = formatted + pairs.join(" ") + ">" + content +


### PR DESCRIPTION
## Description
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with the [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) method which works similarily but isn't deprecated.
.substr() probably isn't going away any time soon but as the change is trivial it probably doesn't hurt to switch.

