### PR TITLE
fix(dropdown): use central delimiter char instead of key

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1531,7 +1531,7 @@ $.fn.dropdown = function(parameters) {
           keydown: function(event) {
             var
               pressedKey    = event.which,
-              isShortcutKey = module.is.inObject(pressedKey, keys)
+              isShortcutKey = module.is.inObject(pressedKey, keys) || event.key === settings.delimiter
             ;
             if(isShortcutKey) {
               var
@@ -1549,7 +1549,7 @@ $.fn.dropdown = function(parameters) {
                 hasSubMenu            = ($subMenu.length> 0),
                 hasSelectedItem       = ($selectedItem.length > 0),
                 selectedIsSelectable  = ($selectedItem.not(selector.unselectable).length > 0),
-                delimiterPressed      = (pressedKey == keys.delimiter && module.is.multiple()),
+                delimiterPressed      = (event.key === settings.delimiter && module.is.multiple()),
                 isAdditionWithoutMenu = (settings.allowAdditions && settings.hideAdditions && (pressedKey == keys.enter || delimiterPressed) && selectedIsSelectable),
                 $nextItem,
                 isSubMenuItem,
@@ -4131,7 +4131,6 @@ $.fn.dropdown.settings = {
 
   keys : {
     backspace  : 8,
-    delimiter  : 188, // comma
     deleteKey  : 46,
     enter      : 13,
     escape     : 27,


### PR DESCRIPTION
## Description
On a multiple dropdown, having `allowAdditions:true`, the press of the delimiter key (comma by default) was checked via the keycode. However the keycode does not take possible pressed shift/alt keys into account.
This results in triggering a multi dropdown entry even when pressing the key together with shift/alt, so it was not possible to declare for example the semicolon as a delimiter.

As we already have the delimiter string for concatenation/splitting of existing values, this PR now also uses that setting for the keypress.

## Testcase
### Broken
https://jsfiddle.net/lubber/27whu5tf/9/

### Fixed
https://jsfiddle.net/lubber/27whu5tf/11/

## Closes
#2245 
https://github.com/Semantic-Org/Semantic-UI/issues/3016
https://github.com/Semantic-Org/Semantic-UI/issues/3318