### PR TITLE
fix(input): date inputs were larger due to icon size

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -143,6 +143,9 @@
 
 .ui.form input::-webkit-calendar-picker-indicator {
   padding: 0;
+  opacity: @iconOpacity;
+  transition: @iconTransition;
+  cursor: pointer;
 }
 
 /* Text Area */
@@ -487,6 +490,10 @@
   background: @textAreaFocusBackground;
   box-shadow: @textAreaFocusBoxShadow;
   -webkit-appearance: none;
+}
+/* Focus */
+.ui.form input:focus::-webkit-calendar-picker-indicator {
+  opacity: @iconFocusOpacity;
 }
 
 & when not (@variationFormStates = false) {

--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -141,6 +141,10 @@
   padding: initial;
 }
 
+.ui.form input::-webkit-calendar-picker-indicator {
+  padding: 0;
+}
+
 /* Text Area */
 .ui.input textarea,
 .ui.form textarea {

--- a/src/definitions/elements/input.less
+++ b/src/definitions/elements/input.less
@@ -55,6 +55,9 @@
   &:not([type="color"]) {
     padding: @padding;
   }
+  &::-webkit-calendar-picker-indicator {
+    padding: 0;
+  }
 }
 
 

--- a/src/definitions/elements/input.less
+++ b/src/definitions/elements/input.less
@@ -57,6 +57,9 @@
   }
   &::-webkit-calendar-picker-indicator {
     padding: 0;
+    opacity: @iconOpacity;
+    transition: @iconTransition;
+    cursor: pointer;
   }
 }
 
@@ -345,6 +348,7 @@
   }
 
   /* Focus */
+  input:focus::-webkit-calendar-picker-indicator,
   .ui.icon.input > textarea:focus ~ i.icon,
   .ui.icon.input > input:focus ~ i.icon {
     opacity: 1;

--- a/src/definitions/elements/input.less
+++ b/src/definitions/elements/input.less
@@ -348,10 +348,10 @@
   }
 
   /* Focus */
-  input:focus::-webkit-calendar-picker-indicator,
+  .ui.input > input:focus::-webkit-calendar-picker-indicator,
   .ui.icon.input > textarea:focus ~ i.icon,
   .ui.icon.input > input:focus ~ i.icon {
-    opacity: 1;
+    opacity: @iconFocusOpacity;
   }
 }
 

--- a/src/themes/default/collections/form.variables
+++ b/src/themes/default/collections/form.variables
@@ -149,6 +149,10 @@
 @groupedLabelFontWeight: @labelFontWeight;
 @groupedLabelTextTransform: @labelTextTransform;
 
+/* Icon */
+@iconOpacity: 0.5;
+@iconFocusOpacity: 1;
+@iconTransition: opacity 0.3s @defaultEasing;
 
 /* Inline */
 @inlineInputSize: @relativeMedium;


### PR DESCRIPTION
## Description
Date or other new input types used in chrome based browsers are showing an additional icon to trigger the value seletcion.
Unfortunately the icons had an additional padding making the inputs appear larger than normal inputs which interferes with the overall ui when such inputs were shown next to each other.
I also adjusted the appearance of the icon to match the `icon input` appearance and added the pointer to the icon as such native icon has a bahaviour to show a dialog.

## Screenshot
### Broken
The Email-Input to the very right has a smaller height than the others
![image](https://user-images.githubusercontent.com/18379884/156924315-9e2229c9-7203-4e69-b549-6c406a048dd5.png)

### Fixed
Same height everywhere
![image](https://user-images.githubusercontent.com/18379884/156924259-6e112d3b-c219-43f3-b406-6abb5cde2003.png)


## Testcase
Remove the CSS to see the issue
https://jsfiddle.net/lubber/1umaonxg/1/