### PR TITLE
fix(segment): adjust inverted attached border color specificity

### DIFF
--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -668,7 +668,7 @@
   }
   & when (@variationSegmentAttached) {
     /* Attached */
-    .ui.inverted.attached.segment {
+    .ui.ui.inverted.attached.segment {
       border-color: @solidWhiteBorderColor;
     }
   }


### PR DESCRIPTION
## Description
Inverted attached segments got wrong border color (from non inverted variant). A slight specificity increase solves this.

## Testcase
Remove CSS to see issue
http://jsfiddle.net/lubber/bxtmyv9z/46/

## Screenshot
### Broken
![image](https://user-images.githubusercontent.com/18379884/156929801-8d3a8684-a1b1-46eb-a00b-c53f9284b63c.png)

### Fixed
![image](https://user-images.githubusercontent.com/18379884/156929827-f68005a8-f3c1-4fc4-aa7f-673a82f9c73d.png)
