### PR TITLE
fix(dropdown): legacyEdge cuts search input

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1869,7 +1869,7 @@ $.fn.dropdown = function(parameters) {
             ;
             $sizer.text(value);
             // prevent rounding issues
-            return Math.ceil( $sizer.width() + (!!window.StyleMedia ? 3 : 1));
+            return Math.ceil( $sizer.width() + (module.is.edge() ? 3 : 1));
           },
           selectionCount: function() {
             var
@@ -3395,6 +3395,9 @@ $.fn.dropdown = function(parameters) {
           },
           bubbledIconClick: function(event) {
             return $(event.target).closest($icon).length > 0;
+          },
+          edge: function() {
+            return !!window.chrome && !!window.StyleMedia;
           },
           chrome: function() {
             return !!window.chrome && !window.StyleMedia;

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1869,7 +1869,7 @@ $.fn.dropdown = function(parameters) {
             ;
             $sizer.text(value);
             // prevent rounding issues
-            return Math.ceil( $sizer.width() + 1);
+            return Math.ceil( $sizer.width() + (!!window.StyleMedia ? 3 : 1));
           },
           selectionCount: function() {
             var


### PR DESCRIPTION
## Description
The search width sizer was cut in legacy Edge.

## Testcase
Use Legacy Edge <= 18 
## Fixed
https://jsfiddle.net/lubber/18mdtc4y/10/
## Broken
https://jsfiddle.net/lubber/18mdtc4y/11/

## Screenshot
Look at the "f" inside the dropdown search at the bottom right of the screenshot
## Fixed
![image](https://user-images.githubusercontent.com/18379884/157267510-d29d5cdb-86e6-4d9c-b2b0-e950410a73fa.png)

## Broken
![image](https://user-images.githubusercontent.com/18379884/157269339-6bf8ae65-b3b4-4b42-b497-4f6c45c632a9.png)

## Closes
#312

