### PR TITLE
fix(form): rebind events on dynamic fields

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -119,7 +119,7 @@ $.fn.form = function(parameters) {
           ;
         },
 
-        refresh: function() {
+        refresh: function(rebindEvents) {
           module.verbose('Refreshing selector cache');
           $field      = $module.find(selector.field);
           $group      = $module.find(selector.group);
@@ -129,6 +129,10 @@ $.fn.form = function(parameters) {
           $submit     = $module.find(selector.submit);
           $clear      = $module.find(selector.clear);
           $reset      = $module.find(selector.reset);
+          if(rebindEvents) {
+            module.removeEvents();
+            module.bindEvents();
+          }
         },
 
         submit: function() {
@@ -391,7 +395,6 @@ $.fn.form = function(parameters) {
           $module.off(eventNamespace);
           $field.off(eventNamespace);
           $submit.off(eventNamespace);
-          $field.off(eventNamespace);
         },
 
         event: {
@@ -864,9 +867,11 @@ $.fn.form = function(parameters) {
               }
             });
             module.debug('Adding rules', newValidation.rules, validation);
+            module.refresh(true);
           },
           fields: function(fields) {
             validation = $.extend(true, {}, validation, module.get.fieldsFromShorthand(fields));
+            module.refresh(true);
           },
           prompt: function(identifier, errors, internal) {
             var
@@ -963,6 +968,7 @@ $.fn.form = function(parameters) {
             $.each(fields, function(index, field) {
               module.remove.rule(field);
             });
+            module.refresh(true);
           },
           // alias
           rules: function(field, rules) {

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -119,7 +119,7 @@ $.fn.form = function(parameters) {
           ;
         },
 
-        refresh: function(rebindEvents) {
+        refresh: function() {
           module.verbose('Refreshing selector cache');
           $field      = $module.find(selector.field);
           $group      = $module.find(selector.group);
@@ -129,10 +129,11 @@ $.fn.form = function(parameters) {
           $submit     = $module.find(selector.submit);
           $clear      = $module.find(selector.clear);
           $reset      = $module.find(selector.reset);
-          if(rebindEvents) {
-            module.removeEvents();
-            module.bindEvents();
-          }
+        },
+
+        refreshEvents: function() {
+          module.removeEvents();
+          module.bindEvents();
         },
 
         submit: function() {
@@ -867,11 +868,11 @@ $.fn.form = function(parameters) {
               }
             });
             module.debug('Adding rules', newValidation.rules, validation);
-            module.refresh(true);
+            module.refreshEvents();
           },
           fields: function(fields) {
             validation = $.extend(true, {}, validation, module.get.fieldsFromShorthand(fields));
-            module.refresh(true);
+            module.refreshEvents();
           },
           prompt: function(identifier, errors, internal) {
             var
@@ -968,7 +969,7 @@ $.fn.form = function(parameters) {
             $.each(fields, function(index, field) {
               module.remove.rule(field);
             });
-            module.refresh(true);
+            module.refreshEvents();
           },
           // alias
           rules: function(field, rules) {


### PR DESCRIPTION
## Description
Whenever a form field is dynamically added to the form and added/removed via `add field` or `remove field` to add/remove related rules, the event listeners to such new fields wre not renewed resulting in not correctly validating the  new field at runtime.

## Testcase
- Click "add val2 field" to add a field dynamically to the already existing form
- Use submit button to make the form invalid.
- Type anything into each field to see the different
### Broken
- The first field (which was already there) gets validated (error class is removed) whenever you type anything into the field
- The second field stays invalid (error class) while typing and only gets valid on blur
https://jsfiddle.net/lubber/0wyz2g7e/15/
### Fixed
- Both fields get validated while typing
https://jsfiddle.net/lubber/0wyz2g7e/18/

## Closes
#2035 