### PR TITLE
fix(theme): material theme changed fontpath in site variables

### DIFF
--- a/src/themes/material/globals/site.variables
+++ b/src/themes/material/globals/site.variables
@@ -44,7 +44,6 @@
 --------------------*/
 
 @imagePath : '../../themes/material/assets/images';
-@fontPath  : '../../themes/material/assets/fonts';
 
 /*--------------
    Paragraphs


### PR DESCRIPTION
## Description

Material theme changed the `@fontpath` in site variables. If one now wants to use the icons from the default theme this is not working anymore and all icons are broken

## Testcase
checkout/clone fui
1. Edit `src/theme.config` and change `@site` to `material` (keep `@icon` to `default`!)
2. Run `npx gulp build`
3. Put `dist` folder somewhere to test icons (i used the local docs to test the icon site)

## Screenshot
### Broken
![image](https://user-images.githubusercontent.com/18379884/157912234-4b117adb-8971-469f-a027-10c09f2f2fe2.png)

### Fixed
![image](https://user-images.githubusercontent.com/18379884/157912018-2457a263-9fd0-46b8-9719-4a905e1cdee8.png)

## Closes
#2261 