### PR TITLE
fix(install): dont start interactive script on npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "url": "https://github.com/fomantic/Fomantic-UI.git"
   },
   "scripts": {
-    "install": "gulp install",
     "build": "gulp build",
     "changelog": "auto-changelog -p"
   },


### PR DESCRIPTION
## Description
This PR removes the interactive auto install which was called automatically after `npm install`.
Whenever Fomantic UI is installed via `npm install fomantic-ui` the `dist` folder is already available, so there is no need to compile it at install time.

The main reason to remove it is that especially yarn and recent versions of npm do not work with inquirer interactive scripts as post install and throw an error.

Manually calling `npx/yarn gulp install` or `npx/yarn gulp build` right after `npm install` however, works fine

a `--ignore-scripts` shouldn't be needed anymore then

## Closes
#811 
#1859 
#1911 