### PR TITLE
build(scripts): reduce nightly publishing

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,8 +22,10 @@ jobs:
     - name: update nightly version
       run: node ./scripts/nightly-version.js
     - name: fomantic install & build
+      if: ${{ success() }}
       run: npx gulp install
     - name: publish to npm
+      if: ${{ success() }}
       run: |
         npm config set //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN
         npm publish --tag nightly

--- a/scripts/nightly-version.js
+++ b/scripts/nightly-version.js
@@ -1,6 +1,7 @@
 // node
 const fs = require('fs')
 const path = require('path')
+const childProcess = require('child_process')
 
 // npm
 const fetch = require('node-fetch')
@@ -13,60 +14,58 @@ const ghBase = 'https://api.github.com'
 const repoUrlPath = 'fomantic/Fomantic-UI'
 const npmBase = 'https://registry.npmjs.org'
 const npmPackage = 'fomantic-ui'
+const currentRev = childProcess // get the current rev from the repo
+  .execSync('git rev-parse HEAD')
+  .toString()
+  .trim()
+  .substr(0, 7)
 
-
-const getGitHubVersion = async function () {
-  return fetch(`${ghBase}/repos/${repoUrlPath}/milestones`)
+const getNextVersion = async function () {
+  const versions = await fetch(`${ghBase}/repos/${repoUrlPath}/milestones`)
     .then(r => r.json())
-    .then(milestones => milestones.filter(m => m.title.indexOf('x') === -1).map(m => m.title).sort()[0])
+    .then(milestones => milestones.filter(m => m.title.indexOf('x') === -1)) // remove all versions with `x` in it
+    .then(versions => versions.map(m => m.title)) // create array of versions
+    .then(versions => semver.sort(versions))
+
+  // Return first entry aka the smallest version in milestones which would therefore
+  // be the next version
+  return semver.parse(versions[0])
 }
 
-const getCurrentNpmVersion = async function () {
-  return fetch(`${npmBase}/${npmPackage}`)
-    .then(r => r.json())
-    .then(p => p['dist-tags'].nightly)
-}
-
-const getNpmPreRelease = async function () {
-  return fetch(`${npmBase}/${npmPackage}`)
-    .then(r => r.json())
-    .then(p => p['dist-tags'].nightly)
-    .then(v => semver.prerelease(v))
-    .then(pr => pr === null ? ['beta', 0] : pr)
-}
-
-const getAllNpmVersions = async function () {
-  // The versions property sometimes does not include versions which are in "time"!
-  // That's why "time" is used here
-  return fetch(`${npmBase}/${npmPackage}`)
+const getPublishedVersion = async function () {
+  // get the latest published nightly tagged version
+  return semver.parse(
+    await fetch(`${npmBase}/${npmPackage}`)
       .then(r => r.json())
-      .then(p => Object.keys(p['time']))
+      .then(p => p['dist-tags'].nightly)
+  )
 }
 
 const getNightlyVersion = async function () {
-  const nextVersion = await getGitHubVersion()
-  const currentNightlyWithPre = semver.parse(await getCurrentNpmVersion())
-  const currentNightly = `${currentNightlyWithPre.major}.${currentNightlyWithPre.minor}.${currentNightlyWithPre.patch}`
-  const allNpmVersions = await getAllNpmVersions()
-  let nightlyVersion = `${nextVersion}-beta.0`
+  const next = semver.parse(await getNextVersion())
+  const current = semver.parse(await getPublishedVersion())
 
-  if (semver.eq(nextVersion, currentNightly)) {
-    const preRelease = await getNpmPreRelease()
-
-    nightlyVersion = semver.inc(
-      `${nextVersion}-${preRelease[0]}.${preRelease[1]}`,
-      'prerelease'
-    )
-  }
-  //check if version was already uploaded to npm previously
-   while (allNpmVersions.indexOf(nightlyVersion) !== -1) {
-    nightlyVersion = semver.inc(
-        nightlyVersion,
-        'prerelease'
-    )
+  if (current.build[0] === currentRev) {
+    console.warn('No new commits since last publish. Exiting.')
+    childProcess.spawnSync.stdin.write('\x03');
+    return
   }
 
-  return nightlyVersion
+  let nightlyVersion = `${next.version}-beta.0`
+
+  // Check if published version is the same version as next version.
+  // Only check major, minor and patch as previously published nightly
+  // versions would include prerelease tag and build metadata
+  if (semver.eq(`${next.major}.${next.minor}.${next.patch}`, `${current.major}.${current.minor}.${current.patch}`)) {
+    // If they match then a nightly version has already been published, so we need to increment
+    // the prerelease and add the new rev as build metadata
+    nightlyVersion = semver.inc(
+    `${next.version}-beta.${current.prerelease[1]}`,
+    'prerelease'
+    )
+  }
+
+  return `${nightlyVersion}+${currentRev}`
 }
 
 getNightlyVersion()

--- a/scripts/nightly-version.js
+++ b/scripts/nightly-version.js
@@ -9,6 +9,7 @@ const semver = require('semver')
 
 // pkg
 const pkg = require('../package.json')
+const process = require('process')
 
 const ghBase = 'https://api.github.com'
 const repoUrlPath = 'fomantic/Fomantic-UI'
@@ -46,8 +47,8 @@ const getNightlyVersion = async function () {
   const current = semver.parse(await getPublishedVersion())
 
   if (current.build[0] === currentRev) {
-    console.warn('No new commits since last publish. Exiting.')
-    childProcess.spawnSync.stdin.write('\x03');
+    console.log('No new commits since last publish. Exiting.')
+    process.exit(1)
     return
   }
 


### PR DESCRIPTION
I've made changes to the nightly script to include the latest commit sha in the build metadata of the version so we can compare them. This allows us to only push the latest nightly to npm if there is now commits to push. I have also made changes to the workflow so it only continues and does the publish if the version was updated.