### PR TITLE
fix(calendar): keep whitespace between date and time

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -1560,7 +1560,7 @@ $.fn.calendar.settings = {
       if (!text) {
         return null;
       }
-      text = String(text).replace(/\s/g,'');
+      text = String(text).trim().replace(/([.:\/\-])\s+/g,'$1').replace(/\s+([.:\/-])/g,'$1').replace(/\s+/g,' ');
       if (text.length === 0) {
         return null;
       }


### PR DESCRIPTION
## Description
This PR corrects the whitespace removement bug from #2200, because the previous fix was not respecting a possible space character between date and time, which was still needed and not working anymore.

I was initially trying to fix it in a single regex but it got too complicated so i went for the easier, reliable and readable solution instead using 2 regexes.

## Testcase
### Broken
The provided date is wrong
https://jsfiddle.net/pL8he1ta/

### Fixed
Date is correct
https://jsfiddle.net/lubber/23y5mc0h/

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/159574421-abb1dd93-e3d4-431b-9c53-16252468d2aa.png)

## Closes 
#2274 
#2200 