### PR TITLE
fix(nightly): get commit hash from npm

### DIFF
--- a/scripts/nightly-version.js
+++ b/scripts/nightly-version.js
@@ -19,7 +19,7 @@ const currentRev = childProcess // get the current rev from the repo
   .execSync('git rev-parse HEAD')
   .toString()
   .trim()
-  .substr(0, 7)
+  .slice(0, 7)
 
 const getNextVersion = async function () {
   const versions = await fetch(`${ghBase}/repos/${repoUrlPath}/milestones`)
@@ -38,7 +38,12 @@ const getPublishedVersion = async function () {
   return semver.parse(
     await fetch(`${npmBase}/${npmPackage}`)
       .then(r => r.json())
-      .then(p => p['dist-tags'].nightly)
+      .then(p => {
+        let nightly = p['dist-tags'].nightly ?? '';
+        let versionInfo = p.versions[nightly] ?? {};
+        let buildCommit = nightly.indexOf('+')===-1 ? '+'+(versionInfo.gitHead ?? '').slice(0,7) : '';
+        return nightly+buildCommit;
+      })
   )
 }
 


### PR DESCRIPTION
## Description

The nightly script is not able to provide the version name + commit hash as version number to npm, as npm always removes the hash from the version number. Thus the nightly is still always created because it can not compare the commit hashes.

This is now fixed, because the script takes the hash information out of the versions details from the npm registry.
npm still does not show the hash in the tags list, but at least the nightly can compare the commit hashes so it only creates a new version now when anything really has changed as @hammy2899 intended 

## Closes
[#2273 ](https://github.com/fomantic/Fomantic-UI/pull/2273#issuecomment-1076019628)
