### PR TITLE
fix(dropdown): floating shadow and radius on direct child menu only

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -1482,8 +1482,8 @@ select.ui.dropdown {
     opacity: 1;
   }
   .ui.simple.dropdown > .menu > .item:active > .left.menu,
-  .ui.simple.dropdown .menu .item:hover > .left.menu, 
-  .right.menu .ui.simple.dropdown > .menu > .item:active > .menu:not(.right), 
+  .ui.simple.dropdown .menu .item:hover > .left.menu,
+  .right.menu .ui.simple.dropdown > .menu > .item:active > .menu:not(.right),
   .right.menu .ui.simple.dropdown > .menu .item:hover > .menu:not(.right) {
     left: auto;
     right: 100%;
@@ -1531,7 +1531,7 @@ select.ui.dropdown {
       Floating
   ---------------*/
 
-  .ui.floating.dropdown .menu {
+  .ui.floating.dropdown > .menu {
     left: 0;
     right: auto;
     box-shadow: @floatingMenuBoxShadow !important;


### PR DESCRIPTION
It's just a 1 character change so I'll keep it short:

There's an ugly and probably unwanted shadow and radius on the inner floating dropdown `.menu` which this fix removes.

https://jsfiddle.net/0cpwnfkz/

![image](https://user-images.githubusercontent.com/45571053/160367193-2689760c-8f80-4f10-b2bf-c80d85c052bd.png)
