### PR TITLE
build(scripts): correct nightly workflow variable

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,7 +33,7 @@ jobs:
       env:
         CI: true
         NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTOMATION }}
-        PUBLISH_VERSION: ${{ steps.nightly-version.outputs.version }}
+        PUBLISH_VERSION: ${{ steps.nightly-version.outputs.publishVersion }}
       run: |
         npm config set //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN
         yarn config set registry https://registry.npmjs.org


### PR DESCRIPTION
Correct the variable used in the publish command for the version