### PR TITLE
build(scripts): fix nightly script

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,7 +9,6 @@ jobs:
     if: github.repository == 'fomantic/Fomantic-UI'
     outputs:
       shouldPublish: ${{ steps.nightly-version.outputs.shouldPublish }}
-      publishVersion: ${{ steps.nightly-version.outputs.publishVersion }}
     steps:
     - uses: actions/checkout@v2
       with:
@@ -33,8 +32,6 @@ jobs:
       env:
         CI: true
         NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTOMATION }}
-        PUBLISH_VERSION: ${{ steps.nightly-version.outputs.publishVersion }}
       run: |
         npm config set //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN
-        yarn config set registry https://registry.npmjs.org
-        yarn publish --tag nightly --new-version $PUBLISH_VERSION --non-interactive
+        npm publish

--- a/scripts/nightly-version.js
+++ b/scripts/nightly-version.js
@@ -42,7 +42,7 @@ const getPublishedVersion = async function () {
       .then(p => {
         let nightly = p['dist-tags'].nightly ?? '';
         let versionInfo = p.versions[nightly] ?? {};
-        let buildCommit = nightly.indexOf('+')===-1 ? '+'+(versionInfo.gitHead ?? '').slice(0,7) : '';
+        let buildCommit = nightly.indexOf('+')===-1 && versionInfo.gitHead ? '+'+(versionInfo.gitHead ?? '').slice(0,7) : '';
         return nightly+buildCommit;
       })
   )
@@ -75,7 +75,6 @@ const getNightlyVersion = async function () {
   }
 
   actions.setOutput('shouldPublish', true)
-  actions.setOutput('publishVersion', nightlyVersion)
   return `${nightlyVersion}+${currentRev}`
 }
 


### PR DESCRIPTION
Fix the nightly script due to yarn publish not adding gitHead to the
registry. Also moved back to npm publish so we can keep functionality of
not publishing when there is no changes.