### PR TITLE
build(actions): add --tag to publish command

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,4 +34,4 @@ jobs:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTOMATION }}
       run: |
         npm config set //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN
-        npm publish
+        npm publish --tag nightly


### PR DESCRIPTION
Add `--tag nightly` to the publish command like it used to be...