### PR TITLE
fix(button): loading buttons still shows labels

### DIFF
--- a/src/definitions/elements/button.less
+++ b/src/definitions/elements/button.less
@@ -169,19 +169,24 @@
 
     box-shadow: 0 0 0 1px transparent;
   }
-}
-& when (@variationButtonLabeledIcon){
-  .ui.labeled.icon.loading.button .icon {
+  .ui.ui.loading.button .label {
     background-color: transparent;
-    box-shadow: none;
+    border-color: transparent;
+    color: transparent;
   }
-}
-& when (@variationButtonBasic){
-  .ui.basic.loading.button:not(.inverted)::before {
-    border-color: @loaderFillColor;
+  & when (@variationButtonLabeledIcon){
+    .ui.labeled.icon.loading.button .icon {
+      background-color: transparent;
+      box-shadow: none;
+    }
   }
-  .ui.basic.loading.button:not(.inverted)::after {
-    border-color: @loaderLineColor;
+  & when (@variationButtonBasic){
+    .ui.basic.loading.button:not(.inverted)::before {
+      border-color: @loaderFillColor;
+    }
+    .ui.basic.loading.button:not(.inverted)::after {
+      border-color: @loaderLineColor;
+    }
   }
 }
 & when (@variationButtonDisabled){

--- a/src/definitions/elements/button.less
+++ b/src/definitions/elements/button.less
@@ -169,7 +169,7 @@
 
     box-shadow: 0 0 0 1px transparent;
   }
-  .ui.ui.loading.button .label {
+  .ui.ui.ui.loading.button .label {
     background-color: transparent;
     border-color: transparent;
     color: transparent;


### PR DESCRIPTION
## Decription
Whenever a `loading button` contains any kind of label it was still shown

## Testcase
- Select anything from the dropdown (it will get the loading state then)
- Remove CSS to see issue
https://jsfiddle.net/lubber/mrza0234/9/

## Screenshot
## Broken
![image](https://user-images.githubusercontent.com/18379884/162549598-1b7c74c6-0d0f-4b0b-81b0-9d987bbfd7d3.png)

## Closes
#2288 