### PR TITLE
fix(popup): tooltips cannot contain headers

### DIFF
--- a/src/definitions/modules/popup.less
+++ b/src/definitions/modules/popup.less
@@ -243,10 +243,6 @@
       border: @tooltipInvertedBorder;
       box-shadow: @tooltipInvertedBoxShadow;
     }
-    [data-tooltip][data-inverted]::after .header {
-      background: @tooltipInvertedHeaderBackground;
-      color: @tooltipInvertedHeaderColor;
-    }
   }
 
   & when (@variationPopupPosition) {

--- a/src/themes/default/modules/popup.variables
+++ b/src/themes/default/modules/popup.variables
@@ -88,8 +88,6 @@
 @tooltipInvertedColor: @invertedColor;
 @tooltipInvertedBorder: @invertedBorder;
 @tooltipInvertedBoxShadow: @invertedBoxShadow;
-@tooltipInvertedHeaderBackground: @invertedHeaderBackground;
-@tooltipInvertedHeaderColor: @invertedHeaderColor;
 
 /* Arrow */
 @tooltipArrowVerticalOffset: -@2px;


### PR DESCRIPTION
## Description

A CSS only tooltip only contains text as it uses the `::after` pseudo element to display the text via the content attribute.
However content cannot contain HTML, thus an additional selector after a ::after pseudo element can never happen and is infact invalid.

This situation not only never happens but also makes some parsers like Parcel complaining about invalid CSS.

Thus, i simply removed the whole selector.

## Closes
#2315 