### PR TITLE
fix(slider): support mouse & touch all the time

### DIFF
--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -322,6 +322,7 @@ $.fn.slider = function(parameters) {
           },
           touchDown: function(event) {
             event.preventDefault();  // disable mouse emulation and touch-scrolling
+            event.stopImmediatePropagation();
             if(touchIdentifier !== undefined) {
               // ignore multiple touches on the same slider --
               // we cannot handle changing both thumbs at once due to shared state

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -777,7 +777,7 @@ $.fn.slider = function(parameters) {
           eventPos: function(event) {
             if(event.type === "touchmove" || event.type === "touchend") {
               var
-                touchEvent = event.Touches ? event : event.originalEvent,
+                touchEvent = event.touches ? event : event.originalEvent,
                 touch = touchEvent.changedTouches[0];  // fall back to first touch if correct touch not found
               for(var i=0; i < touchEvent.touches.length; i++) {
                 if(touchEvent.touches[i].identifier === touchIdentifier) {

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -86,7 +86,6 @@ $.fn.slider = function(parameters) {
         secondPos,
         offset,
         precision,
-        isTouch,
         gapRatio = 1,
         previousValue,
 
@@ -104,7 +103,6 @@ $.fn.slider = function(parameters) {
           currentRange += 1;
           documentEventID = currentRange;
 
-          isTouch = module.setup.testOutTouch();
           module.setup.layout();
           module.setup.labels();
 
@@ -175,14 +173,6 @@ $.fn.slider = function(parameters) {
               }
             }
           },
-          testOutTouch: function() {
-            try {
-             document.createEvent('TouchEvent');
-             return true;
-            } catch (e) {
-             return false;
-            }
-          },
           customLabel: function() {
             var
               $children   = $labels.find('.label'),
@@ -236,9 +226,6 @@ $.fn.slider = function(parameters) {
             module.bind.globalKeyboardEvents();
             module.bind.keyboardEvents();
             module.bind.mouseEvents();
-            if(module.is.touch()) {
-              module.bind.touchEvents();
-            }
             if (settings.autoAdjustLabels) {
               module.bind.windowEvents();
             }
@@ -265,26 +252,11 @@ $.fn.slider = function(parameters) {
               isHover = false;
             });
           },
-          touchEvents: function() {
-            module.verbose('Binding touch events');
-            $module.find('.track, .thumb, .inner').on('touchstart' + eventNamespace, function(event) {
-              event.stopImmediatePropagation();
-              event.preventDefault();
-              module.event.down(event);
-            });
-            $module.on('touchstart' + eventNamespace, module.event.down);
-          },
           slidingEvents: function() {
             // these don't need the identifier because we only ever want one of them to be registered with document
             module.verbose('Binding page wide events while handle is being draged');
-            if(module.is.touch()) {
-              $(document).on('touchmove' + eventNamespace, module.event.move);
-              $(document).on('touchend' + eventNamespace, module.event.up);
-            }
-            else {
-              $(document).on('mousemove' + eventNamespace, module.event.move);
-              $(document).on('mouseup' + eventNamespace, module.event.up);
-            }
+            $(document).on('mousemove' + eventNamespace, module.event.move);
+            $(document).on('mouseup' + eventNamespace, module.event.up);
           },
           windowEvents: function() {
             $window.on('resize' + eventNamespace, module.event.resize);
@@ -294,24 +266,17 @@ $.fn.slider = function(parameters) {
         unbind: {
           events: function() {
             $module.find('.track, .thumb, .inner').off('mousedown' + eventNamespace);
-            $module.find('.track, .thumb, .inner').off('touchstart' + eventNamespace);
             $module.off('mousedown' + eventNamespace);
             $module.off('mouseenter' + eventNamespace);
             $module.off('mouseleave' + eventNamespace);
-            $module.off('touchstart' + eventNamespace);
             $module.off('keydown' + eventNamespace);
             $module.off('focusout' + eventNamespace);
             $(document).off('keydown' + eventNamespace + documentEventID, module.event.activateFocus);
             $window.off('resize' + eventNamespace);
           },
           slidingEvents: function() {
-            if(module.is.touch()) {
-              $(document).off('touchmove' + eventNamespace);
-              $(document).off('touchend' + eventNamespace);
-            } else {
-              $(document).off('mousemove' + eventNamespace);
-              $(document).off('mouseup' + eventNamespace);
-            }
+            $(document).off('mousemove' + eventNamespace);
+            $(document).off('mouseup' + eventNamespace);
           },
         },
 
@@ -500,9 +465,6 @@ $.fn.slider = function(parameters) {
           },
           smooth: function() {
             return settings.smooth || $module.hasClass(settings.className.smooth);
-          },
-          touch: function() {
-            return isTouch;
           }
         },
 
@@ -766,7 +728,7 @@ $.fn.slider = function(parameters) {
             return value;
           },
           eventPos: function(event) {
-            if(module.is.touch()) {
+            if(event.type === "touchmove") {
               var
                 touchEvent = event.changedTouches ? event : event.originalEvent,
                 touches = touchEvent.changedTouches[0] ? touchEvent.changedTouches : touchEvent.touches,


### PR DESCRIPTION
## Description
As proposed in #1988, I did a rework of the touch event handling of the slider component. The new touch event code

 - does not prevent mouse input (fixes #1988)
 - tracks Touch identifier to avoid confusion by other fingers on the touch screen
 - handles touchcancel events in a sensible way
 - does no dynamic binding and unbinding to all touch events on the page. In combination with the second point, this enables multitouch sliding of multiple sliders on the same page (I know, nobody asked for this, but it works. ;) ) – Unfortunately, multitouch sliding of the first and second thumb of the same slider is not easy to implement due global state within each slider module.
 - only binds to touchstart events on the `.thumb` element to avoid accidential sliding while scrolling the page on a mobile device (obsoletes #1987)

The last point can be considered a disadvantage/regression compared to the old code, if you consider touch-sliding anywhere on the slider as a feature. However, in my experience, it's really annoying to change a slider position (which has immediate real-world effects in my home automation software) when scrolling the page and accidentially hitting a slider. Using the mouse, one can still slide the slider anywhere on its track.

## Testcase
https://jsfiddle.net/sfz45v0m/3/

## Screenshot (if possible)
--

## Closes
- #1988
- #1987
