### PR TITLE
fix(emoji,flag): default lineheight should meet text

### DIFF
--- a/src/themes/default/elements/emoji.variables
+++ b/src/themes/default/elements/emoji.variables
@@ -15,4 +15,4 @@
 /* Emoji Variables */
 @opacity: 1;
 @loadingDuration: 2s;
-@emojiLineHeight: @headerLineHeight;
+@emojiLineHeight: 1em;

--- a/src/themes/default/elements/flag.variables
+++ b/src/themes/default/elements/flag.variables
@@ -12,4 +12,4 @@
        Element
 --------------------*/
 
-@flagLineHeight: @headerLineHeight;
+@flagLineHeight: 1em;


### PR DESCRIPTION
## Description
Emojis and flags were larger than the inheriting line-height, resulting in larger dropdowns when they contain such emojis/flags
This PR makes them in line with surrounding text.

I tag this as breaking change, because existing projects using emojis will get slightly smaller emojis unless they provide a size class.

## Testcase
Remove CSS to see issue (left dropdown is higher then right)
https://jsfiddle.net/lubber/ub7sgh96/12/

## Screenshot
|Before|After
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/164993262-fc60dfff-ba84-4260-a2e6-51b935cadeec.png)|![image](https://user-images.githubusercontent.com/18379884/164993237-f7cd4514-c5f4-4a92-b14e-0608124744d5.png)|

## Closes
#2333 
