### PR TITLE
feat(ci): fix ci should not stop when one action fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ jobs:
     name: Test build process on node ${{ matrix.node-version }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node-version: [12, 14, 16]
     steps:


### PR DESCRIPTION
## Description
We recently had a dependabot PR which fails for node 12. Unfortunaltey the default for githubs [fast fail strategy](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast) is to stop every other test build 

As we only set node 14 and 16 as required i would like to see if at lease the required checks will build, so this PR sets fast fail to false