### PR TITLE
feat(build): require node 12 as minimum

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,8 +79,8 @@
     "semver": "^7.3.5"
   },
   "engines": {
-    "node": ">=10.15.3",
-    "npm": ">=6.4.1"
+    "node": ">=12",
+    "npm": ">=6.14.8"
   },
   "title": "Fomantic UI",
   "style": "dist/semantic.css"


### PR DESCRIPTION
## Description

Upgrade node dependency to 12, which is the least supported version by now (yes, runs out of service by end of April, but i believe v12 is still widely spread and other dependencies are ugrading as well