### PR TITLE
fix(dropdown): support preselected on value update for select tag

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1074,7 +1074,7 @@ $.fn.dropdown = function(parameters) {
                     settings.preserveHTML
                   )
                 ;
-                $input.append('<option value="' + value + '">' + name + '</option>');
+                $input.append('<option value="' + value + '"' + (item.selected === true ? ' selected' : '') + '>' + name + '</option>');
               });
               module.observe.select();
             }


### PR DESCRIPTION
## Description
Whenever a dropdown was initialized via a select tag and also had initial values via the `values` setting, any preselected item was ignored.

## Testcase
### Broken
The first select does not show any value, although 2 items are preselected
http://jsfiddle.net/cf4a7yoL/5/

### Fixed
All fine
http://jsfiddle.net/lubber/yv4f0ces/

## Closes
#2342 