### PR TITLE
fix(api): fix inefficient RegExp that may cause ReDoS

### DIFF
--- a/src/definitions/behaviors/api.js
+++ b/src/definitions/behaviors/api.js
@@ -1208,7 +1208,7 @@ $.api.settings = {
   regExp  : {
     required : /\{\$*[A-z0-9]+\}/g,
     optional : /\{\/\$*[A-z0-9]+\}/g,
-    validate: /^[a-z_][a-z0-9_-]*(?:\[(?:\d*|[a-z0-9_-]+)\])*$/i,
+    validate: /^[a-z_][a-z0-9_-]*(?:\[[a-z0-9_-]*\])*$/i,
     key:      /[a-z0-9_-]+|(?=\[\])/gi,
     push:     /^$/,
     fixed:    /^\d+$/,


### PR DESCRIPTION
## Description
Fixes inefficient RegExp which could cause Regular expression Denial of Service attack

The problematic part `(?:\[(?:\d*|[a-z0-9_-]+)\])*` will matches

* (empty)
* `[]`
*  `[0123]`
*  `[abcd]`
*  `[0a_1b_c2]`
* `[][]`
*  `[0123][]`
*  `[abcd][0a_1b_c2]`

All these pattern is covered with the fixed regexp, I think.

. | Before | After
---|---|---
[ReDoS check](https://makenowjust-labs.github.io/recheck/playground/) | <img width="813" alt="image" src="https://user-images.githubusercontent.com/127635/166092555-00489c22-8cfc-4bc4-8795-21bf35944701.png"> | <img width="734" alt="image" src="https://user-images.githubusercontent.com/127635/166092549-034fd171-8d5d-46ac-b640-2a8b12ad9632.png">
[Railroad diagram (Only the problematic part)](https://regexper.com/) | [<img width="276" alt="image" src="https://user-images.githubusercontent.com/127635/166092740-c713f2ae-2cc8-47ed-a1e2-0d8981cd3c8f.png">](https://regexper.com/#%28%3F%3A%5C%5B%28%3F%3A%5Cd*%7C%5Ba-z0-9_-%5D%2B%29%5C%5D%29*) | [<img width="254" alt="image" src="https://user-images.githubusercontent.com/127635/166093512-bea70500-4b12-478d-9f5c-85236e60c23f.png">](https://regexper.com/#%28%3F%3A%5C%5B%5Ba-z0-9_-%5D*%5C%5D%29*)



## Testcase

None

## Screenshot (if possible)

N/A

## Closes
None

Fixes https://github.com/fomantic/Fomantic-UI/security/code-scanning/1