### PR TITLE
fix(dropdown): input width specifitiy was same as form input

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -191,7 +191,7 @@
   border-top: none;
 }
 
-.ui.dropdown.dropdown .menu > .input {
+.ui.ui.ui.dropdown .menu > .input {
   width: auto;
   display: flex;
   margin: @menuInputMargin;


### PR DESCRIPTION
## Description
The specificity level for width setting for form input and dropdown menu input was identical. 
Thus, when dropdown.css was loaded before form.css and a search dropdown was used inside a form, the input was overflowing the dropdown menu.
by increasing the specificity this situation is fixed.

## Testcase
The second dropdown has an overflowing input field
### Broken
https://jsfiddle.net/lubber/mcw01fob/4/

### Fixed
Second dropdown looks good 
https://jsfiddle.net/lubber/mcw01fob/5/

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/168329302-82f90819-7e5a-4c5b-8ea4-a54fc480eb74.png)

## Closes
#2368 