### PR TITLE
fix(dropdown): support callbacks given inside apisettings

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -814,20 +814,28 @@ $.fn.dropdown = function(parameters) {
               throttle      : settings.throttle,
               urlData       : {
                 query: query
-              },
-              onError: function() {
+              }
+            },
+            apiCallbacks = {
+              onError: function(errorMessage, $module, xhr) {
                 module.add.message(message.serverError);
                 iconClicked = false;
                 focused = false;
                 callback.apply(null, callbackParameters);
+                if(typeof settings.apiSettings.onError === 'function') {
+                  settings.apiSettings.onError.call(this, errorMessage, $module, xhr);
+                }
               },
-              onFailure: function() {
+              onFailure: function(response, $module, xhr) {
                 module.add.message(message.serverError);
                 iconClicked = false;
                 focused = false;
                 callback.apply(null, callbackParameters);
+                if(typeof settings.apiSettings.onFailure === 'function') {
+                  settings.apiSettings.onFailure.call(this, response, $module, xhr);
+                }
               },
-              onSuccess : function(response) {
+              onSuccess : function(response, $module, xhr) {
                 var
                   values          = response[fields.remoteValues]
                 ;
@@ -852,13 +860,16 @@ $.fn.dropdown = function(parameters) {
                 iconClicked = false;
                 focused = false;
                 callback.apply(null, callbackParameters);
+                if(typeof settings.apiSettings.onSuccess === 'function') {
+                  settings.apiSettings.onSuccess.call(this, response, $module, xhr);
+                }
               }
             }
           ;
           if( !$module.api('get request') ) {
             module.setup.api();
           }
-          apiSettings = $.extend(true, {}, apiSettings, settings.apiSettings);
+          apiSettings = $.extend(true, {}, apiSettings, settings.apiSettings, apiCallbacks);
           $module
             .api('setting', apiSettings)
             .api('query')

--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -367,20 +367,36 @@ $.fn.search = function(parameters) {
                 urlData           : {
                   query : searchTerm
                 },
-                onSuccess         : function(response) {
+              },
+              apiCallbacks = {
+                onSuccess         : function(response, $module, xhr) {
                   module.parse.response.call(element, response, searchTerm);
                   callback();
+                  if(settings.apiSettings && typeof settings.apiSettings.onSuccess === 'function') {
+                    settings.apiSettings.onSuccess.call(this, response, $module, xhr);
+                  }
                 },
-                onFailure         : function() {
+                onFailure         : function(response, $module, xhr) {
                   module.displayMessage(error.serverError);
                   callback();
+                  if(settings.apiSettings && typeof settings.apiSettings.onFailure === 'function') {
+                    settings.apiSettings.onFailure.call(this, response, $module, xhr);
+                  }
                 },
-                onAbort : function(response) {
+                onAbort : function(status, $module, xhr) {
+                  if(settings.apiSettings && typeof settings.apiSettings.onAbort === 'function') {
+                    settings.apiSettings.onAbort.call(this, status, $module, xhr);
+                  }
                 },
-                onError           : module.error
+                onError           : function(errorMessage, $module, xhr){
+                  module.error();
+                  if(settings.apiSettings && typeof settings.apiSettings.onError === 'function') {
+                    settings.apiSettings.onError.call(this, errorMessage, $module, xhr);
+                  }
+                }
               }
             ;
-            $.extend(true, apiSettings, settings.apiSettings);
+            $.extend(true, apiSettings, settings.apiSettings, apiCallbacks);
             module.verbose('Setting up API request', apiSettings);
             $module.api(apiSettings);
           }


### PR DESCRIPTION
## Description
Whenever a dropdown had `apiSettings` set which also contained any callback for `onSuccess` or `onFailure` or `onError`, the menu was not shown anymore.
The search component had the same issue, so i also fixed it there.


## Testcase
- Open developer tools to watch console
- Click into the dropdown
### Broken
- menu is not shown
- console output shows the onsuccess message
https://jsfiddle.net/34z06c2e/

### Fixed
- menu is shown as expected
- console output also shows the onsuccess message 
https://jsfiddle.net/lubber/3kj1b0wL/1/


## Closes
#2401 