### PR TITLE
feat(dropdown): improve accessibility in relation to search dropdown

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -110,8 +110,8 @@ $.fn.dropdown = function(parameters) {
               settings.ignoreDiacritics = false;
               module.error(error.noNormalize, element);
             }
-            module.create.id();
-            module.setup.layout(id);
+
+            module.setup.layout();
 
             if(settings.values) {
               module.set.initialLoad();
@@ -124,6 +124,7 @@ $.fn.dropdown = function(parameters) {
             module.save.defaults();
             module.restore.selected();
 
+            module.create.id();
             module.bind.events();
 
             module.observeChanges();
@@ -365,22 +366,18 @@ $.fn.dropdown = function(parameters) {
             }
             if( module.is.search() && !module.has.search() ) {
               module.verbose('Adding search input');
-              if($module.prev('label').length) {
-                $search = $('<input />')
+              var labelNode = $module.prev('label');
+              $search = $('<input />')
                 .addClass(className.search)
                 .prop('autocomplete', module.is.chrome() ? 'fomantic-search' : 'off')
-                .attr('aria-labelledby',id+'_formLabel')
-                .insertBefore($text)
-                ;
-                $module.prev('label').attr('id', id + '_formLabel');
+              ;
+              if (labelNode.length) {
+                if (!labelNode.attr('id')) {
+                  labelNode.attr('id', module.get.id() + '_formLabel');
+                }
+                $search.attr('aria-labelledby', labelNode.attr('id'));
               }
-              else {
-                $search = $('<input />')
-                .addClass(className.search)
-                .prop('autocomplete', module.is.chrome() ? 'fomantic-search' : 'off')
-                .insertBefore($text)
-                ;
-              }
+              $search.insertBefore($text);
             }
             if( module.is.multiple() && module.is.searchSelection() && !module.has.sizer()) {
               module.create.sizer();

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -111,6 +111,7 @@ $.fn.dropdown = function(parameters) {
               module.error(error.noNormalize, element);
             }
 
+            module.create.id();
             module.setup.layout();
 
             if(settings.values) {
@@ -124,7 +125,6 @@ $.fn.dropdown = function(parameters) {
             module.save.defaults();
             module.restore.selected();
 
-            module.create.id();
             module.bind.events();
 
             module.observeChanges();
@@ -366,7 +366,9 @@ $.fn.dropdown = function(parameters) {
             }
             if( module.is.search() && !module.has.search() ) {
               module.verbose('Adding search input');
-              var labelNode = $module.prev('label');
+              var
+                  labelNode = $module.prev('label')
+              ;
               $search = $('<input />')
                 .addClass(className.search)
                 .prop('autocomplete', module.is.chrome() ? 'fomantic-search' : 'off')

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -110,8 +110,8 @@ $.fn.dropdown = function(parameters) {
               settings.ignoreDiacritics = false;
               module.error(error.noNormalize, element);
             }
-
-            module.setup.layout();
+            module.create.id();
+            module.setup.layout(id);
 
             if(settings.values) {
               module.set.initialLoad();
@@ -124,7 +124,6 @@ $.fn.dropdown = function(parameters) {
             module.save.defaults();
             module.restore.selected();
 
-            module.create.id();
             module.bind.events();
 
             module.observeChanges();
@@ -366,11 +365,22 @@ $.fn.dropdown = function(parameters) {
             }
             if( module.is.search() && !module.has.search() ) {
               module.verbose('Adding search input');
-              $search = $('<input />')
+              if($module.prev('label').length) {
+                $search = $('<input />')
+                .addClass(className.search)
+                .prop('autocomplete', module.is.chrome() ? 'fomantic-search' : 'off')
+                .attr('aria-labelledby',id+'_formLabel')
+                .insertBefore($text)
+                ;
+                $module.prev('label').attr('id', id + '_formLabel');
+              }
+              else {
+                $search = $('<input />')
                 .addClass(className.search)
                 .prop('autocomplete', module.is.chrome() ? 'fomantic-search' : 'off')
                 .insertBefore($text)
-              ;
+                ;
+              }
             }
             if( module.is.multiple() && module.is.searchSelection() && !module.has.sizer()) {
               module.create.sizer();


### PR DESCRIPTION
## Description
in case of using the &lt;label&gt; element before a search dropdown to improove accessibility
- id of module is used to add an unique id to this very label 
- a reference to this label is made via the attribut "labelledby"
- see https://www.w3.org/WAI/tutorials/forms/labels/

## Testcase
https://jsfiddle.net/inselhopper/ot5zqvb2/38/