### PR TITLE
[Dropdown] Fix focus flow when a search dropdown is used from a mobile

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1153,7 +1153,7 @@ $.fn.dropdown = function(parameters) {
               if(module.is.multiple()) {
                 module.remove.activeLabel();
               }
-              if(!focused && !module.is.active() && (settings.showOnFocus || (event.type !== 'focus' && event.type !== 'focusin'))) {
+              if(!focused && !module.is.active() && (settings.showOnFocus || (event.type !== 'focus' && event.type !== 'focusin')) && event.type !== 'touchstart') {
                 focused = true;
                 module.search();
               }


### PR DESCRIPTION
<!--
 Please read our Contributing Guide and Code of Conduct before you
 submit a pull request.
  
 Contributing Guide: https://github.com/fomantic/Fomantic-UI/blob/master/CONTRIBUTING.md
 Code of Conduct: https://github.com/fomantic/Fomantic-UI/blob/master/CODE_OF_CONDUCT.md

 ----

 Please use the following pull request title format:
 "[<scope>] <summary of what you fixed/changed>"
-->

## Description

When using a search dropdown from a mobile, it doesn't correctly open when you click on it.
The flow is stuck at a point :
```
// dropdown.js - line 1150
// When we click on the search dropdown, a touchscreen event is triggered, and
// it is attached to the search.focus function when the selector is a .input.search

search: {
            focus: function(event) {
              activated = true;
              if(module.is.multiple()) {
                module.remove.activeLabel();
              }
              if(!focused && !module.is.active() && (settings.showOnFocus || (event.type !== 'focus' && event.type !== 'focusin'))) {
                focused = true;
                module.search();
              }
            }
...
```

If the condition is met, `focused` becomes true, and we call `module.search()`.
After a few methods calls, we end up in the `filter` method : 
```
// dropdown.js - line 767
...
if(module.is.searchSelection() && module.can.show() && module.is.focusedOnSearch() ) {
       module.show();
}
```

But as the `touchscreen` event doesn't focus the dropdown, `module.is.focusedOnSearch()` is `false`.
We are then stuck with a `focused` as true without the dropdown being opened, and consequently the `hide` method is never called and `focused` stays as `true` forever.

A `focus` event is triggered right after the `touchscreen` event, but as `focused` is equal to `true`, the condition line 1156 is never met.

That's why I wouldn't trigger the `search` flow if the event is `touchscreen`.

## Screenshot (if possible)

Before my fix : 
![Aug-03-2022 10-49-12](https://user-images.githubusercontent.com/34269296/182566231-bd5e9bb0-b763-4a6a-977d-ce4626344e47.gif)

After my fix : 
![Aug-03-2022 10-47-35](https://user-images.githubusercontent.com/34269296/182566064-460fb488-8e31-43c1-8a7c-8248ede661fe.gif)
