### PR TITLE
feat(transition): firefox needs reattached node to retrieve new anima…

### DIFF
--- a/src/definitions/modules/transition.js
+++ b/src/definitions/modules/transition.js
@@ -698,6 +698,7 @@ $.fn.transition = function() {
                 .addClass(className.transition)
                 .css('animationName')
               ;
+              $clone.detach().insertAfter($module);
               inAnimation = $clone
                 .addClass(className.inward)
                 .css('animationName')

--- a/src/definitions/modules/transition.js
+++ b/src/definitions/modules/transition.js
@@ -704,6 +704,7 @@ $.fn.transition = function() {
                 .css('animationName')
               ;
               if(!displayType) {
+                $clone.detach().insertAfter($module);
                 displayType = $clone
                   .attr('class', elementClass)
                   .removeAttr('style')


### PR DESCRIPTION
## Description
Latest Firefox 103 does not seem to provide the correct changed animationname in all cases.
This fix simply reattaches the temporary node to make sure firefox freshly computes the animationname.

## Testcase
- Use Firefox 103.x (latest)
- Open dev console
- close the first accordion
- reopen the accordion or any other closed accordion

### Broken
- Console says `Transition: Element is no longer attached to DOM. Unable to animate.  Use silent setting to surpress this warning in production. fade in <p class="transition hidden">`
- accordion does not show opened content

https://jsfiddle.net/lubber/3ybfs51n/2/

### Fixed
All fine 
https://jsfiddle.net/lubber/3ybfs51n/4/

## Closes
#2412 