### PR TITLE
fix(form): inverted form labels were black

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -69,11 +69,10 @@
   font-size: @labelFontSize;
   font-weight: @labelFontWeight;
   text-transform: @labelTextTransform;
-  &:not(.button) {
-    color: @labelColor;
-  }
 }
-
+.ui.form:not(.inverted) .field > label:not(.button) {
+  color: @labelColor;
+}
 /*--------------------
     Standard Inputs
 ---------------------*/


### PR DESCRIPTION
## Description
form labels in inverted forms were not shown white but still black

## Screenshot
![invertedformlabel](https://user-images.githubusercontent.com/18379884/183713289-ae2974e6-5415-410f-b081-c2f5b77ee815.gif)

## Closes
#2421 