### PR TITLE
fix(popup): broken and unnecessary check for string

### DIFF
--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -121,7 +121,7 @@ $.fn.popup = function(parameters) {
         },
 
         refresh: function() {
-          if(settings.popup && typeof settings.popup === 'string') {
+          if(settings.popup) {
             $popup = $(document).find(settings.popup).eq(0);
           }
           else {
@@ -286,7 +286,7 @@ $.fn.popup = function(parameters) {
             }
             settings.onCreate.call($popup, element);
           }
-          else if(settings.popup && typeof settings.popup === 'string') {
+          else if(settings.popup) {
             $(document).find(settings.popup).data(metadata.activator, $module);
             module.verbose('Used popup specified in settings');
             module.refresh();


### PR DESCRIPTION
## Description
popup and calendar did not work anymore since the codeql fixes unnecessarily added a check for the popup settings being a string.
However on instantiating a popup a possible given string setting turns into an object, so whenever the popup is tried to be shown a script error and no popup occurs. Found this while trying calendar module...

## Fixes
#2375 

