### PR TITLE
fix(modal): avoid propagation of escape to modal

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -593,8 +593,8 @@ $.fn.calendar = function(parameters) {
           },
           keydown: function (event) {
             var keyCode = event.which;
-            if (keyCode === 27 || keyCode === 9) {
-              //esc || tab
+            if (keyCode === 9) {
+              //tab
               module.popup('hide');
             }
 
@@ -629,6 +629,9 @@ $.fn.calendar = function(parameters) {
                 }
                 //disable form submission:
                 event.preventDefault();
+                event.stopPropagation();
+              } else if (keyCode === 27) {
+                module.popup('hide');
                 event.stopPropagation();
               }
             }

--- a/src/definitions/modules/checkbox.js
+++ b/src/definitions/modules/checkbox.js
@@ -244,6 +244,7 @@ $.fn.checkbox = function(parameters) {
               module.verbose('Escape key pressed blurring field');
               $input.blur();
               shortcutPressed = true;
+              event.stopPropagation();
             }
             else if(!event.ctrlKey && module.can.change()) {
                 if( key == keyCode.space || (key == keyCode.enter && settings.enableEnterKey) ) {

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1699,6 +1699,7 @@ $.fn.dropdown = function(parameters) {
                 if(pressedKey == keys.escape) {
                   module.verbose('Escape key pressed, closing dropdown');
                   module.hide();
+                  event.stopPropagation();
                 }
 
               }

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -723,7 +723,7 @@ $.fn.modal = function(parameters) {
           keyboardShortcuts: function() {
             module.verbose('Adding keyboard shortcuts');
             $document
-              .on('keyup' + eventNamespace, module.event.keyboard)
+              .on('keydown' + eventNamespace, module.event.keyboard)
             ;
           }
         },
@@ -803,7 +803,7 @@ $.fn.modal = function(parameters) {
           keyboardShortcuts: function() {
             module.verbose('Removing keyboard shortcuts');
             $document
-              .off('keyup' + eventNamespace)
+              .off('keydown' + eventNamespace)
             ;
           },
           scrolling: function() {

--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -262,7 +262,7 @@ $.fn.search = function(parameters) {
 
           resultsScrollTop = $results.scrollTop();
           resultsHeight = $results.height();
-            
+
           if (elTop < 0) {
             $results.scrollTop(resultsScrollTop + elTop);
           }
@@ -295,6 +295,7 @@ $.fn.search = function(parameters) {
           if(keyCode == keys.escape) {
             module.verbose('Escape key pressed, blurring search field');
             module.hideResults();
+            event.stopPropagation();
             resultsDismissed = true;
           }
           if( module.is.visible() ) {
@@ -678,10 +679,10 @@ $.fn.search = function(parameters) {
                 ;
                 if(fieldExists) {
                   var text;
-                  if (typeof content[field] === 'string'){  
+                  if (typeof content[field] === 'string'){
                       text = module.remove.diacritics(content[field]);
                   } else {
-                      text = content[field].toString(); 
+                      text = content[field].toString();
                   }
                   if( text.search(matchRegExp) !== -1) {
                     // content starts with value (first in results)


### PR DESCRIPTION
## Description
Allow using escape to dismiss calendars, dropdown, checkbox or search popups.
Previously, the escape key events (keydown, keyup) bubbled through the whole component tree.
This closed the modal when the escape key was used to dismiss a popup.

Fixing the issue requires all components to use the same event (keydown or keyup).
Standardize on keydown. This way propagation can be stopped prior to the modal closing.

This approach allows different components to "eat" the keystroke, while leaving the event
bubble up when required.

https://www.mutuallyhuman.com/blog/keydown-is-the-only-keyboard-event-we-need/


## Testcase
https://jsfiddle.net/lubber/hvbq6ke0/1/


## Closes
- #2428 