### PR TITLE
fix(modal): support context properly

### DIFF
--- a/src/definitions/modules/dimmer.less
+++ b/src/definitions/modules/dimmer.less
@@ -28,8 +28,8 @@
 .ui.dimmer {
   display: none;
   position: @dimmerPosition;
-  top: 0 !important;
-  left: 0 !important;
+  top: 0;
+  left: 0;
 
   width: 100%;
   height: 100%;
@@ -303,11 +303,11 @@ body.dimmable > .dimmer {
     height: auto;
   }
   .ui[class*="bottom dimmer"] {
-    top: auto !important;
+    top: auto;
     bottom: 0;
   }
   .ui[class*="center dimmer"] {
-    top:50% !important;
+    top:50%;
     transform: translateY(-50%);
     -webkit-transform: translateY(calc(-50% - .5px));
   }

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -65,7 +65,8 @@ $.fn.modal = function(parameters) {
         moduleNamespace = 'module-' + namespace,
 
         $module         = $(this),
-        $context        = [window,document].indexOf(settings.context) < 0 ? $(document).find(settings.context) : $(settings.context),
+        $context        = [window,document].indexOf(settings.context) < 0 ? $document.find(settings.context) : $body,
+        isBody          = $context[0] === $body[0],
         $closeIcon      = $module.find(selector.closeIcon),
         $inputs,
 
@@ -84,6 +85,8 @@ $.fn.modal = function(parameters) {
         initialMouseDownInScrollbar,
         initialBodyMargin = '',
         tempBodyMargin = '',
+        keepScrollingClass = false,
+        hadScrollbar = false,
 
         elementEventNamespace,
         id,
@@ -201,6 +204,7 @@ $.fn.modal = function(parameters) {
             }
             module.debug('Creating dimmer');
             $dimmable = $context.dimmer(dimmerSettings);
+            keepScrollingClass = module.is.scrolling();
             if(settings.detachable) {
               module.verbose('Modal is detachable, moving content into dimmer');
               $dimmable.dimmer('add content', $module);
@@ -326,13 +330,13 @@ $.fn.modal = function(parameters) {
           },
           scrollLock: function() {
             // touch events default to passive, due to changes in chrome to optimize mobile perf
-            $dimmable.get(0).addEventListener('touchmove', module.event.preventScroll, { passive: false });
+            $dimmable[0].addEventListener('touchmove', module.event.preventScroll, { passive: false });
           }
         },
 
         unbind: {
           scrollLock: function() {
-            $dimmable.get(0).removeEventListener('touchmove', module.event.preventScroll, { passive: false });
+            $dimmable[0].removeEventListener('touchmove', module.event.preventScroll, { passive: false });
           }
         },
 
@@ -414,7 +418,7 @@ $.fn.modal = function(parameters) {
             if(initialMouseDownInModal) {
               module.verbose('Mouse down event registered inside the modal');
             }
-            initialMouseDownInScrollbar = module.is.scrolling() && ((!isRtl && $(window).outerWidth() - settings.scrollbarWidth <= event.clientX) || (isRtl && settings.scrollbarWidth >= event.clientX));
+            initialMouseDownInScrollbar = module.is.scrolling() && ((!isRtl && $window.outerWidth() - settings.scrollbarWidth <= event.clientX) || (isRtl && settings.scrollbarWidth >= event.clientX));
             if(initialMouseDownInScrollbar) {
               module.verbose('Mouse down event registered inside the scrollbar');
             }
@@ -518,9 +522,12 @@ $.fn.modal = function(parameters) {
               module.verbose('Show callback returned false cancelling show');
               return;
             }
+            hadScrollbar = module.has.scrollbar();
             module.showDimmer();
             module.cacheSizes();
-            module.set.bodyMargin();
+            if(hadScrollbar) {
+              module.set.bodyMargin();
+            }
             if(module.can.useFlex()) {
               module.remove.legacy();
             }
@@ -645,7 +652,12 @@ $.fn.modal = function(parameters) {
 
         showDimmer: function() {
           if($dimmable.dimmer('is animating') || !$dimmable.dimmer('is active') ) {
-            module.save.bodyMargin();
+            if(hadScrollbar) {
+              if(!isBody) {
+                $dimmer.css('top', $dimmable.scrollTop());
+              }
+              module.save.bodyMargin();
+            }
             module.debug('Showing dimmer');
             $dimmable.dimmer('show');
           }
@@ -658,7 +670,9 @@ $.fn.modal = function(parameters) {
           if( $dimmable.dimmer('is animating') || ($dimmable.dimmer('is active')) ) {
             module.unbind.scrollLock();
             $dimmable.dimmer('hide', function() {
-              module.restore.bodyMargin();
+              if(hadScrollbar) {
+                module.restore.bodyMargin();
+              }
               module.remove.clickaway();
               module.remove.screenHeight();
             });
@@ -739,9 +753,9 @@ $.fn.modal = function(parameters) {
             }
           },
           bodyMargin: function() {
-            initialBodyMargin = $body.css('margin-'+(module.can.leftBodyScrollbar() ? 'left':'right'));
+            initialBodyMargin = $context.css((isBody ? 'margin-':'padding-')+(module.can.leftBodyScrollbar() ? 'left':'right'));
             var bodyMarginRightPixel = parseInt(initialBodyMargin.replace(/[^\d.]/g, '')),
-                bodyScrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
+                bodyScrollbarWidth = isBody ? window.innerWidth - document.documentElement.clientWidth : $context[0].offsetWidth - $context[0].clientWidth;
             tempBodyMargin = bodyMarginRightPixel + bodyScrollbarWidth;
           }
         },
@@ -754,8 +768,8 @@ $.fn.modal = function(parameters) {
           },
           bodyMargin: function() {
             var position = module.can.leftBodyScrollbar() ? 'left':'right';
-            $body.css('margin-'+position, initialBodyMargin);
-            $body.find(selector.bodyFixed.replace('right',position)).each(function(){
+            $context.css((isBody ? 'margin-':'padding-')+position, initialBodyMargin);
+            $context.find(selector.bodyFixed.replace('right',position)).each(function(){
               var el = $(this),
                   attribute = el.css('position') === 'fixed' ? 'padding-'+position : position
               ;
@@ -789,16 +803,17 @@ $.fn.modal = function(parameters) {
             $dimmable.removeClass(className.blurring);
           },
           bodyStyle: function() {
-            if($body.attr('style') === '') {
+            if($context.attr('style') === '') {
               module.verbose('Removing style attribute');
-              $body.removeAttr('style');
+              $context.removeAttr('style');
             }
           },
           screenHeight: function() {
             module.debug('Removing page height');
-            $body
+            $context
               .css('height', '')
             ;
+            module.remove.bodyStyle()
           },
           keyboardShortcuts: function() {
             module.verbose('Removing keyboard shortcuts');
@@ -807,7 +822,9 @@ $.fn.modal = function(parameters) {
             ;
           },
           scrolling: function() {
-            $dimmable.removeClass(className.scrolling);
+            if(!keepScrollingClass) {
+              $dimmable.removeClass(className.scrolling);
+            }
             $module.removeClass(className.scrolling);
           }
         },
@@ -821,12 +838,12 @@ $.fn.modal = function(parameters) {
           ;
           if(module.cache.pageHeight === undefined || modalHeight !== 0) {
             $.extend(module.cache, {
-              pageHeight    : $(document).outerHeight(),
+              pageHeight    : $document.outerHeight(),
               width         : modalWidth,
               height        : modalHeight + settings.offset,
               scrollHeight  : scrollHeight + settings.offset,
-              contextHeight : (settings.context == 'body')
-                ? $(window).height()
+              contextHeight : isBody
+                ? $window.height()
                 : $dimmable.height(),
             });
             module.cache.topOffset = -(module.cache.height / 2);
@@ -900,6 +917,9 @@ $.fn.modal = function(parameters) {
         has: {
           configActions: function () {
             return Array.isArray(settings.actions) && settings.actions.length > 0;
+          },
+          scrollbar: function() {
+            return isBody || $context.css('overflow-y') !== 'visible';
           }
         },
         is: {
@@ -973,9 +993,9 @@ $.fn.modal = function(parameters) {
           bodyMargin: function() {
             var position = module.can.leftBodyScrollbar() ? 'left':'right';
             if(settings.detachable || module.can.fit()) {
-              $body.css('margin-'+position, tempBodyMargin + 'px');
+              $context.css((isBody ? 'margin-':'padding-')+position, tempBodyMargin + 'px');
             }
-            $body.find(selector.bodyFixed.replace('right',position)).each(function(){
+            $context.find(selector.bodyFixed.replace('right',position)).each(function(){
               var el = $(this),
                   attribute = el.css('position') === 'fixed' ? 'padding-'+position : position
               ;
@@ -1041,10 +1061,10 @@ $.fn.modal = function(parameters) {
               $module
                 .css({
                   top: (!$module.hasClass('aligned') && canFit)
-                    ? $(document).scrollTop() + (module.cache.contextHeight - module.cache.height) / 2
+                    ? $document.scrollTop() + (module.cache.contextHeight - module.cache.height) / 2
                     : !canFit || $module.hasClass('top')
-                      ? $(document).scrollTop() + settings.padding
-                      : $(document).scrollTop() + (module.cache.contextHeight - module.cache.height - settings.padding),
+                      ? $document.scrollTop() + settings.padding
+                      : $document.scrollTop() + (module.cache.contextHeight - module.cache.height - settings.padding),
                   marginLeft: -(module.cache.width / 2)
                 })
               ;
@@ -1062,11 +1082,11 @@ $.fn.modal = function(parameters) {
           },
           screenHeight: function() {
             if( module.can.fit() ) {
-              $body.css('height', '');
+              $context.css('height', '');
             }
             else if(!$module.hasClass('bottom')) {
               module.debug('Modal is taller than page content, resizing page height');
-              $body
+              $context
                 .css('height', module.cache.height + (settings.padding * 2) )
               ;
             }

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -951,7 +951,7 @@ $.fn.modal = function(parameters) {
           },
           rtl: function() {
             if(module.cache.isRTL === undefined) {
-              module.cache.isRTL = $body.attr('dir') === 'rtl' || $body.css('direction') === 'rtl';
+              module.cache.isRTL = $module.attr('dir') === 'rtl' || $module.css('direction') === 'rtl' || $body.attr('dir') === 'rtl' || $body.css('direction') === 'rtl' || $context.attr('dir') === 'rtl' || $context.css('direction') === 'rtl';
             }
             return module.cache.isRTL;
           },

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -919,7 +919,7 @@ $.fn.modal = function(parameters) {
             return Array.isArray(settings.actions) && settings.actions.length > 0;
           },
           scrollbar: function() {
-            return isBody || $context.css('overflow-y') !== 'visible';
+            return isBody || $context.css('overflow-y') !== 'hidden';
           }
         },
         is: {

--- a/src/definitions/modules/modal.less
+++ b/src/definitions/modules/modal.less
@@ -447,6 +447,10 @@
     justify-content: flex-start;
     position: fixed;
   }
+  .scrolling.dimmable:not(body) > .dimmer {
+    justify-content: center;
+    position: absolute;
+  }
   .scrolling.dimmable.dimmed > .dimmer {
     overflow: auto;
     -webkit-overflow-scrolling: touch;


### PR DESCRIPTION
## Description
A possible use of modal inside a different context container than body was not properly implemented. 
- Fetch/Hide/Restore of scrollbar did not work
- Positioning of the modal inside a scrolling container also broke
- Accidently usage of window or document as context setting broke the code

What i also fixed
- many preset/cached variables were not reused, which slightly costs performance
- used the slightly quicker array Access instead of jquerys .get() method
- Removed unnecessary !important settings (those were infact needed in case the context container has scrolled when the modal is opened (when testing this, you should have to change `.ui.dimmer {top:0!important}` to `.ui.dimmer {top:0}` in the jsfiddle via console) 

## Testcase
Click the button to open a modal. It is supposed to be displayed and dimmed inside the separate attached segment

### Broken
https://jsfiddle.net/lubber/asgn0opm/3/

### Fixed
https://jsfiddle.net/lubber/asgn0opm/4/

