### PR TITLE
fix(search): blur on escape and proper type usage

### DIFF
--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -293,8 +293,12 @@ $.fn.search = function(parameters) {
           ;
           // search shortcuts
           if(keyCode == keys.escape) {
-            module.verbose('Escape key pressed, blurring search field');
-            module.hideResults();
+            if(!module.is.visible()) {
+              module.verbose('Escape key pressed, blurring search field');
+              $prompt.blur();
+            } else {
+              module.hideResults();
+            }
             event.stopPropagation();
             resultsDismissed = true;
           }
@@ -531,8 +535,8 @@ $.fn.search = function(parameters) {
           },
           type: function(type) {
             type = type || settings.type;
-            if(settings.type == 'category') {
-              $module.addClass(settings.type);
+            if(className[type]) {
+              $module.addClass(className[type]);
             }
           },
           buttonPressed: function() {
@@ -1351,6 +1355,7 @@ $.fn.search.settings = {
   className: {
     animating : 'animating',
     active    : 'active',
+    category  : 'category',
     empty     : 'empty',
     focus     : 'focus',
     hidden    : 'hidden',


### PR DESCRIPTION
## Description
Hitting the escape key is supposed to blur the search field, but this never happens. It only hides a possible given result set.
This PR now implements it the way it is meant to be and blurs the field when there is NO resultset being displayed (otherwise it still hides it as before)
I also fixed the `set.type` function properly. A possible given "type" parameter made no sense, was not used and it only worked with the default category. So now somebody really can create custom templates and a given classname is added to the search component , not only category. 

## Testcase
- Click into the search field
- Hit Escape

or

- Click into the search field
- type "f" so something is displayed in the resultset
- Hit escape (it should hide the resultset)
- Hit escape again

## Broken
Nothing happens
https://jsfiddle.net/lubber/naxphsft/2/

## Fixed
Field is blurred
https://jsfiddle.net/lubber/naxphsft/3/