### PR TITLE
fix(sidebar): scrolllock and returnscroll

### DIFF
--- a/src/definitions/modules/sidebar.less
+++ b/src/definitions/modules/sidebar.less
@@ -95,10 +95,14 @@
      Pushable
 ---------------*/
 
-.pushable {
+.pushable.pushable.pushable {
   height: 100%;
   overflow-x: hidden;
-  padding: 0 !important;
+  padding: 0;
+  &.locked {
+    overflow-y: hidden;
+    background: inherit;
+  }
 }
 
 /* Whole Page */


### PR DESCRIPTION
## Description
The `scrollLock` and `returnScroll` setting was not working which this PR fixes
It also adopts the same scrollbar vanish code from modal to avoid moving page content when the scrollbar vanishes

>  When this is merged, remember to also adjust the new flyout component, as this uses the same selectors for .pushable and needs to be equal

## Testcase
### Broken
#### ScrollLock
- open sidebar
- dimmed pusher area is still scrollable as scrollbar remains visible
https://jsfiddle.net/lubber/dpu8gy65/1/

#### returnScroll
- open sidebar
- scroll pusher content
- close sidebar
- scroll position does not change
https://jsfiddle.net/lubber/dpu8gy65/18/

### Fixed
#### ScrollLock
- dimmed pusher area is not scrollable anymore and scrollbar is hidden just as in modal
https://jsfiddle.net/lubber/dpu8gy65/23/

#### returnScroll
- scrollbar returns to the position where it was when the sidebar was opened
https://jsfiddle.net/lubber/dpu8gy65/19/

## Closes
#2406 