### PR TITLE
fix(popup): detailed rtl check

### DIFF
--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -1135,7 +1135,7 @@ $.fn.popup = function(parameters) {
             return !module.is.visible();
           },
           rtl: function () {
-            return $module.attr('dir') === 'rtl' || $module.css('direction') === 'rtl';
+            return $module.attr('dir') === 'rtl' || $module.css('direction') === 'rtl' || $body.attr('dir') === 'rtl' || $body.css('direction') === 'rtl' || $context.attr('dir') === 'rtl' || $context.css('direction') === 'rtl';
           }
         },
 


### PR DESCRIPTION
## Description
I added  more detailed check for rtl. Currently only the module is checked. However, if body or the surrounding context would be defined as rtl then the module itself is also displayed as rtl, so this PR enhances the check (i already did the same inside the [sidebar PR](#2436 ) and [modal PR](#2433 ))