### PR TITLE
feat(toast,modal): support short notation $.

### DIFF
--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -23,7 +23,7 @@ window = (typeof window != 'undefined' && window.Math == Math)
     : Function('return this')()
 ;
 
-$.fn.modal = function(parameters) {
+$.modal = $.fn.modal = function(parameters) {
   var
     $allModules    = $(this),
     $window        = $(window),
@@ -75,8 +75,10 @@ $.fn.modal = function(parameters) {
         $dimmable,
         $dimmer,
 
+        isModalComponent = $module.hasClass('modal'),
+
         element         = this,
-        instance        = $module.hasClass('modal') ? $module.data(moduleNamespace) : undefined,
+        instance        = isModalComponent ? $module.data(moduleNamespace) : undefined,
 
         ignoreRepeatedEvents = false,
 
@@ -94,7 +96,7 @@ $.fn.modal = function(parameters) {
 
         initialize: function() {
           module.create.id();
-          if(!$module.hasClass('modal')) {
+          if(!isModalComponent) {
             module.create.modal();
             if(!$.isFunction(settings.onHidden)) {
               settings.onHidden = function () {

--- a/src/definitions/modules/toast.js
+++ b/src/definitions/modules/toast.js
@@ -23,7 +23,7 @@ window = (typeof window != 'undefined' && window.Math == Math)
     : Function('return this')()
 ;
 
-$.fn.toast = function(parameters) {
+$.toast = $.fn.toast = function(parameters) {
   var
     $allModules    = $(this),
     moduleSelector = $allModules.selector || '',


### PR DESCRIPTION
## Description

This PR adds jquery short notation support (`$.`) to toast and modal which are made dynamically out of js properties and thus are not bound to an existing dom node.

Previously you always had to select body (which still works) when no existing domnode template exists. Infact the body selector was completely ignored.

### Before notation (still supported)
```javascript
  $('body').toast({
    message: 'hello'
  });

  $('body').modal({
    autoShow: true,
    title: 'hello'
  });
```

### After notation
```javascript
  $.toast({
    message: 'hello'
  });

  $.modal({
    autoShow: true,
    title: 'hello'
  });
```

## Testcase
https://jsfiddle.net/lubber/7s9ouapq/2/