### PR TITLE
fix(search): missing default easing results in js error

### DIFF
--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -1588,4 +1588,10 @@ $.fn.search.settings = {
   }
 };
 
+$.extend($.easing, {
+  easeOutExpo: function(x) {
+    return x === 1 ? 1 : 1 - Math.pow(2, -10 * x);
+  }
+});
+
 })( jQuery, window, document );


### PR DESCRIPTION
## Description

The default easing of the search module was missing, thus resulting in a jquery/js console error when `transition` is set to false or the transition module is not loaded (only then the easing setting is used at all)

## Testcase
## Broken
console throws lots of errors when typing into the search field
https://jsfiddle.net/lubber/ge715toh/8/

## Fixed
https://jsfiddle.net/lubber/ge715toh/7/