### PR TITLE
fix(modal): Hiding dimmer with multiple modals

### DIFF
--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -614,6 +614,9 @@ $.fn.modal = function(parameters) {
                     if( settings.keyboardShortcuts && !module.others.active() ) {
                       module.remove.keyboardShortcuts();
                     }
+                    if(!module.others.active() && !module.others.animating() && !keepDimmed) {
+                      module.hideDimmer();
+                    }
                   },
                   onComplete : function() {
                     module.unbind.scrollLock();
@@ -627,9 +630,9 @@ $.fn.modal = function(parameters) {
                       else {
                         $previousModal.find(selector.dimmer).removeClass('active');
                       }
-                    }
-                    if(!module.others.active() && !module.others.animating() && !keepDimmed) {
-                      module.hideDimmer();
+                      if(!module.others.active() && !module.others.animating() && !keepDimmed) {
+                        module.hideDimmer();
+                      }
                     }
                     if($.isFunction(settings.onHidden)) {
                       settings.onHidden.call(element);

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -611,9 +611,6 @@ $.fn.modal = function(parameters) {
                   duration    : settings.transition.hideDuration || settings.duration,
                   useFailSafe : true,
                   onStart     : function() {
-                    if(!module.others.active() && !module.others.animating() && !keepDimmed) {
-                      module.hideDimmer();
-                    }
                     if( settings.keyboardShortcuts && !module.others.active() ) {
                       module.remove.keyboardShortcuts();
                     }
@@ -630,6 +627,9 @@ $.fn.modal = function(parameters) {
                       else {
                         $previousModal.find(selector.dimmer).removeClass('active');
                       }
+                    }
+                    if(!module.others.active() && !module.others.animating() && !keepDimmed) {
+                      module.hideDimmer();
                     }
                     if($.isFunction(settings.onHidden)) {
                       settings.onHidden.call(element);


### PR DESCRIPTION
## Description
This PR moves the check for other active/animating modals to hide the dimmer to the hide animation complete instead of the hide animation start.

## Testcase
[https://jsfiddle.net/xmd9eht6/](https://jsfiddle.net/xmd9eht6/)

## Screenshot
Original
![Original](https://user-images.githubusercontent.com/9520224/187529679-265b5ce9-ea9a-42c5-96db-383b0c9c5e2a.gif)

After change
![Fix](https://user-images.githubusercontent.com/9520224/187529706-7be0a5dd-95c3-4072-9381-840407b226d6.gif)

## Closes
#2441
