### PR TITLE
fix(toast): enable smooth transition

### DIFF
--- a/src/definitions/modules/toast.less
+++ b/src/definitions/modules/toast.less
@@ -127,6 +127,7 @@
     margin-bottom: @toastBoxMarginBottom;
     border-radius: @defaultBorderRadius;
     cursor: default;
+    will-change: transform, opacity;
     &:hover {
       opacity: @toastOpacityOnHover;
     }


### PR DESCRIPTION
## Description
Toast transitions were not smooth  on start and end of animation because the browser switches from 3d to 2d transform which makes the toast noticably change by some pixels.
by applying a `will-change` hint this is not happening anymore

## Testcase
Remove CSS to see the issue
Watch the toast edges and font. A bit hard to recognize by the gifs. Try the testcase and check yourself ;)
https://jsfiddle.net/lubber/tu9rqm5p/5/

## Screenshots 


### Before
![toasttransition_bad](https://user-images.githubusercontent.com/18379884/189494364-c61be523-1d6b-44c6-937b-3deaf2684d4c.gif)

### After
![toasttransition_good](https://user-images.githubusercontent.com/18379884/189494369-be12e507-4fec-4031-9f8a-2a0da92c5ed8.gif)

