### PR TITLE
fix(sidebar): dont resize on ios touchmove

### DIFF
--- a/src/definitions/modules/sidebar.js
+++ b/src/definitions/modules/sidebar.js
@@ -95,7 +95,9 @@ $.fn.sidebar = function(parameters) {
           module.debug('Initializing sidebar', parameters);
 
           module.create.id();
-
+          if(module.is.ios()) {
+            module.set.ios();
+          }
           transitionEvent = module.get.transitionEvent();
 
           // avoids locking rendering if initialized in onReady

--- a/src/definitions/modules/sidebar.less
+++ b/src/definitions/modules/sidebar.less
@@ -270,6 +270,9 @@ body.pushable > .pusher {
        iOS
 ---------------*/
 
+html.ios .ui.sidebar {
+  touch-action: @iOStouchAction;
+}
 
 /*******************************
           Variations

--- a/src/themes/default/modules/sidebar.variables
+++ b/src/themes/default/modules/sidebar.variables
@@ -30,6 +30,8 @@
 @topLayer: 102;
 @dimmerLayer: 1000;
 
+@iOStouchAction: pan-y;
+
 /*-------------------
       Variations
 --------------------*/


### PR DESCRIPTION
## Description
Safari on iOS 13.1+ seem to drag html containers on touchmove by default. At least this is happening for the sidebar.

I am not quite sure if this could break existing projects as the `pan-y` default limits the sidebars content to only that gesture. Thinking of only default menu items, this might be ok, but other content might need other gestures(?). 
The `set.ios()` function was already present but not used, just in case you wonder. 

## Testcase
- Run this on Safari 13+ on iOS only
- Open the sidebar
- Inside the open sidebar, drag to the left

### Broken
The sidebar gets shrinked
https://fomantic-ui.com/jsfiddle/#!lubber/7d2hxouf/44/

### Fixed
Nothing happens as expected. Sidebar keeps it's width
https://fomantic-ui.com/jsfiddle/#!lubber/7d2hxouf/43/

## Closes
#2449 