### PR TITLE
feat(flyout): support short notation $.

### DIFF
--- a/src/definitions/modules/flyout.js
+++ b/src/definitions/modules/flyout.js
@@ -23,7 +23,7 @@ window = (typeof window != 'undefined' && window.Math == Math)
     : Function('return this')()
 ;
 
-$.fn.flyout = function(parameters) {
+$.flyout = $.fn.flyout = function(parameters) {
   var
     $allModules     = $(this),
     $window         = $(window),
@@ -75,8 +75,10 @@ $.fn.flyout = function(parameters) {
         $pusher              = $context.children(selector.pusher),
         $style,
 
+        isFlyoutComponent    = $module.hasClass(namespace),
+
         element              = this,
-        instance             = $module.hasClass(namespace) ? $module.data(moduleNamespace) : undefined,
+        instance             = isFlyoutComponent ? $module.data(moduleNamespace) : undefined,
 
         ignoreRepeatedEvents = false,
         isBody               = $context[0] === $body[0],
@@ -97,7 +99,7 @@ $.fn.flyout = function(parameters) {
         initialize: function() {
           module.debug('Initializing flyout', parameters);
 
-          if(!$module.hasClass(namespace)) {
+          if(!isFlyoutComponent) {
             module.create.flyout();
             if(!$.isFunction(settings.onHidden)) {
               settings.onHidden = function () {
@@ -422,13 +424,6 @@ $.fn.flyout = function(parameters) {
           $flyouts = $context.children(selector.flyout);
         },
 
-        repaint: function() {
-          module.verbose('Forcing repaint event');
-          element.style.display = 'none';
-          element.scrollTop = element.scrollTop;
-          element.style.display = '';
-        },
-
         setup: {
           cache: function() {
             module.cache = {
@@ -591,7 +586,6 @@ $.fn.flyout = function(parameters) {
             : function(){}
           ;
           module.set.overlay();
-          module.repaint();
           if(settings.returnScroll) {
             currentScroll = (isBody ? $window : $context).scrollTop();
           }

--- a/src/definitions/modules/flyout.js
+++ b/src/definitions/modules/flyout.js
@@ -107,6 +107,9 @@ $.flyout = $.fn.flyout = function(parameters) {
                 $module.remove();
               };
             }
+            if(!settings.autoShow) {
+              settings.autoShow = true;
+            }
           }
           $module.addClass(settings.class);
           if (settings.title !== '') {

--- a/src/definitions/modules/flyout.js
+++ b/src/definitions/modules/flyout.js
@@ -75,7 +75,7 @@ $.flyout = $.fn.flyout = function(parameters) {
         $pusher              = $context.children(selector.pusher),
         $style,
 
-        isFlyoutComponent    = $module.hasClass(namespace),
+        isFlyoutComponent    = $module.hasClass('flyout'),
 
         element              = this,
         instance             = isFlyoutComponent ? $module.data(moduleNamespace) : undefined,


### PR DESCRIPTION
## Description

This PR is an adaptation from @lubber-de's #2442.

It adds jquery short notation support (`$.`) to flyout which is made dynamically out of js properties and thus are not bound to an existing dom node.

Previously you always had to select body (which still works) when no existing domnode template exists. Infact the body selector was completely ignored.

### Before notation (still supported)
```javascript
  $('body').flyout({
    title: 'Important Notice',
    content: 'You will be logged out in 5 Minutes',
    actions: [{
      text: 'Alright, got it',
      class: 'green',
      icon: 'save'
    }]
  });
```

### After notation
```javascript
  $.flyout({
    title: 'Important Notice',
    content: 'You will be logged out in 5 Minutes',
    actions: [{
      text: 'Alright, got it',
      class: 'green',
      icon: 'save'
    }]
  });
```
