### PR TITLE
fix(dropdown): generated id should not start with a number

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -374,7 +374,7 @@ $.fn.dropdown = function(parameters) {
               ;
               if (labelNode.length) {
                 if (!labelNode.attr('id')) {
-                  labelNode.attr('id', module.get.id() + '_formLabel');
+                  labelNode.attr('id', '_' + module.get.id() + '_formLabel');
                 }
                 $search.attr('aria-labelledby', labelNode.attr('id'));
               }


### PR DESCRIPTION
introduced in https://github.com/fomantic/Fomantic-UI/pull/2409

this change was failing our strict tests as we require ID to not start with a number

no BC break as no stable release shipped yet

ping @Inselhopper, you are the original author, can the ID be anything or is some special format required?