### PR TITLE
fix(dropdown): hide menu on menu search blur

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1156,7 +1156,7 @@ $.fn.dropdown = function(parameters) {
             },
             blur: function(event) {
               pageLostFocus = (document.activeElement === this);
-              if(module.is.searchSelection() && !willRefocus) {
+              if(module.is.searchSelection(true) && !willRefocus) {
                 if(!itemActivated && !pageLostFocus) {
                   if(settings.forceSelection) {
                     module.forceSelection();
@@ -3479,8 +3479,8 @@ $.fn.dropdown = function(parameters) {
           search: function() {
             return $module.hasClass(className.search);
           },
-          searchSelection: function() {
-            return ( module.has.search() && $search.parent(selector.dropdown).length === 1 );
+          searchSelection: function(deep) {
+            return ( module.has.search() && (deep ? $search.parents(selector.dropdown) : $search.parent(selector.dropdown)).length === 1 );
           },
           selection: function() {
             return $module.hasClass(className.selection);

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1111,7 +1111,7 @@ $.fn.dropdown = function(parameters) {
             }
           },
           mousedown: function() {
-            if(module.is.searchSelection()) {
+            if(module.is.searchSelection(true)) {
               // prevent menu hiding on immediate re-focus
               willRefocus = true;
             }
@@ -1121,7 +1121,7 @@ $.fn.dropdown = function(parameters) {
             }
           },
           mouseup: function() {
-            if(module.is.searchSelection()) {
+            if(module.is.searchSelection(true)) {
               // prevent menu hiding on immediate re-focus
               willRefocus = false;
             }


### PR DESCRIPTION
## Description
Whenever a dropdown has a search input inside the menu itself (for example a button dropdown), blurring this search field did not close the dropdown. 
Some docs examples (mainly the one on the homepage) has to be slightly adjusted for a proper fix as those did not have the `search` class or a `search input` wrapper being added. Will do that in a separate docs PR 

## Testcase
- open the dropdown by clicking on the button
- click into the searchfield (should be focussed already, so most probably not needed)
- press tab

### Broken
The next item in the dom gets highlighted, but the dropdown stays open
https://jsfiddle.net/lubber/xom7fy4z/2/

### Fixed
The dropdown gets closed
https://jsfiddle.net/lubber/xom7fy4z/6/

## Closes
#2101 