### PR TITLE
feat(menu): support descriptions in vertical menu

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -97,6 +97,11 @@
   border-radius: @borderRadius 0 0 @borderRadius;
 }
 
+.ui.menu > .item.vertical {
+  display: flex;
+  flex-direction: column-reverse;
+}
+
 /* Border */
 .ui.menu .item::before {
   position: absolute;
@@ -125,6 +130,26 @@
 .ui.menu .item > p:last-child {
   margin-bottom: 0;
 }
+
+.ui.menu > .item.vertical > .text {
+  margin-bottom: @verticalItemMargin;
+}
+
+/*-----------------
+  Item Description
+-------------------*/
+
+.ui.menu > .item > .description {
+  float: @itemDescriptionFloat;
+  margin: @itemDescriptionMargin;
+  color: @itemDescriptionColor;
+}
+
+.ui.menu > .item.vertical > .description {
+  margin: 0;
+}
+
+
 
 /*--------------
       Icons
@@ -281,6 +306,10 @@
   .ui.inverted.menu .search.dropdown.item > .search,
   .ui.inverted.menu .search.dropdown.item > .text {
     color: @invertedSelectionDropdownColor;
+  }
+
+  .ui.inverted.menu > .item > .description {
+    color: @invertedItemDescriptionColor;
   }
 }
 
@@ -545,7 +574,7 @@ Floated Menu / Item
   }
 
   /*--- Item ---*/
-  .ui.vertical.menu .item {
+  .ui.vertical.menu .item:not(.vertical) {
     display: block;
     background: @verticalItemBackground;
     border-top: none;

--- a/src/themes/default/collections/menu.variables
+++ b/src/themes/default/collections/menu.variables
@@ -53,6 +53,14 @@
     Elements
 ---------------*/
 
+/* Description */
+@itemDescriptionFloat: right;
+@itemDescriptionMargin: 0 0 0 1em;
+@itemDescriptionColor: @lightTextColor;
+
+/* Vertical Item */
+@verticalItemMargin: 0.25em;
+
 /* Icon */
 @iconFloat: none;
 @iconMargin: 0 @relative5px 0 0;
@@ -426,6 +434,9 @@
 /* Inverted Colored */
 @invertedColoredDividerBackground: @dividerBackground;
 @invertedColoredActiveBackground: @strongTransparentBlack;
+
+/* Inverted Vertical Description */
+@invertedItemDescriptionColor: @invertedUnselectedTextColor;
 
 /* Fixed */
 @fixedPrecedingGridMargin: 2.75rem;


### PR DESCRIPTION
## Description
This PR implements a description in the menu items, which can be right floated or under a text.

Under description can also be displayed in not vertical menu, but right floated no as it looks bloated right now (see screenshots).

## Screenshot
![image](https://user-images.githubusercontent.com/7557689/195113092-a849b37e-9510-492e-af41-ca59964f26fb.png)

Inverted works too:
![image](https://user-images.githubusercontent.com/7557689/195113458-76697cae-1497-45cd-a3bb-0b81d6a93669.png)

Description under text works as intended, but not the right floated one. Help is welcome 😃 
![image](https://user-images.githubusercontent.com/7557689/195113676-d4930cb2-eaee-4883-9d00-2008b4d732a3.png)

## Closes
#2232
