### PR TITLE
feat(chore): strip/adjust comment headers via config

### DIFF
--- a/tasks/build/css.js
+++ b/tasks/build/css.js
@@ -109,6 +109,7 @@ function pack(type, compress) {
     .pipe(dedupe())
     .pipe(replace(assets.uncompressed, assets.packaged))
     .pipe(concatCSS(concatenatedCSS, settings.concatCSS))
+    .pipe(gulpif(config.stripHeaders, replace(comments.header.in, comments.header.out)))
     .pipe(gulpif(config.hasPermissions, chmod(config.parsedPermissions)))
     .pipe(gulpif(compress, minifyCSS(settings.concatMinify)))
     .pipe(header(banner, settings.header))

--- a/tasks/build/javascript.js
+++ b/tasks/build/javascript.js
@@ -77,6 +77,7 @@ function pack(type, compress) {
     .pipe(dedupe())
     .pipe(replace(assets.uncompressed, assets.packaged))
     .pipe(concat(concatenatedJS))
+    .pipe(gulpif(config.stripHeaders, replace(comments.header.in, comments.header.out)))
     .pipe(gulpif(compress, uglify(settings.concatUglify)))
     .pipe(header(banner, settings.header))
     .pipe(gulpif(config.hasPermissions, chmod(config.parsedPermissions)))

--- a/tasks/config/defaults.js
+++ b/tasks/config/defaults.js
@@ -115,6 +115,8 @@ module.exports = {
   // whether to load admin tasks
   admin: false,
 
+  header: {},
+
   // globs used for matching file patterns
   globs      : {
     ignored    : '!(*.min|*.map|*.rtl)',

--- a/tasks/config/tasks.js
+++ b/tasks/config/tasks.js
@@ -17,9 +17,14 @@ var overrideBrowserslist = hasBrowserslistConfig ? undefined : [
   'android 4'
 ]
 
+// Node 12 does not support ??, so a little polyfill
+var nullish = (value,fallback) => {
+  return value !== undefined && value !== null ? value : fallback
+}
+
 module.exports = {
 
-  banner : release.banner,
+  banner : config.banner || release.banner,
 
   log: {
     created: function(file) {
@@ -42,6 +47,11 @@ module.exports = {
   regExp: {
 
     comments: {
+      // remove all component headers in concatenated file
+      header: {
+        in: /\/\*!(?:(?!\/\*).)*# Fomantic-UI \d+\.\d+\.(?:(?!\/\*).)*MIT license(?:(?!\/\*).)*\*\/\n?/gs,
+        out: ''
+      },
 
       // remove all comments from config files (.variable)
       variables : {
@@ -87,11 +97,11 @@ module.exports = {
 
     /* Comment Banners */
     header: {
-      year       : (new Date()).getFullYear(),
-      title      : release.title,
-      version    : release.version,
-      repository : release.repository,
-      url        : release.url
+      year       : nullish(config.header.year,(new Date()).getFullYear()),
+      title      : nullish(config.header.title, release.title),
+      version    : nullish(config.header.version, release.version),
+      repository : nullish(config.header.repository, release.repository),
+      url        : nullish(config.header.url, release.url)
     },
 
     plumber: {
@@ -113,7 +123,7 @@ module.exports = {
                 console.error('Missing theme.config value for ', element);
               }
               console.error('Most likely new UI was added in an update. You will need to add missing elements from theme.config.example');
-            } else if (error.line == 73) {
+            } else if (error.line == 84) {
               element = regExp.element.exec(error.message)[1];
               theme   = regExp.theme.exec(error.message)[1];
               console.error(theme + ' is not an available theme for ' + element);

--- a/tasks/config/tasks.js
+++ b/tasks/config/tasks.js
@@ -24,7 +24,7 @@ var nullish = (value,fallback) => {
 
 module.exports = {
 
-  banner : config.banner || release.banner,
+  banner : nullish(config.banner, release.banner),
 
   log: {
     created: function(file) {


### PR DESCRIPTION
## Description
This PR allows to adjust the comment headers via config settings in `semantic.json`

- top comment banner in semantic(.min).(css/js) either by providing a complete custom text in `banner` or adjust some of the variables in the default banner template (year,url,repository,version,title) (of course you could combine them if the custom banner also has lodash templates variables inside via `<%= version %>` 
- strip all top headers from each component inside the concatenated semantic.css/js (this is already the case in the minified version) via `stripHeaders: true` . I intentionally did not set this to true by default as other peoples projects might rely on that.

I also fixed error fetching in case a themes name is not existing

#### Inside semantic.json
```json
"banner": "/* A custom central FUI Banner !!!\n Awesome Release! \n*/",
"stripHeaders": true, 
"header": {
    "year": "ALWAYS 2099 :)",
    "title": "Fomantic-UI Pro",
    "repository": "Not yet available",
    "url": "https://fomantic-ui.com/pro"
}
```
## Testcase
Change your semantic.json accordingly and `yarn build`

## Closes
#2468 

