### PR TITLE
fix(chore): support node12 on add

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@actions/core": "^1.6.0",
-    "@octokit/core": ">=3",
+    "@octokit/core": "^3.6.0",
     "@octokit/rest": "^16.16.0",
     "better-console": "1.0.1",
     "browserslist": "^4.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -31,7 +31,7 @@
   dependencies:
     "@octokit/types" "^6.0.3"
 
-"@octokit/core@>=3":
+"@octokit/core@^3.6.0":
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/@octokit/core/-/core-3.6.0.tgz#3376cb9f3008d9b3d110370d90e0a1fcd5fe6085"
   integrity sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==


### PR DESCRIPTION
## Description

The dependency to octokit was not bound to a major version making `yarn add fomantic-ui` break on node 12

## Closes
#2511 

