### PR TITLE
fix(icon): fix lighthouse warning

### DIFF
--- a/src/themes/default/elements/icon.variables
+++ b/src/themes/default/elements/icon.variables
@@ -49,6 +49,7 @@ Icons are order A-Z in their group, Solid, Outline, Thin (Pro only) and Brand
     if(@supportIE, e(',') url("@{fontPath}/@{fontName}.woff") format('woff'));
     font-style     : normal;
     font-weight    : @normal;
+    font-display   : block;
     font-variant   : normal;
     text-decoration: inherit;
     text-transform : none;
@@ -59,6 +60,7 @@ Icons are order A-Z in their group, Solid, Outline, Thin (Pro only) and Brand
     if(@supportIE, e(',') url("@{fontPath}/@{outlineFontName}.woff") format('woff'));
     font-style     : normal;
     font-weight    : @normal;
+    font-display   : block;
     font-variant   : normal;
     text-decoration: inherit;
     text-transform : none;
@@ -69,6 +71,7 @@ Icons are order A-Z in their group, Solid, Outline, Thin (Pro only) and Brand
     if(@supportIE, e(',') url("@{fontPath}/@{brandFontName}.woff") format('woff'));
     font-style     : normal;
     font-weight    : @normal;
+    font-display   : block;
     font-variant   : normal;
     text-decoration: inherit;
     text-transform : none;


### PR DESCRIPTION
## Description
the icon fonts need font-display to eliminate lighthouse warning in devtools
Fontaweseome did this themselves by https://github.com/FortAwesome/wordpress-fontawesome/pull/110

## Screenshots
![image](https://user-images.githubusercontent.com/18379884/197366129-284ed0fc-5ce2-4470-b220-5afe66c66e62.png)
