### PR TITLE
fix(nag): overlay nags were always shown

### DIFF
--- a/src/definitions/modules/nag.less
+++ b/src/definitions/modules/nag.less
@@ -104,7 +104,6 @@ a.ui.nag {
   .ui.overlay.nags,
   .ui.overlay.nag {
     position: absolute;
-    display: block;
   }
 }
 

--- a/src/themes/default/modules/nag.variables
+++ b/src/themes/default/modules/nag.variables
@@ -11,7 +11,7 @@
 @zIndex: 999;
 @margin: 0;
 
-@background: #777777;
+@background: #909090;
 @opacity: 0.95;
 @minHeight: 0;
 @padding: 0.75em 1em;


### PR DESCRIPTION
## Description

overlay nag were always shown, although a nag should be hidden by default.
While we are at it i slightly adjusted the default background for better readability

## Closes
https://github.com/fomantic/Fomantic-UI-Docs/issues/400