### PR TITLE
fix(build): one single component does not build

### DIFF
--- a/tasks/build/css.js
+++ b/tasks/build/css.js
@@ -134,10 +134,9 @@ function buildCSS(src, type, config, opts, callback) {
   }
 
   if (globs.individuals !== undefined && typeof src === 'string') {
-    const individuals = config.globs.individuals.replace(/\{/g,'');
-    const components = config.globs.components.replace(/\}/g,',').concat(individuals);
+    const components = config.globs.components.replace(/[{}]/g,'') + ',' + config.globs.individuals.replace(/[{}]/g,'');
 
-    src = config.paths.source.definitions + '/**/' + components + '.less';
+    src = config.paths.source.definitions + '/**/{' + components + '}.less';
   }
 
   const buildUncompressed       = () => build(src, type, false, config, opts);

--- a/tasks/build/javascript.js
+++ b/tasks/build/javascript.js
@@ -101,10 +101,9 @@ function buildJS(src, type, config, callback) {
   }
 
   if (globs.individuals !== undefined && typeof src === 'string') {
-    const individuals = config.globs.individuals.replace(/\{/g,'');
-    const components = config.globs.components.replace(/\}/g,',').concat(individuals);
+    const components = config.globs.components.replace(/[{}]/g,'') + ',' + config.globs.individuals.replace(/[{}]/g,'');
 
-    src = config.paths.source.definitions + '/**/' + components + (config.globs.ignored || '') + '.js';
+    src = config.paths.source.definitions + '/**/{' + components + '}' + (config.globs.ignored || '') + '.js';
   }
 
   // copy source javascript

--- a/tasks/config/project/config.js
+++ b/tasks/config/project/config.js
@@ -138,10 +138,10 @@ module.exports = {
     const componentsExceptIndividuals = components.filter((component) => !individuals.includes(component));
 
     // takes component object and creates file glob matching selected components
-    config.globs.components = '{' + componentsExceptIndividuals.join(',') + '}';
+    config.globs.components = componentsExceptIndividuals.length === 1 ? componentsExceptIndividuals[0] : '{' + componentsExceptIndividuals.join(',') + '}';
 
     // components that should be built, but excluded from main .css/.js files
-    config.globs.individuals = (individuals.length >= 1)
+    config.globs.individuals = individuals.length === 1 ? individuals[0] : (individuals.length > 1)
       ? '{' + individuals.join(',') + '}'
       : undefined
     ;


### PR DESCRIPTION
## Description
When trying to only compile one single component, for example doing this in `semantic.json`

```json
"components": ["popup"],
```

the build does not compile anything. That's because the used https://github.com/micromatch/braces lib expects at least 2 entries so `{popup,segment}` would work, but `{popup}` does not. That leads to gulp not finding any file match, thus not compiling anything.
