### PR TITLE
fix(nag): make sure value is string for all storage engines

### DIFF
--- a/src/definitions/modules/nag.js
+++ b/src/definitions/modules/nag.js
@@ -65,6 +65,9 @@ $.fn.nag = function(parameters) {
 
         initialize: function() {
           module.verbose('Initializing element');
+          if(typeof settings.value !== 'string') {
+            settings.value = JSON.stringify(settings.value);
+          }
           storage = module.get.storage();
           $module
             .on('click' + eventNamespace, selector.close, module.dismiss)


### PR DESCRIPTION
## Description
The cookie storage engine does only support string values. This PR adjusts a given `value` and converts it to string in case a boolean/object/array/null/etc. is given, so it's independent to any storage engine