### PR TITLE
feat(popup): multiline tooltip variation

### DIFF
--- a/src/definitions/modules/popup.less
+++ b/src/definitions/modules/popup.less
@@ -475,6 +475,12 @@
       display: none;
     }
   }
+
+  & when (@variationPopupMultiline) {
+    [data-tooltip][data-variation~="multiline"]::after {
+      white-space: @multilineWhiteSpace;
+    }
+  }
 }
 
 /*--------------

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -609,6 +609,7 @@
 @variationPopupFluid: true;
 @variationPopupFlowing: true;
 @variationPopupFixed: true;
+@variationPopupMultiline: true;
 @variationPopupSizes: @variationAllSizes;
 @variationPopupColors: @variationAllColors;
 

--- a/src/themes/default/modules/popup.variables
+++ b/src/themes/default/modules/popup.variables
@@ -116,6 +116,8 @@
        Variations
 --------------------*/
 
+@multilineWhiteSpace: pre-line;
+
 /* Wide */
 @wideWidth: 350px;
 @veryWideWidth: 550px;


### PR DESCRIPTION
## Description
This PR allows multiline tooltips via new `multiline` variation to be set in `data-variation`.
However the `data-tooltip` text has to be cleverly prepared to make this work completely.

- non breaking spaces have to use a non visible character like U+A0 (see https://qwerty.dev/whitespace/)
- newlines to break lines / trigger a tooltip newline

## Testcase
https://jsfiddle.net/lubber/Lk2sp8nq/15/

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/202266761-010f0f0f-33e5-4a6b-99fe-dda00563febe.png)
