### PR TITLE
fix(label): disabled and centered label(s)

### DIFF
--- a/src/definitions/elements/label.less
+++ b/src/definitions/elements/label.less
@@ -551,8 +551,10 @@ a.ui.label {
       Disabled
 --------------------*/
 & when (@variationLabelDisabled) {
+  .ui.disabled.labels .label,
   .ui.label.disabled {
-    opacity: 0.5;
+    opacity: @disabledOpacity;
+    pointer-events: @disabledPointerEvents;
   }
 }
 /*-------------------

--- a/src/definitions/elements/label.less
+++ b/src/definitions/elements/label.less
@@ -689,6 +689,7 @@ a.ui.active.label:hover::before {
 }
 
 & when (@variationLabelCentered) {
+  .ui.centered.labels .label,
   .ui.centered.label {
     text-align: center;
   }

--- a/src/definitions/elements/label.less
+++ b/src/definitions/elements/label.less
@@ -688,6 +688,12 @@ a.ui.active.label:hover::before {
   }
 }
 
+& when (@variationLabelCentered) {
+  .ui.centered.label {
+    text-align: center;
+  }
+}
+
 & when (@variationLabelInverted) {
   /*-------------------
          Inverted

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -152,6 +152,7 @@
 @variationLabelBasic: true;
 @variationLabelAttached: true;
 @variationLabelFluid: true;
+@variationLabelCentered: true;
 @variationLabelSizes: @variationAllSizes;
 @variationLabelColors: @variationAllColors;
 


### PR DESCRIPTION
## Description
- new `centered` variant (useful for `fluid` or `attached` labels) to center text inside label
- disable pointer events on disabled labels and support groups

