### PR TITLE
[dropdown] Fix rounded corners on menu

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -1550,9 +1550,6 @@ select.ui.dropdown {
     box-shadow: @floatingMenuBoxShadow !important;
     border-radius: @floatingMenuBorderRadius !important;
   }
-  .ui.floating.dropdown > .menu {
-    border-radius: @floatingMenuBorderRadius !important;
-  }
   .ui:not(.upward).floating.dropdown > .menu {
     margin-top: @floatingMenuDistance;
   }

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -1549,6 +1549,7 @@ select.ui.dropdown {
     right: auto;
     box-shadow: @floatingMenuBoxShadow !important;
     border-radius: @floatingMenuBorderRadius !important;
+    overflow: hidden;
   }
   .ui:not(.upward).floating.dropdown > .menu {
     margin-top: @floatingMenuDistance;


### PR DESCRIPTION
<!--
 Please read our Contributing Guide and Code of Conduct before you
 submit a pull request.
  
 Contributing Guide: https://github.com/fomantic/Fomantic-UI/blob/master/CONTRIBUTING.md
 Code of Conduct: https://github.com/fomantic/Fomantic-UI/blob/master/CODE_OF_CONDUCT.md

 ----

 Please use the following pull request title format:
 "[<scope>] <summary of what you fixed/changed>"
-->

## Description
<!-- Describe what you fixed/changed in great detail (required). -->
On a filtered dropdown menu the bottom corners are not round. This PR makes all corners of the dropdown menu round.

## Testcase
<!--
  If possible create an example of your change via a JSFiddle. 

  How to create an example:
   1. Open the following JSFiddle - https://jsfiddle.net/31d6y7mn
   2. Click "Fork" at the top
   3. Add the minimum required HTML, CSS and JavaScript which shows your change
   4. Click "Save" at the top
   5. Copy the URL of your fiddle and link it here
-->
When opening the filtered dropdown, the bottom two corners of the menu are not rounded.

https://jsfiddle.net/e0zmt376/

## Screenshot (if possible)
<!--
  If possible include images or gifs of your issue.

  E.g. Incorrect component CSS should include an image of what the
  component looks like.
  
  If your looking for a tool we recommend ShareX - https://github.com/ShareX/ShareX
-->
![image](https://user-images.githubusercontent.com/45571053/202673313-caeb314f-6069-458d-afe5-e53a29bca7af.png)


## Closes
<!--
  List all the issues this pull request closes (only if it does).
-->
