### PR TITLE
fix(dropdown): keep overflow visible for non simple selection

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -1479,7 +1479,7 @@ select.ui.dropdown {
 
   .ui.simple.active.dropdown > .menu,
   .ui.simple.dropdown:hover > .menu {
-    overflow: auto;
+    overflow: visible;
     width: auto;
     height: auto;
     top: 100%;
@@ -1487,12 +1487,20 @@ select.ui.dropdown {
   }
   .ui.simple.dropdown > .menu > .item:active > .menu,
   .ui.simple.dropdown .menu .item:hover > .menu {
-    overflow: auto;
+    overflow: visible;
     width: auto;
     height: auto;
     top: 0 !important;
     left: 100%;
     opacity: 1;
+  }
+  & when (@variationDropdownSelection) {
+    .ui.simple.selection.active.dropdown > .menu,
+    .ui.simple.selection.dropdown:hover > .menu,
+    .ui.simple.selection.dropdown > .menu > .item:active > .menu,
+    .ui.simple.selection.dropdown .menu .item:hover > .menu {
+      overflow: auto;
+    }
   }
   .ui.simple.dropdown > .menu > .item:active > .left.menu,
   .ui.simple.dropdown .menu .item:hover > .left.menu,
@@ -1556,7 +1564,7 @@ select.ui.dropdown {
   .ui:not(.upward).floating.dropdown > .menu {
     margin-top: @floatingMenuDistance;
   }
-  .ui.upward.floating.dropdown > .menu {
+  .ui.upward.floating.dropdown:not(.simple) > .menu {
     margin-bottom: @floatingMenuDistance;
   }
 }


### PR DESCRIPTION
## Description

This partly reverts #2219 and only adds the overflow setting in case of a `simple selection` dropdown where a possible scrollbar is only needed. Since 2.9.0 a simple menu item dropdown unfortunately also applied a scrollbar, which is wrong.

This PR also fixes upward menu positioning in case a `floating simple upward dropdown` is used

## Testcase
https://jsfiddle.net/lubber/cz09kaue/12/

## Closes
#2500 