### PR TITLE
fix(api): support [] inside form names

### DIFF
--- a/src/definitions/behaviors/api.js
+++ b/src/definitions/behaviors/api.js
@@ -468,7 +468,9 @@ $.api = $.fn.api = function(parameters) {
                 } else {
                   pushValues[pushKey] = [pushValues[pushKey] , value];
                 }
-                value = pushValues[pushKey];
+                if(pushKey.indexOf('[]')===-1) {
+                  value = pushValues[pushKey];
+                }
 
                 while ((k = nameKeys.pop()) !== undefined) {
                   // foo[]


### PR DESCRIPTION
## Description
One case was not fetched in the new 2.9.0 api form serializer: When a named key has an array push in between the named key like "foo[][bar]"

## Testcase
https://jsfiddle.net/lubber/pqxr5041/36/

## Closes
#2520 