### PR TITLE
fix(dropdown): reuse select tabindex

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -428,6 +428,9 @@ $.fn.dropdown = function(parameters) {
               if($input.is('[required]')) {
                 settings.forceSelection = true;
               }
+              if(!settings.allowTab) {
+                $input.removeAttr('tabindex');
+              }
               $input
                 .prop('required',false)
                 .removeAttr('class')
@@ -2507,13 +2510,14 @@ $.fn.dropdown = function(parameters) {
               module.debug('Added tabindex to dropdown');
               if( $module.attr('tabindex') === undefined) {
                 $module
-                  .attr('tabindex', 0)
+                  .attr('tabindex', $input.attr('tabindex') || 0)
                 ;
                 $menu
                   .attr('tabindex', -1)
                 ;
               }
             }
+            $input.removeAttr('tabindex');
           },
           initialLoad: function() {
             module.verbose('Setting initial load');


### PR DESCRIPTION
## Description
Reuse existing tabindex from select tag when transforming into dropdown. Even worse, an existing tabindex for a select would have inpact on tabbing even though the original select is hidden when transformed into a dropdown.

@inspector71 This will fix your issue

## Screenshot
### Before
![image](https://user-images.githubusercontent.com/18379884/205133368-faf9b28e-7dd1-47db-a382-2130246f133d.png)

### After
![image](https://user-images.githubusercontent.com/18379884/205133237-2afbface-c6ae-4c68-80ec-df7883af16cc.png)

## Testcase
### Before
https://jsfiddle.net/lubber/qkyou3c1/2/
### After
https://jsfiddle.net/lubber/qkyou3c1/3/

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/7100