### PR TITLE
feat(chore): use modern globalThis

### DIFF
--- a/src/definitions/behaviors/api.js
+++ b/src/definitions/behaviors/api.js
@@ -14,15 +14,14 @@
     function isWindow(obj) {
         return obj != null && obj === obj.window;
     }
+
     function isFunction(obj) {
         return typeof obj === 'function' && typeof obj.nodeType !== 'number';
     }
 
     window = (typeof window != 'undefined' && window.Math == Math)
         ? window
-        : (typeof self != 'undefined' && self.Math == Math)
-            ? self
-            : Function('return this')();
+        : globalThis;
 
     $.api = $.fn.api = function (parameters) {
         var

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -17,9 +17,7 @@
 
     window = (typeof window != 'undefined' && window.Math == Math)
         ? window
-        : (typeof self != 'undefined' && self.Math == Math)
-            ? self
-            : Function('return this')();
+        : globalThis;
 
     $.fn.form = function (parameters) {
         var

--- a/src/definitions/behaviors/state.js
+++ b/src/definitions/behaviors/state.js
@@ -17,9 +17,7 @@
 
     window = (typeof window != 'undefined' && window.Math == Math)
         ? window
-        : (typeof self != 'undefined' && self.Math == Math)
-            ? self
-            : Function('return this')();
+        : globalThis;
 
     $.fn.state = function (parameters) {
         var

--- a/src/definitions/behaviors/visibility.js
+++ b/src/definitions/behaviors/visibility.js
@@ -17,9 +17,7 @@
 
     window = (typeof window != 'undefined' && window.Math == Math)
         ? window
-        : (typeof self != 'undefined' && self.Math == Math)
-            ? self
-            : Function('return this')();
+        : globalThis;
 
     $.fn.visibility = function (parameters) {
         var

--- a/src/definitions/globals/site.js
+++ b/src/definitions/globals/site.js
@@ -9,9 +9,15 @@
  */
 
 (function ($, window, document, undefined) {
+    'use strict';
+
     function isFunction(obj) {
         return typeof obj === 'function' && typeof obj.nodeType !== 'number';
     }
+
+    window = (window !== undefined && window.Math == Math)
+        ? window
+        : globalThis;
 
     $.site = $.fn.site = function (parameters) {
         var

--- a/src/definitions/modules/accordion.js
+++ b/src/definitions/modules/accordion.js
@@ -17,9 +17,7 @@
 
     window = (typeof window != 'undefined' && window.Math == Math)
         ? window
-        : (typeof self != 'undefined' && self.Math == Math)
-            ? self
-            : Function('return this')();
+        : globalThis;
 
     $.fn.accordion = function (parameters) {
         var

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -17,9 +17,7 @@
 
     window = (typeof window != 'undefined' && window.Math == Math)
         ? window
-        : (typeof self != 'undefined' && self.Math == Math)
-            ? self
-            : Function('return this')();
+        : globalThis;
 
     $.fn.calendar = function (parameters) {
         var

--- a/src/definitions/modules/checkbox.js
+++ b/src/definitions/modules/checkbox.js
@@ -17,9 +17,7 @@
 
     window = (typeof window != 'undefined' && window.Math == Math)
         ? window
-        : (typeof self != 'undefined' && self.Math == Math)
-            ? self
-            : Function('return this')();
+        : globalThis;
 
     $.fn.checkbox = function (parameters) {
         var

--- a/src/definitions/modules/dimmer.js
+++ b/src/definitions/modules/dimmer.js
@@ -17,9 +17,7 @@
 
     window = (typeof window != 'undefined' && window.Math == Math)
         ? window
-        : (typeof self != 'undefined' && self.Math == Math)
-            ? self
-            : Function('return this')();
+        : globalThis;
 
     $.fn.dimmer = function (parameters) {
         var

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -17,9 +17,7 @@
 
     window = (typeof window != 'undefined' && window.Math == Math)
         ? window
-        : (typeof self != 'undefined' && self.Math == Math)
-            ? self
-            : Function('return this')();
+        : globalThis;
 
     $.fn.dropdown = function (parameters) {
         var

--- a/src/definitions/modules/embed.js
+++ b/src/definitions/modules/embed.js
@@ -17,9 +17,7 @@
 
     window = (typeof window != 'undefined' && window.Math == Math)
         ? window
-        : (typeof self != 'undefined' && self.Math == Math)
-            ? self
-            : Function('return this')();
+        : globalThis;
 
     $.fn.embed = function (parameters) {
         var

--- a/src/definitions/modules/flyout.js
+++ b/src/definitions/modules/flyout.js
@@ -17,9 +17,7 @@
 
     window = (typeof window != 'undefined' && window.Math == Math)
         ? window
-        : (typeof self != 'undefined' && self.Math == Math)
-            ? self
-            : Function('return this')();
+        : globalThis;
 
     $.flyout = $.fn.flyout = function (parameters) {
         var

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -17,9 +17,7 @@
 
     window = (typeof window != 'undefined' && window.Math == Math)
         ? window
-        : (typeof self != 'undefined' && self.Math == Math)
-            ? self
-            : Function('return this')();
+        : globalThis;
 
     $.modal = $.fn.modal = function (parameters) {
         var

--- a/src/definitions/modules/nag.js
+++ b/src/definitions/modules/nag.js
@@ -17,9 +17,7 @@
 
     window = (typeof window != 'undefined' && window.Math == Math)
         ? window
-        : (typeof self != 'undefined' && self.Math == Math)
-            ? self
-            : Function('return this')();
+        : globalThis;
 
     $.fn.nag = function (parameters) {
         var

--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -17,9 +17,7 @@
 
     window = (typeof window != 'undefined' && window.Math == Math)
         ? window
-        : (typeof self != 'undefined' && self.Math == Math)
-            ? self
-            : Function('return this')();
+        : globalThis;
 
     $.fn.popup = function (parameters) {
         var

--- a/src/definitions/modules/progress.js
+++ b/src/definitions/modules/progress.js
@@ -17,9 +17,7 @@
 
     window = (typeof window != 'undefined' && window.Math == Math)
         ? window
-        : (typeof self != 'undefined' && self.Math == Math)
-            ? self
-            : Function('return this')();
+        : globalThis;
 
     $.fn.progress = function (parameters) {
         var

--- a/src/definitions/modules/rating.js
+++ b/src/definitions/modules/rating.js
@@ -17,9 +17,7 @@
 
     window = (typeof window != 'undefined' && window.Math == Math)
         ? window
-        : (typeof self != 'undefined' && self.Math == Math)
-            ? self
-            : Function('return this')();
+        : globalThis;
 
     $.fn.rating = function (parameters) {
         var

--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -17,9 +17,7 @@
 
     window = (typeof window != 'undefined' && window.Math == Math)
         ? window
-        : (typeof self != 'undefined' && self.Math == Math)
-            ? self
-            : Function('return this')();
+        : globalThis;
 
     $.fn.search = function (parameters) {
         var

--- a/src/definitions/modules/shape.js
+++ b/src/definitions/modules/shape.js
@@ -17,9 +17,7 @@
 
     window = (typeof window != 'undefined' && window.Math == Math)
         ? window
-        : (typeof self != 'undefined' && self.Math == Math)
-            ? self
-            : Function('return this')();
+        : globalThis;
 
     $.fn.shape = function (parameters) {
         var

--- a/src/definitions/modules/sidebar.js
+++ b/src/definitions/modules/sidebar.js
@@ -17,9 +17,7 @@
 
     window = (typeof window != 'undefined' && window.Math == Math)
         ? window
-        : (typeof self != 'undefined' && self.Math == Math)
-            ? self
-            : Function('return this')();
+        : globalThis;
 
     $.fn.sidebar = function (parameters) {
         var

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -17,9 +17,7 @@
 
     window = (typeof window != 'undefined' && window.Math == Math)
         ? window
-        : (typeof self != 'undefined' && self.Math == Math)
-            ? self
-            : Function('return this')();
+        : globalThis;
 
     $.fn.slider = function (parameters) {
         var

--- a/src/definitions/modules/sticky.js
+++ b/src/definitions/modules/sticky.js
@@ -17,9 +17,7 @@
 
     window = (typeof window != 'undefined' && window.Math == Math)
         ? window
-        : (typeof self != 'undefined' && self.Math == Math)
-            ? self
-            : Function('return this')();
+        : globalThis;
 
     $.fn.sticky = function (parameters) {
         var

--- a/src/definitions/modules/tab.js
+++ b/src/definitions/modules/tab.js
@@ -14,15 +14,14 @@
     function isWindow(obj) {
         return obj != null && obj === obj.window;
     }
+
     function isFunction(obj) {
         return typeof obj === 'function' && typeof obj.nodeType !== 'number';
     }
 
     window = (typeof window != 'undefined' && window.Math == Math)
         ? window
-        : (typeof self != 'undefined' && self.Math == Math)
-            ? self
-            : Function('return this')();
+        : globalThis;
 
     $.fn.tab = function (parameters) {
         var

--- a/src/definitions/modules/toast.js
+++ b/src/definitions/modules/toast.js
@@ -17,9 +17,7 @@
 
     window = (typeof window != 'undefined' && window.Math == Math)
         ? window
-        : (typeof self != 'undefined' && self.Math == Math)
-            ? self
-            : Function('return this')();
+        : globalThis;
 
     $.toast = $.fn.toast = function (parameters) {
         var

--- a/src/definitions/modules/transition.js
+++ b/src/definitions/modules/transition.js
@@ -17,9 +17,7 @@
 
     window = (typeof window != 'undefined' && window.Math == Math)
         ? window
-        : (typeof self != 'undefined' && self.Math == Math)
-            ? self
-            : Function('return this')();
+        : globalThis;
 
     $.fn.transition = function () {
         var


### PR DESCRIPTION
`globalThis` is quite new feature, but all supported browsers except IE11 should support it - https://caniuse.com/?search=globalThis

I do not consider this a problem, as IE11 is kept supported when `window` is defined which normally is, only there is no longer a fallback when undefined/shadowed.

For documentation purposes and easier revert/git bisect I propose this change as a separate PR.