### PR TITLE
feat(lint): remove unneeded parentheses around expressions

### DIFF
--- a/.eslint/index.js
+++ b/.eslint/index.js
@@ -1,0 +1,23 @@
+module.exports = {
+    rules: {
+        'no-extra-parens': require('./no-extra-parens-rule'),
+    },
+    configs: {
+        recommended: {
+            plugins: [
+                '@internal/eslint-plugin',
+            ],
+            rules: {
+                // https://github.com/eslint/eslint/issues/16626
+                // https://github.com/airbnb/javascript/blob/eslint-config-airbnb-v19.0.4/packages/eslint-config-airbnb-base/rules/errors.js#L66
+                '@internal/no-extra-parens': ['error', 'all', {
+                    conditionalAssign: true,
+                    enforceForArrowConditionals: false,
+                    ignoreJSX: 'all',
+                    nestedBinaryExpressions: false,
+                    returnAssign: false,
+                }],
+            },
+        },
+    },
+};

--- a/.eslint/no-extra-parens-rule.js
+++ b/.eslint/no-extra-parens-rule.js
@@ -1,0 +1,17 @@
+const eslint = require('eslint');
+const ruleComposer = require('eslint-rule-composer');
+
+const rule = new eslint.Linter().getRules().get('no-extra-parens');
+
+module.exports = ruleComposer.filterReports(
+    rule,
+    (problem) => {
+        if (problem.node.type === 'ConditionalExpression'
+            && (problem.node.parent.type === 'ConditionalExpression' || problem.node.parent.type === 'SpreadElement')
+        ) {
+            return false;
+        }
+
+        return problem;
+    }
+);

--- a/.eslint/package.json
+++ b/.eslint/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@internal/eslint-plugin",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "eslint-rule-composer": "^0.3.0"
+  },
+  "peerDependencies": {
+    "eslint": "*"
+  }
+}

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,7 @@ module.exports = {
     extends: [
         'airbnb-base',
         'plugin:unicorn/recommended',
+        'plugin:@internal/eslint-plugin/recommended',
     ],
     parserOptions: {
         ecmaVersion: '2020',
@@ -22,10 +23,10 @@ module.exports = {
         'class-methods-use-this': 'off',
         'comma-dangle': ['error', {
             arrays: 'always-multiline',
-            objects: 'always-multiline',
+            exports: 'always-multiline',
             functions: 'never',
             imports: 'always-multiline',
-            exports: 'always-multiline',
+            objects: 'always-multiline',
         }],
         'consistent-return': 'off',
         curly: ['error', 'all'],
@@ -47,10 +48,6 @@ module.exports = {
                 VariableDeclarator: true,
             },
         }],
-        'no-extra-parens': 'off', /* TODO https://github.com/eslint/eslint/issues/16626#issuecomment-1341016901 ['error', 'all', {
-            nestedBinaryExpressions: false,
-            enforceForNewInMemberExpressions: false,
-        }], */
         'no-nested-ternary': 'off',
         'no-param-reassign': 'off',
         'no-plusplus': 'off',
@@ -60,8 +57,8 @@ module.exports = {
         'object-shorthand': ['error', 'never'],
         'padding-line-between-statements': ['error', {
             blankLine: 'always',
-            prev: '*',
             next: ['continue', 'break', 'export', 'return', 'throw'],
+            prev: '*',
         }],
         'prefer-destructuring': 'off',
         'prefer-template': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -104,6 +104,7 @@ module.exports = {
         'unicorn/no-array-for-each': 'off',
         'unicorn/no-for-loop': 'off', // autofixes to "for of"
         'unicorn/prefer-code-point': 'off',
+        'unicorn/prefer-default-parameters': 'off',
         'unicorn/prefer-includes': 'off',
         'unicorn/prefer-node-protocol': 'off', // needs Node 14+
         'unicorn/prefer-number-properties': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -117,10 +117,8 @@ module.exports = {
         eqeqeq: 'off', // about 300 errors to be fixed manually
         'global-require': 'off', // about 30 errors to be fixed manually
         'no-shadow': 'off', // about 220 errors to be fixed manually
+        'no-shadow-restricted-names': 'off', // TODO https://github.com/fomantic/Fomantic-UI/pull/2604
         'prefer-arrow-callback': 'off', // about 350 errors (all autofixable)
-
-        // TODO
-        'no-shadow-restricted-names': 'off',
     },
     reportUnusedDisableDirectives: true,
     globals: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -96,6 +96,7 @@ module.exports = {
         'one-var': 'off',
         'prefer-const': 'off',
         'prefer-exponentiation-operator': 'off',
+        'prefer-rest-params': 'off',
         'prefer-spread': 'off',
         'semi-style': 'off',
         'unicorn/no-array-for-each': 'off',
@@ -117,7 +118,6 @@ module.exports = {
         'global-require': 'off', // about 30 errors to be fixed manually
         'no-shadow': 'off', // about 220 errors to be fixed manually
         'prefer-arrow-callback': 'off', // about 350 errors (all autofixable)
-        'prefer-rest-params': 'off', // about 180 errors to be fixed manually
 
         // TODO
         'no-shadow-restricted-names': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -121,7 +121,6 @@ module.exports = {
 
         // TODO
         'no-shadow-restricted-names': 'off',
-        'no-use-before-define': 'off',
         'unicorn/prefer-negative-index': 'off',
     },
     reportUnusedDisableDirectives: true,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -120,7 +120,6 @@ module.exports = {
         'prefer-rest-params': 'off', // about 180 errors to be fixed manually
 
         // TODO
-        'no-return-assign': 'off',
         'no-shadow-restricted-names': 'off',
         'no-use-before-define': 'off',
         'unicorn/prefer-negative-index': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -102,7 +102,6 @@ module.exports = {
         'unicorn/no-array-for-each': 'off',
         'unicorn/no-for-loop': 'off', // autofixes to "for of"
         'unicorn/prefer-code-point': 'off',
-        'unicorn/prefer-default-parameters': 'off',
         'unicorn/prefer-includes': 'off',
         'unicorn/prefer-node-protocol': 'off', // needs Node 14+
         'unicorn/prefer-number-properties': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -121,7 +121,6 @@ module.exports = {
 
         // TODO
         'no-shadow-restricted-names': 'off',
-        'unicorn/prefer-negative-index': 'off',
     },
     reportUnusedDisableDirectives: true,
     globals: {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,7 +2,7 @@
  *           Set-up
  *******************************/
 
-let
+const
     gulp   = require('gulp'),
 
     // read user config to know what task to load

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "yamljs": "^0.3.0"
   },
   "devDependencies": {
+    "@internal/eslint-plugin": "file:.eslint",
     "all-contributors-cli": "^6.7.0",
     "auto-changelog": "^2.4.0",
     "eslint": "^8.29.0",

--- a/src/definitions/behaviors/api.js
+++ b/src/definitions/behaviors/api.js
@@ -362,11 +362,11 @@
                                         variable = templatedString.indexOf('$') !== -1
                                             ? templatedString.slice(2, -1)
                                             : templatedString.slice(1, -1),
-                                        value   = ($.isPlainObject(urlData) && urlData[variable] !== undefined)
+                                        value   = $.isPlainObject(urlData) && urlData[variable] !== undefined
                                             ? urlData[variable]
-                                            : (($module.data(variable) !== undefined)
+                                            : ($module.data(variable) !== undefined
                                                 ? $module.data(variable)
-                                                : (($context.data(variable) !== undefined) // eslint-disable-line unicorn/no-nested-ternary
+                                                : ($context.data(variable) !== undefined // eslint-disable-line unicorn/no-nested-ternary
                                                     ? $context.data(variable)
                                                     : urlData[variable]))
                                     ;
@@ -393,11 +393,11 @@
                                         variable = templatedString.indexOf('$') !== -1
                                             ? templatedString.slice(3, -1)
                                             : templatedString.slice(2, -1),
-                                        value   = ($.isPlainObject(urlData) && urlData[variable] !== undefined)
+                                        value   = $.isPlainObject(urlData) && urlData[variable] !== undefined
                                             ? urlData[variable]
-                                            : (($module.data(variable) !== undefined)
+                                            : ($module.data(variable) !== undefined
                                                 ? $module.data(variable)
-                                                : (($context.data(variable) !== undefined) // eslint-disable-line unicorn/no-nested-ternary
+                                                : ($context.data(variable) !== undefined // eslint-disable-line unicorn/no-nested-ternary
                                                     ? $context.data(variable)
                                                     : urlData[variable]))
                                     ;
@@ -748,15 +748,15 @@
                     },
                     responseFromXHR: function (xhr) {
                         return $.isPlainObject(xhr)
-                            ? ((module.is.expectingJSON())
+                            ? (module.is.expectingJSON()
                                 ? module.decode.json(xhr.responseText)
                                 : xhr.responseText)
                             : false;
                     },
                     errorFromRequest: function (response, status, httpMessage) {
-                        return ($.isPlainObject(response) && response.error !== undefined)
+                        return $.isPlainObject(response) && response.error !== undefined
                             ? response.error // use json error message
-                            : ((settings.error[status] !== undefined) // use server error message
+                            : (settings.error[status] !== undefined // use server error message
                                 ? settings.error[status]
                                 : httpMessage);
                     },
@@ -836,9 +836,9 @@
                         }
                         if (settings.on == 'auto') {
                             if ($module.is('input')) {
-                                return (element.oninput !== undefined)
+                                return element.oninput !== undefined
                                     ? 'input'
-                                    : ((element.onpropertychange !== undefined)
+                                    : (element.onpropertychange !== undefined
                                         ? 'propertychange'
                                         : 'keyup');
                             }

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -136,7 +136,10 @@
                 },
 
                 attachEvents: function (selector, action) {
-                    action = action || 'submit';
+                    if (!action) {
+                        action = 'submit';
+                    }
+
                     $(selector).on('click' + eventNamespace, function (event) {
                         module[action]();
                         event.preventDefault();

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -492,9 +492,9 @@
                         return module.get.inputEvent();
                     },
                     inputEvent: function () {
-                        return (document.createElement('input').oninput !== undefined)
+                        return document.createElement('input').oninput !== undefined
                             ? 'input'
-                            : ((document.createElement('input').onpropertychange !== undefined)
+                            : (document.createElement('input').onpropertychange !== undefined
                                 ? 'propertychange'
                                 : 'keyup');
                     },
@@ -539,13 +539,11 @@
                         if (ancillary && ['integer', 'decimal', 'number'].indexOf(ruleName) >= 0 && ancillary.indexOf('..') >= 0) {
                             parts = ancillary.split('..', 2);
                             if (!rule.prompt) {
-                                suffixPrompt = (
-                                    parts[0] === ''
-                                        ? settings.prompt.maxValue.replace(/{ruleValue}/g, '{max}')
-                                        : (parts[1] === ''
-                                            ? settings.prompt.minValue.replace(/{ruleValue}/g, '{min}')
-                                            : settings.prompt.range)
-                                );
+                                suffixPrompt = parts[0] === ''
+                                    ? settings.prompt.maxValue.replace(/{ruleValue}/g, '{max}')
+                                    : (parts[1] === ''
+                                        ? settings.prompt.minValue.replace(/{ruleValue}/g, '{min}')
+                                        : settings.prompt.range);
                                 prompt += suffixPrompt.replace(/{name}/g, ' ' + settings.text.and);
                             }
                             prompt = prompt.replace(/{min}/g, parts[0]);

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -136,10 +136,7 @@
                 },
 
                 attachEvents: function (selector, action) {
-                    if (!action) {
-                        action = 'submit';
-                    }
-
+                    action = action || 'submit';
                     $(selector).on('click' + eventNamespace, function (event) {
                         module[action]();
                         event.preventDefault();

--- a/src/definitions/modules/accordion.js
+++ b/src/definitions/modules/accordion.js
@@ -122,7 +122,7 @@
                 toggle: function (query) {
                     var
                         $activeTitle = query !== undefined
-                            ? ((typeof query === 'number')
+                            ? (typeof query === 'number'
                                 ? $title.eq(query)
                                 : $(query).closest(selector.title))
                             : $(this).closest(selector.title),
@@ -147,7 +147,7 @@
                 open: function (query) {
                     var
                         $activeTitle = query !== undefined
-                            ? ((typeof query === 'number')
+                            ? (typeof query === 'number'
                                 ? $title.eq(query)
                                 : $(query).closest(selector.title))
                             : $(this).closest(selector.title),
@@ -217,7 +217,7 @@
                 close: function (query) {
                     var
                         $activeTitle = query !== undefined
-                            ? ((typeof query === 'number')
+                            ? (typeof query === 'number'
                                 ? $title.eq(query)
                                 : $(query).closest(selector.title))
                             : $(this).closest(selector.title),

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -531,8 +531,8 @@
                             var focused = module.helper.dateEqual(cellDate, focusDate, mode);
                             var inRange = !rangeDate
                                 ? false
-                                : ((!!startDate && module.helper.isDateInRange(cellDate, mode, startDate, rangeDate))
-                                    || (!!endDate && module.helper.isDateInRange(cellDate, mode, rangeDate, endDate)));
+                                : (!!startDate && module.helper.isDateInRange(cellDate, mode, startDate, rangeDate))
+                                    || (!!endDate && module.helper.isDateInRange(cellDate, mode, rangeDate, endDate));
                             $cell.toggleClass(className.focusCell, focused && (!isTouch || isTouchDown) && (!adjacent || (settings.selectAdjacentDays && adjacent)) && !disabled);
 
                             if (module.helper.isTodayButton($cell)) {
@@ -1112,7 +1112,7 @@
                                 ss: ('0' + s).slice(-2),
                                 a: a,
                                 A: a.toUpperCase(),
-                                S: ['th', 'st', 'nd', 'rd'][(D % 10) > 3 ? 0 : (((D % 100) - (D % 10) === 10) ? 0 : D % 10)],
+                                S: ['th', 'st', 'nd', 'rd'][(D % 10) > 3 ? 0 : ((D % 100) - (D % 10) === 10 ? 0 : D % 10)],
                                 w: w,
                                 ww: ('0' + w).slice(-2),
                             }
@@ -1392,9 +1392,9 @@
 
                         return !date
                             ? date
-                            : ((minDate && module.helper.dateDiff(date, minDate, 'minute') > 0)
+                            : (minDate && module.helper.dateDiff(date, minDate, 'minute') > 0
                                 ? (isTimeOnly ? module.helper.mergeDateTime(date, minDate) : minDate) // eslint-disable-line unicorn/no-nested-ternary
-                                : ((maxDate && module.helper.dateDiff(maxDate, date, 'minute') > 0) // eslint-disable-line unicorn/no-nested-ternary
+                                : (maxDate && module.helper.dateDiff(maxDate, date, 'minute') > 0 // eslint-disable-line unicorn/no-nested-ternary
                                     ? (isTimeOnly ? module.helper.mergeDateTime(date, maxDate) : maxDate)
                                     : date));
                     },

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -1123,7 +1123,7 @@
                                 return tokens[match];
                             }
 
-                            return match.slice(1, match.length - 1);
+                            return match.slice(1, -1);
                         });
                     },
                     isDisabled: function (date, mode) {

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -1342,7 +1342,10 @@
                         return date;
                     },
                     dateDiff: function (date1, date2, mode) {
-                        mode = mode || 'day';
+                        if (!mode) {
+                            mode = 'day';
+                        }
+
                         var isTimeOnly = settings.type === 'time';
                         var isYear = mode === 'year';
                         var isYearOrMonth = isYear || mode === 'month';

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -1342,10 +1342,7 @@
                         return date;
                     },
                     dateDiff: function (date1, date2, mode) {
-                        if (!mode) {
-                            mode = 'day';
-                        }
-
+                        mode = mode || 'day';
                         var isTimeOnly = settings.type === 'time';
                         var isYear = mode === 'year';
                         var isYearOrMonth = isYear || mode === 'month';

--- a/src/definitions/modules/dimmer.js
+++ b/src/definitions/modules/dimmer.js
@@ -48,7 +48,7 @@
                 moduleNamespace = 'module-' + namespace,
                 moduleSelector  = $allModules.selector || '',
 
-                clickEvent      = ('ontouchstart' in document.documentElement)
+                clickEvent      = 'ontouchstart' in document.documentElement
                     ? 'touchstart'
                     : 'click',
 

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1920,8 +1920,8 @@
                             return '';
                         }
 
-                        return (!module.has.selectInput() && module.is.multiple())
-                            ? ((typeof value === 'string') // delimited string
+                        return !module.has.selectInput() && module.is.multiple()
+                            ? (typeof value === 'string' // delimited string
                                 ? (raw
                                     ? value
                                     : module.escape.htmlEntities(value)).split(settings.delimiter)
@@ -1965,9 +1965,9 @@
                                 $choice.find(selector.menuIcon).remove();
                             }
 
-                            return ($choice.data(metadata.text) !== undefined)
+                            return $choice.data(metadata.text) !== undefined
                                 ? $choice.data(metadata.text)
-                                : ((preserveHTML)
+                                : (preserveHTML
                                     ? $choice.html() && $choice.html().trim()
                                     : $choice.text() && $choice.text().trim());
                         }
@@ -1978,9 +1978,9 @@
                             return false;
                         }
 
-                        return ($choice.data(metadata.value) !== undefined)
+                        return $choice.data(metadata.value) !== undefined
                             ? String($choice.data(metadata.value))
-                            : ((typeof choiceText === 'string')
+                            : (typeof choiceText === 'string'
                                 ? String(
                                     settings.ignoreSearchCase
                                         ? choiceText.toLowerCase()
@@ -1993,9 +1993,9 @@
                             input = $search[0]
                         ;
                         if (input) {
-                            return (input.oninput !== undefined)
+                            return input.oninput !== undefined
                                 ? 'input'
-                                : ((input.onpropertychange !== undefined)
+                                : (input.onpropertychange !== undefined
                                     ? 'propertychange'
                                     : 'keyup');
                         }
@@ -2102,14 +2102,14 @@
                         ;
                         value = value !== undefined
                             ? value
-                            : ((module.get.values() !== undefined)
+                            : (module.get.values() !== undefined
                                 ? module.get.values()
                                 : module.get.text());
-                        isMultiple = (module.is.multiple() && Array.isArray(value));
-                        shouldSearch = (isMultiple)
+                        isMultiple = module.is.multiple() && Array.isArray(value);
+                        shouldSearch = isMultiple
                             ? value.length > 0
-                            : (value !== undefined && value !== null);
-                        strict = (value === '' || value === false || value === true)
+                            : value !== undefined && value !== null;
+                        strict = value === '' || value === false || value === true
                             ? true
                             : strict || false;
                         if (shouldSearch) {
@@ -2384,7 +2384,7 @@
                         : elementIndex < $selectableItem.length;
                     $nextSelectedItem = isWithinRange
                         ? $selectableItem.eq(elementIndex)
-                        : ((direction == 'up')
+                        : (direction == 'up'
                             ? $selectableItem.first()
                             : $selectableItem.last());
                     if ($nextSelectedItem.length > 0) {

--- a/src/definitions/modules/flyout.js
+++ b/src/definitions/modules/flyout.js
@@ -1015,8 +1015,8 @@
                     ie: function () {
                         if (module.cache.isIE === undefined) {
                             var
-                                isIE11 = (!(window.ActiveXObject) && 'ActiveXObject' in window),
-                                isIE = ('ActiveXObject' in window)
+                                isIE11 = !window.ActiveXObject && 'ActiveXObject' in window,
+                                isIE = 'ActiveXObject' in window
                             ;
                             module.cache.isIE = isIE11 || isIE;
                         }

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -941,8 +941,8 @@
                     ie: function () {
                         if (module.cache.isIE === undefined) {
                             var
-                                isIE11 = (!(window.ActiveXObject) && 'ActiveXObject' in window),
-                                isIE = ('ActiveXObject' in window)
+                                isIE11 = !window.ActiveXObject && 'ActiveXObject' in window,
+                                isIE = 'ActiveXObject' in window
                             ;
                             module.cache.isIE = isIE11 || isIE;
                         }

--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -28,7 +28,7 @@
 
             moduleSelector = $allModules.selector || '',
 
-            clickEvent      = ('ontouchstart' in document.documentElement)
+            clickEvent      = 'ontouchstart' in document.documentElement
                 ? 'touchstart'
                 : 'click',
 

--- a/src/definitions/modules/progress.js
+++ b/src/definitions/modules/progress.js
@@ -260,16 +260,13 @@
 
                 get: {
                     text: function (templateText, index) {
-                        if (!index) {
-                            index = 0;
-                        }
-
                         var
-                            value   = module.get.value(index),
+                            index_  = index || 0,
+                            value   = module.get.value(index_),
                             total   = module.get.total(),
                             percent = animating
-                                ? module.get.displayPercent(index)
-                                : module.get.percent(index),
+                                ? module.get.displayPercent(index_)
+                                : module.get.percent(index_),
                             left = total !== false
                                 ? Math.max(0, total - value)
                                 : 100 - percent
@@ -280,7 +277,7 @@
                             .replace('{total}', total || 0)
                             .replace('{left}', left)
                             .replace('{percent}', percent)
-                            .replace('{bar}', settings.text.bars[index] || '')
+                            .replace('{bar}', settings.text.bars[index_] || '')
                         ;
                         module.verbose('Adding variables to progress bar text', templateText);
 

--- a/src/definitions/modules/progress.js
+++ b/src/definitions/modules/progress.js
@@ -320,9 +320,9 @@
                     },
 
                     numericValue: function (value) {
-                        return (typeof value === 'string')
-                            ? ((value.replace(/[^\d.]/g, '') !== '')
-                                ? +(value.replace(/[^\d.]/g, ''))
+                        return typeof value === 'string'
+                            ? (value.replace(/[^\d.]/g, '') !== ''
+                                ? +value.replace(/[^\d.]/g, '')
                                 : false)
                             : value;
                     },
@@ -497,7 +497,7 @@
                     percent: function (percents) {
                         percents = module.helper.forceArray(percents).map(function (percent) {
                             percent = typeof percent === 'string'
-                                ? +(percent.replace('%', ''))
+                                ? +percent.replace('%', '')
                                 : percent;
 
                             return settings.limitValues

--- a/src/definitions/modules/progress.js
+++ b/src/definitions/modules/progress.js
@@ -260,13 +260,16 @@
 
                 get: {
                     text: function (templateText, index) {
+                        if (!index) {
+                            index = 0;
+                        }
+
                         var
-                            index_  = index || 0,
-                            value   = module.get.value(index_),
+                            value   = module.get.value(index),
                             total   = module.get.total(),
                             percent = animating
-                                ? module.get.displayPercent(index_)
-                                : module.get.percent(index_),
+                                ? module.get.displayPercent(index)
+                                : module.get.percent(index),
                             left = total !== false
                                 ? Math.max(0, total - value)
                                 : 100 - percent
@@ -277,7 +280,7 @@
                             .replace('{total}', total || 0)
                             .replace('{left}', left)
                             .replace('{percent}', percent)
-                            .replace('{bar}', settings.text.bars[index_] || '')
+                            .replace('{bar}', settings.text.bars[index] || '')
                         ;
                         module.verbose('Adding variables to progress bar text', templateText);
 

--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -458,9 +458,9 @@
                     inputEvent: function () {
                         var
                             prompt = $prompt[0],
-                            inputEvent   = (prompt !== undefined && prompt.oninput !== undefined)
+                            inputEvent   = prompt !== undefined && prompt.oninput !== undefined
                                 ? 'input'
-                                : ((prompt !== undefined && prompt.onpropertychange !== undefined)
+                                : (prompt !== undefined && prompt.onpropertychange !== undefined
                                     ? 'propertychange'
                                     : 'keyup')
                         ;

--- a/src/definitions/modules/shape.js
+++ b/src/definitions/modules/shape.js
@@ -245,19 +245,19 @@
                             $clone      = $module.clone().addClass(className.loading),
                             $side       = $clone.find('>' + selector.sides + '>' + selector.side),
                             $activeSide = $side.filter('.' + settings.className.active),
-                            $nextSide   = (nextIndex)
+                            $nextSide   = nextIndex
                                 ? $side.eq(nextIndex)
-                                : (($activeSide.next(selector.side).length > 0)
+                                : ($activeSide.next(selector.side).length > 0
                                     ? $activeSide.next(selector.side)
                                     : $side.first()),
                             newWidth    = settings.width === 'next'
                                 ? $nextSide.outerWidth(true)
-                                : ((settings.width === 'initial')
+                                : (settings.width === 'initial'
                                     ? $module.width()
                                     : settings.width),
                             newHeight    = settings.height === 'next'
                                 ? $nextSide.outerHeight(true)
-                                : ((settings.height === 'initial')
+                                : (settings.height === 'initial'
                                     ? $module.height()
                                     : settings.height)
                         ;

--- a/src/definitions/modules/sidebar.js
+++ b/src/definitions/modules/sidebar.js
@@ -724,11 +724,11 @@
                             direction = module.get.direction(),
                             transition
                         ;
-                        transition = (module.is.mobile())
-                            ? ((settings.mobileTransition == 'auto')
+                        transition = module.is.mobile()
+                            ? (settings.mobileTransition == 'auto'
                                 ? settings.defaultTransition.mobile[direction]
                                 : settings.mobileTransition)
-                            : ((settings.transition == 'auto')
+                            : (settings.transition == 'auto'
                                 ? settings.defaultTransition.computer[direction]
                                 : settings.transition);
                         module.verbose('Determined transition', transition);
@@ -786,8 +786,8 @@
                     ie: function () {
                         if (module.cache.isIE === undefined) {
                             var
-                                isIE11 = (!(window.ActiveXObject) && 'ActiveXObject' in window),
-                                isIE = ('ActiveXObject' in window)
+                                isIE11 = !window.ActiveXObject && 'ActiveXObject' in window,
+                                isIE = 'ActiveXObject' in window
                             ;
                             module.cache.isIE = isIE11 || isIE;
                         }

--- a/src/definitions/modules/toast.js
+++ b/src/definitions/modules/toast.js
@@ -932,13 +932,18 @@
                 return n1 * x * x;
             }
             if (x < 2 / d1) {
-                return n1 * (x -= 1.5 / d1) * x + 0.75;
+                x -= 1.5 / d1;
+
+                return n1 * x * x + 0.75;
             }
             if (x < 2.5 / d1) {
-                return n1 * (x -= 2.25 / d1) * x + 0.9375;
-            }
+                x -= 2.25 / d1;
 
-            return n1 * (x -= 2.625 / d1) * x + 0.984375;
+                return n1 * x * x + 0.9375;
+            }
+            x -= 2.625 / d1;
+
+            return n1 * x * x + 0.984375;
         },
         easeOutCubic: function (t) {
             return --t * t * t + 1;

--- a/src/definitions/modules/transition.js
+++ b/src/definitions/modules/transition.js
@@ -579,8 +579,8 @@
                             duration = $module.css('animation-duration') || 0;
                         }
 
-                        return (typeof duration === 'string')
-                            ? ((duration.indexOf('ms') > -1)
+                        return typeof duration === 'string'
+                            ? (duration.indexOf('ms') > -1
                                 ? parseFloat(duration)
                                 : parseFloat(duration) * 1000)
                             : duration;

--- a/tasks/admin/components/create.js
+++ b/tasks/admin/components/create.js
@@ -14,7 +14,7 @@
   * create meteor.js file
 */
 
-let
+const
     gulp            = require('gulp'),
 
     // node dependencies

--- a/tasks/admin/components/init.js
+++ b/tasks/admin/components/init.js
@@ -12,7 +12,7 @@
 
 */
 
-let
+const
     gulp      = require('gulp'),
 
     // node dependencies

--- a/tasks/admin/components/update.js
+++ b/tasks/admin/components/update.js
@@ -12,7 +12,7 @@
 
 */
 
-let
+const
     gulp           = require('gulp'),
 
     // node dependencies

--- a/tasks/admin/distributions/create.js
+++ b/tasks/admin/distributions/create.js
@@ -9,7 +9,7 @@
   * update package.json file
 */
 
-let
+const
     gulp            = require('gulp'),
 
     // node dependencies

--- a/tasks/admin/distributions/init.js
+++ b/tasks/admin/distributions/init.js
@@ -12,7 +12,7 @@
 
 */
 
-let
+const
     gulp      = require('gulp'),
 
     // node dependencies

--- a/tasks/admin/distributions/update.js
+++ b/tasks/admin/distributions/update.js
@@ -12,7 +12,7 @@
 
 */
 
-let
+const
     gulp           = require('gulp'),
 
     // node dependencies

--- a/tasks/admin/publish.js
+++ b/tasks/admin/publish.js
@@ -9,9 +9,7 @@
 
 */
 
-let
-    gulp = require('gulp')
-;
+const gulp = require('gulp');
 
 /* Release All */
 module.exports = function (callback) {

--- a/tasks/admin/register.js
+++ b/tasks/admin/register.js
@@ -8,13 +8,13 @@
   * Registers component with NPM
 */
 
+// node dependencies
+const process = require('child_process');
+
+// config
+const release = require('../config/admin/release');
+
 let
-    // node dependencies
-    process = require('child_process'),
-
-    // config
-    release = require('../config/admin/release'),
-
     // register components and distributions
     repos   = release.distributions.concat(release.components),
     total   = repos.length,

--- a/tasks/admin/release.js
+++ b/tasks/admin/release.js
@@ -10,9 +10,7 @@
 
 */
 
-let
-    gulp = require('gulp')
-;
+const gulp = require('gulp');
 
 /* Release All */
 module.exports = function (callback) {

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -2,7 +2,7 @@
  *         Build Task
  *******************************/
 
-let
+const
     // dependencies
     gulp     = require('gulp'),
 

--- a/tasks/build/assets.js
+++ b/tasks/build/assets.js
@@ -2,7 +2,7 @@
  Build Task
  *******************************/
 
-let
+const
     gulp      = require('gulp'),
 
     // gulp dependencies

--- a/tasks/check-install.js
+++ b/tasks/check-install.js
@@ -2,7 +2,7 @@
  *        Check Install
  *******************************/
 
-let
+const
     // node dependencies
     gulp    = require('gulp'),
     console = require('better-console'),

--- a/tasks/clean.js
+++ b/tasks/clean.js
@@ -2,7 +2,7 @@
           Clean Task
 *******************************/
 
-let
+const
     del    = require('del'),
     config = require('./config/user'),
     tasks  = require('./config/tasks')

--- a/tasks/collections/admin.js
+++ b/tasks/collections/admin.js
@@ -14,7 +14,7 @@
  *******************************/
 
 module.exports = function (gulp) {
-    let
+    const
         // less/css distributions
         initComponents      = require('../admin/components/init'),
         createComponents    = require('../admin/components/create'),

--- a/tasks/collections/rtl.js
+++ b/tasks/collections/rtl.js
@@ -4,7 +4,7 @@
 
 module.exports = function (gulp) {
     // rtl
-    let
+    const
         buildRTL = require('../rtl/build'),
         watchRTL = require('../rtl/watch')
     ;

--- a/tasks/config/admin/github.js
+++ b/tasks/config/admin/github.js
@@ -5,7 +5,7 @@
   Logs into GitHub using OAuth
 */
 
-let
+const
     fs          = require('fs'),
     path        = require('path'),
     GithubAPI   = require('@octokit/rest'),
@@ -13,15 +13,14 @@ let
     // stores oauth info for GitHub API
     oAuth       = fs.existsSync(path.join(__dirname, './oauth.js'))
         ? require('./oauth.js') // eslint-disable-line import/extensions
-        : false,
-    github
+        : false
 ;
 
 if (!oAuth) {
     console.error('Must add oauth token for GitHub in tasks/config/admin/oauth.js');
 }
 
-github = new GithubAPI({
+let github = new GithubAPI({
     version: '3.0.0',
     debug: true,
     protocol: 'https',

--- a/tasks/config/npm/gulpfile.js
+++ b/tasks/config/npm/gulpfile.js
@@ -2,7 +2,7 @@
  *           Set-up
  *******************************/
 
-let
+const
     gulp   = require('gulp'),
 
     // read user config to know what task to load

--- a/tasks/config/project/config.js
+++ b/tasks/config/project/config.js
@@ -2,7 +2,7 @@
             Set-up
 *******************************/
 
-let
+const
     fs       = require('fs'),
     path     = require('path'),
 

--- a/tasks/config/project/install.js
+++ b/tasks/config/project/install.js
@@ -2,7 +2,7 @@
             Set-up
 *******************************/
 
-let
+const
     fs             = require('fs'),
     path           = require('path'),
     requireDotFile = require('require-dot-file'),

--- a/tasks/config/project/release.js
+++ b/tasks/config/project/release.js
@@ -2,8 +2,9 @@
          Release Config
 *******************************/
 
+const requireDotFile = require('require-dot-file');
+
 let
-    requireDotFile = require('require-dot-file'),
     config,
     npmPackage,
     version

--- a/tasks/config/tasks.js
+++ b/tasks/config/tasks.js
@@ -1,4 +1,4 @@
-let
+const
     browserslist = require('browserslist'),
     console = require('better-console'),
     config  = require('./user'),

--- a/tasks/config/tasks.js
+++ b/tasks/config/tasks.js
@@ -95,7 +95,7 @@ module.exports = {
 
         /* Comment Banners */
         header: {
-            year: nullish(config.header.year, (new Date()).getFullYear()),
+            year: nullish(config.header.year, new Date().getFullYear()),
             title: nullish(config.header.title, release.title),
             version: nullish(config.header.version, release.version),
             repository: nullish(config.header.repository, release.repository),

--- a/tasks/config/user.js
+++ b/tasks/config/user.js
@@ -2,7 +2,7 @@
              Set-up
 *******************************/
 
-let
+const
     // npm dependencies
     extend          = require('extend'),
     fs              = require('fs'),
@@ -11,8 +11,10 @@ let
 
     // semantic.json defaults
     defaults        = require('./defaults'),
-    config          = require('./project/config'),
+    config          = require('./project/config')
+;
 
+let
     // Final config object
     gulpConfig = {},
 

--- a/tasks/docs/build.js
+++ b/tasks/docs/build.js
@@ -2,7 +2,7 @@
  Build Docs
  *******************************/
 
-let
+const
     extend      = require('extend'),
     gulp        = require('gulp'),
 

--- a/tasks/docs/metadata.js
+++ b/tasks/docs/metadata.js
@@ -2,7 +2,7 @@
            Summarize Docs
 *******************************/
 
-let
+const
     // node dependencies
     console      = require('better-console'),
     fs           = require('fs'),

--- a/tasks/docs/serve.js
+++ b/tasks/docs/serve.js
@@ -1,7 +1,8 @@
 /*******************************
  Serve Docs
  *******************************/
-let
+
+const
     extend      = require('extend'),
     gulp        = require('gulp'),
 

--- a/tasks/install.js
+++ b/tasks/install.js
@@ -13,7 +13,7 @@
    * Standard installer runs asking for paths to site files etc
 */
 
-let
+const
     gulp           = require('gulp'),
 
     // node dependencies

--- a/tasks/rtl/build.js
+++ b/tasks/rtl/build.js
@@ -2,9 +2,7 @@
  *         Build Task
  *******************************/
 
-let
-    gulp = require('gulp')
-;
+const gulp = require('gulp');
 
 // RTL builds are now handled by the default build process
 module.exports = function (callback) {

--- a/tasks/rtl/watch.js
+++ b/tasks/rtl/watch.js
@@ -2,9 +2,7 @@
  *          Watch Task
  *******************************/
 
-let
-    gulp = require('gulp')
-;
+const gulp = require('gulp');
 
 // RTL watch are now handled by the default watch process
 module.exports = function (callback) {

--- a/tasks/version.js
+++ b/tasks/version.js
@@ -2,9 +2,7 @@
           Version Task
 *******************************/
 
-let
-    release = require('./config/project/release')
-;
+const release = require('./config/project/release');
 
 module.exports = function (callback) {
     console.log(release.title + ' ' + release.version);

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -2,7 +2,7 @@
  *          Watch Task
  *******************************/
 
-let
+const
     gulp       = require('gulp'),
 
     // node dependencies

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,6 +84,11 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
+"@internal/eslint-plugin@file:.eslint":
+  version "1.0.0"
+  dependencies:
+    eslint-rule-composer "^0.3.0"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -1590,6 +1595,11 @@ eslint-plugin-import@^2.26.0:
     object.values "^1.1.5"
     resolve "^1.22.0"
     tsconfig-paths "^3.14.1"
+
+eslint-rule-composer@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
+  integrity sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==
 
 eslint-scope@^7.1.1:
   version "7.1.1"


### PR DESCRIPTION
Modernize code using eslint advisory introduced in GH-2596. This PR focuses on fixing `no-extra-parens` rule with a help or a custom rule output filter.