### PR TITLE
feat(lint): type-safe equality operator when comparing literals

### DIFF
--- a/.eslint/eqeqeq-rule.js
+++ b/.eslint/eqeqeq-rule.js
@@ -9,7 +9,6 @@ module.exports = ruleComposer.filterReports(
         if (problem.node.type === 'BinaryExpression'
             && (problem.node.operator === '==' || problem.node.operator === '!=')
             && problem.node.right.type === 'Literal'
-            && problem.node.right.raw !== '\'\''
         ) {
             return problem;
         }

--- a/.eslint/eqeqeq-rule.js
+++ b/.eslint/eqeqeq-rule.js
@@ -1,0 +1,19 @@
+const eslint = require('eslint');
+const ruleComposer = require('eslint-rule-composer');
+
+const rule = new eslint.Linter().getRules().get('eqeqeq');
+
+module.exports = ruleComposer.filterReports(
+    rule,
+    (problem) => {
+        if (problem.node.type === 'BinaryExpression'
+            && (problem.node.operator === '==' || problem.node.operator === '!=')
+            && problem.node.right.type === 'Literal'
+            && problem.node.right.raw !== '\'\''
+        ) {
+            return problem;
+        }
+
+        return false;
+    }
+);

--- a/.eslint/index.js
+++ b/.eslint/index.js
@@ -1,5 +1,6 @@
 module.exports = {
     rules: {
+        eqeqeq: require('./eqeqeq-rule'),
         'no-extra-parens': require('./no-extra-parens-rule'),
     },
     configs: {
@@ -8,6 +9,8 @@ module.exports = {
                 '@internal/eslint-plugin',
             ],
             rules: {
+                // fixes only variable == (or !=) 'non-empty-string-scalar'
+                '@internal/eqeqeq': ['error', 'always'],
                 // https://github.com/eslint/eslint/issues/16626
                 // https://github.com/airbnb/javascript/blob/eslint-config-airbnb-v19.0.4/packages/eslint-config-airbnb-base/rules/errors.js#L66
                 '@internal/no-extra-parens': ['error', 'all', {

--- a/.eslint/index.js
+++ b/.eslint/index.js
@@ -9,7 +9,7 @@ module.exports = {
                 '@internal/eslint-plugin',
             ],
             rules: {
-                // fixes only variable == (or !=) 'non-empty-string-scalar'
+                // fixes only variable == (or !=) literal expression
                 '@internal/eqeqeq': ['error', 'always'],
                 // https://github.com/eslint/eslint/issues/16626
                 // https://github.com/airbnb/javascript/blob/eslint-config-airbnb-v19.0.4/packages/eslint-config-airbnb-base/rules/errors.js#L66

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -113,7 +113,7 @@ module.exports = {
         'vars-on-top': 'off',
 
         // TODO rules with a lot of errors to be fixed manually, fix in a separate PR
-        eqeqeq: 'off', // about 300 errors to be fixed manually
+        eqeqeq: 'off', // about 180 errors to be fixed manually
         'global-require': 'off', // about 30 errors to be fixed manually
         'no-shadow': 'off', // about 220 errors to be fixed manually
         'no-shadow-restricted-names': 'off', // TODO https://github.com/fomantic/Fomantic-UI/pull/2604

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -85,7 +85,6 @@ module.exports = {
         'unicorn/prefer-array-some': 'off', // https://github.com/sindresorhus/eslint-plugin-unicorn/issues/2007
         'unicorn/prefer-module': 'off',
         'unicorn/prevent-abbreviations': 'off',
-        'unicorn/switch-case-braces': ['error', 'avoid'],
         'wrap-iife': ['error', 'inside'],
 
         // TODO rules to be removed/fixed in v2.10.0 as fixes are not compatible with IE11

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -112,7 +112,7 @@ module.exports = {
         'vars-on-top': 'off',
 
         // TODO rules with a lot of errors to be fixed manually, fix in a separate PR
-        eqeqeq: 'off', // about 180 errors to be fixed manually
+        eqeqeq: 'off', // about 20 errors to be fixed manually
         'global-require': 'off', // about 30 errors to be fixed manually
         'no-shadow': 'off', // about 220 errors to be fixed manually
         'no-shadow-restricted-names': 'off', // TODO https://github.com/fomantic/Fomantic-UI/pull/2604

--- a/src/definitions/behaviors/api.js
+++ b/src/definitions/behaviors/api.js
@@ -117,7 +117,7 @@
                             $module
                                 .on(triggerEvent + eventNamespace, module.event.trigger)
                             ;
-                        } else if (settings.on == 'now') {
+                        } else if (settings.on === 'now') {
                             module.debug('Querying API endpoint immediately');
                             module.query();
                         }
@@ -296,7 +296,7 @@
                     },
                     loading: function () {
                         return module.request
-                            ? module.request.state() == 'pending'
+                            ? module.request.state() === 'pending'
                             : false;
                     },
                     abortedRequest: function (xhr) {
@@ -334,13 +334,13 @@
                         return module.cancelled || false;
                     },
                     successful: function () {
-                        return module.request && module.request.state() == 'resolved';
+                        return module.request && module.request.state() === 'resolved';
                     },
                     failure: function () {
-                        return module.request && module.request.state() == 'rejected';
+                        return module.request && module.request.state() === 'rejected';
                     },
                     complete: function () {
-                        return module.request && (module.request.state() == 'resolved' || module.request.state() == 'rejected');
+                        return module.request && (module.request.state() === 'resolved' || module.request.state() === 'rejected');
                     },
                 },
 
@@ -525,7 +525,7 @@
                 event: {
                     trigger: function (event) {
                         module.query();
-                        if (event.type == 'submit' || event.type == 'click') {
+                        if (event.type === 'submit' || event.type === 'click') {
                             event.preventDefault();
                         }
                     },
@@ -614,15 +614,15 @@
                                 response     = module.get.responseFromXHR(xhr),
                                 errorMessage = module.get.errorFromRequest(response, status, httpMessage)
                             ;
-                            if (status == 'aborted') {
+                            if (status === 'aborted') {
                                 module.debug('XHR Aborted (Most likely caused by page navigation or CORS Policy)', status, httpMessage);
                                 settings.onAbort.call(context, status, $module, xhr);
 
                                 return true;
                             }
-                            if (status == 'invalid') {
+                            if (status === 'invalid') {
                                 module.debug('JSON did not pass success test. A server-side error has most likely occurred', response);
-                            } else if (status == 'error') {
+                            } else if (status === 'error') {
                                 if (xhr !== undefined) {
                                     module.debug('XHR produced a server error', status, httpMessage);
                                     // make sure we have an error to display to console
@@ -829,12 +829,12 @@
                         return data;
                     },
                     event: function () {
-                        if (isWindow(element) || settings.on == 'now') {
+                        if (isWindow(element) || settings.on === 'now') {
                             module.debug('API called without element, no events attached');
 
                             return false;
                         }
-                        if (settings.on == 'auto') {
+                        if (settings.on === 'auto') {
                             if ($module.is('input')) {
                                 return element.oninput !== undefined
                                     ? 'input'

--- a/src/definitions/behaviors/api.js
+++ b/src/definitions/behaviors/api.js
@@ -478,7 +478,7 @@
                                 while (nameKeys.length > 0) {
                                     var k = nameKeys.pop();
 
-                                    if (k == '' && !Array.isArray(value)) { // foo[]
+                                    if (k === '' && !Array.isArray(value)) { // foo[]
                                         value = build([], pushes[pushKey]++, value);
                                     } else if (settings.regExp.fixed.test(k)) { // foo[n]
                                         value = build([], k, value);

--- a/src/definitions/behaviors/api.js
+++ b/src/definitions/behaviors/api.js
@@ -12,7 +12,7 @@
     'use strict';
 
     function isWindow(obj) {
-        return obj != null && obj === obj.window;
+        return obj !== null && obj === obj.window;
     }
 
     function isFunction(obj) {

--- a/src/definitions/behaviors/api.js
+++ b/src/definitions/behaviors/api.js
@@ -1004,17 +1004,17 @@
                         query = query.split(/[ .]/);
                         maxDepth = query.length - 1;
                         $.each(query, function (depth, value) {
-                            var camelCaseValue = depth != maxDepth
+                            var camelCaseValue = depth !== maxDepth
                                 ? value + query[depth + 1].charAt(0).toUpperCase() + query[depth + 1].slice(1)
                                 : query
                             ;
-                            if ($.isPlainObject(object[camelCaseValue]) && (depth != maxDepth)) {
+                            if ($.isPlainObject(object[camelCaseValue]) && (depth !== maxDepth)) {
                                 object = object[camelCaseValue];
                             } else if (object[camelCaseValue] !== undefined) {
                                 found = object[camelCaseValue];
 
                                 return false;
-                            } else if ($.isPlainObject(object[value]) && (depth != maxDepth)) {
+                            } else if ($.isPlainObject(object[value]) && (depth !== maxDepth)) {
                                 object = object[value];
                             } else if (object[value] !== undefined) {
                                 found = object[value];

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -865,7 +865,7 @@
                         // For each new rule, check if there's not already one with the same type
                         $.each(newValidation.rules, function (_index, rule) {
                             if ($.grep(validation[name].rules, function (item) {
-                                return item.type == rule.type;
+                                return item.type === rule.type;
                             }).length === 0) {
                                 validation[name].rules.push(rule);
                             }
@@ -1169,7 +1169,7 @@
                     optional: function (identifier, bool) {
                         bool = bool !== false;
                         $.each(validation, function (fieldName, field) {
-                            if (identifier == fieldName || identifier == field.identifier) {
+                            if (identifier === fieldName || identifier === field.identifier) {
                                 field.optional = bool;
                             }
                         });

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1758,7 +1758,7 @@
                 if (!range || ['', '..'].indexOf(range) !== -1) {
 
                     // do nothing
-                } else if (range.indexOf('..') == -1) {
+                } else if (range.indexOf('..') === -1) {
                     if (regExp.test(range)) {
                         min = range - 0;
                         max = min;
@@ -1904,7 +1904,7 @@
                 }
 
                 return matchingValue !== undefined
-                    ? value.toString() == matchingValue.toString()
+                    ? value.toString() === matchingValue.toString()
                     : false;
             },
 

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -428,7 +428,7 @@
                                 $fieldGroup     = $field.closest($group),
                                 validationRules = module.get.validation($field)
                             ;
-                            if (validationRules && (settings.on == 'blur' || ($fieldGroup.hasClass(className.error) && settings.revalidate))) {
+                            if (validationRules && (settings.on === 'blur' || ($fieldGroup.hasClass(className.error) && settings.revalidate))) {
                                 module.debug('Revalidating field', $field, validationRules);
                                 module.validate.field(validationRules);
                                 if (!settings.inline) {
@@ -442,7 +442,7 @@
                                 $fieldGroup = $field.closest($group),
                                 validationRules = module.get.validation($field)
                             ;
-                            if (validationRules && (settings.on == 'change' || ($fieldGroup.hasClass(className.error) && settings.revalidate))) {
+                            if (validationRules && (settings.on === 'change' || ($fieldGroup.hasClass(className.error) && settings.revalidate))) {
                                 clearTimeout(module.timer);
                                 module.timer = setTimeout(function () {
                                     module.debug('Revalidating field', $field, validationRules);
@@ -488,7 +488,7 @@
                         return rule.type;
                     },
                     changeEvent: function (type, $input) {
-                        if (type == 'checkbox' || type == 'radio' || type == 'hidden' || $input.is('select')) {
+                        if (type === 'checkbox' || type === 'radio' || type === 'hidden' || $input.is('select')) {
                             return 'change';
                         }
 
@@ -730,11 +730,11 @@
                                         var date = $calendar.calendar('get date');
 
                                         if (date !== null) {
-                                            if (settings.dateHandling == 'date') {
+                                            if (settings.dateHandling === 'date') {
                                                 values[name] = date;
-                                            } else if (settings.dateHandling == 'input') {
+                                            } else if (settings.dateHandling === 'input') {
                                                 values[name] = $calendar.calendar('get input date');
-                                            } else if (settings.dateHandling == 'formatter') {
+                                            } else if (settings.dateHandling === 'formatter') {
                                                 var type = $calendar.calendar('setting', 'type');
 
                                                 switch (type) {
@@ -1139,7 +1139,7 @@
                                 validation = module.get.validation($el),
                                 hasEmptyRule = validation
                                     ? $.grep(validation.rules, function (rule) {
-                                        return rule.type == 'empty';
+                                        return rule.type === 'empty';
                                     }) !== 0
                                     : false,
                                 identifier = validation.identifier || $el.attr('id') || $el.attr('name') || $el.data(metadata.validate)

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -352,7 +352,7 @@
                             initialValue = initialValue.toString();
                         }
                         var currentValue = $el.val();
-                        if (currentValue === undefined) {
+                        if (currentValue === undefined || currentValue === null) {
                             currentValue = '';
                         } else if (Array.isArray(currentValue)) {
                             // multiple select values are returned as arrays which are never equal, so do string conversion first

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -731,48 +731,49 @@
 
                                         if (date !== null) {
                                             switch (settings.dateHandling) {
-                                                case 'date':
+                                                case 'date': {
                                                     values[name] = date;
 
                                                     break;
-
-                                                case 'input':
+                                                }
+                                                case 'input': {
                                                     values[name] = $calendar.calendar('get input date');
 
                                                     break;
-
+                                                }
                                                 case 'formatter': {
                                                     var type = $calendar.calendar('setting', 'type');
 
                                                     switch (type) {
-                                                        case 'date':
+                                                        case 'date': {
                                                             values[name] = settings.formatter.date(date);
 
                                                             break;
-
-                                                        case 'datetime':
+                                                        }
+                                                        case 'datetime': {
                                                             values[name] = settings.formatter.datetime(date);
 
                                                             break;
-
-                                                        case 'time':
+                                                        }
+                                                        case 'time': {
                                                             values[name] = settings.formatter.time(date);
 
                                                             break;
-
-                                                        case 'month':
+                                                        }
+                                                        case 'month': {
                                                             values[name] = settings.formatter.month(date);
 
                                                             break;
-
-                                                        case 'year':
+                                                        }
+                                                        case 'year': {
                                                             values[name] = settings.formatter.year(date);
 
                                                             break;
-
-                                                        default:
+                                                        }
+                                                        default: {
                                                             module.debug('Wrong calendar mode', $calendar, type);
                                                             values[name] = '';
+                                                        }
                                                     }
 
                                                     break;

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -557,7 +557,7 @@
                         }
                         if (requiresName) {
                             $label = $field.closest(selector.group).find('label').eq(0);
-                            name = $label.length == 1
+                            name = $label.length === 1
                                 ? $label.text()
                                 : $field.prop('placeholder') || settings.text.unspecifiedField;
                             prompt = prompt.replace(/{name}/g, name);
@@ -730,42 +730,52 @@
                                         var date = $calendar.calendar('get date');
 
                                         if (date !== null) {
-                                            if (settings.dateHandling === 'date') {
-                                                values[name] = date;
-                                            } else if (settings.dateHandling === 'input') {
-                                                values[name] = $calendar.calendar('get input date');
-                                            } else if (settings.dateHandling === 'formatter') {
-                                                var type = $calendar.calendar('setting', 'type');
+                                            switch (settings.dateHandling) {
+                                                case 'date':
+                                                    values[name] = date;
 
-                                                switch (type) {
-                                                    case 'date':
-                                                        values[name] = settings.formatter.date(date);
+                                                    break;
 
-                                                        break;
+                                                case 'input':
+                                                    values[name] = $calendar.calendar('get input date');
 
-                                                    case 'datetime':
-                                                        values[name] = settings.formatter.datetime(date);
+                                                    break;
 
-                                                        break;
+                                                case 'formatter': {
+                                                    var type = $calendar.calendar('setting', 'type');
 
-                                                    case 'time':
-                                                        values[name] = settings.formatter.time(date);
+                                                    switch (type) {
+                                                        case 'date':
+                                                            values[name] = settings.formatter.date(date);
 
-                                                        break;
+                                                            break;
 
-                                                    case 'month':
-                                                        values[name] = settings.formatter.month(date);
+                                                        case 'datetime':
+                                                            values[name] = settings.formatter.datetime(date);
 
-                                                        break;
+                                                            break;
 
-                                                    case 'year':
-                                                        values[name] = settings.formatter.year(date);
+                                                        case 'time':
+                                                            values[name] = settings.formatter.time(date);
 
-                                                        break;
+                                                            break;
 
-                                                    default:
-                                                        module.debug('Wrong calendar mode', $calendar, type);
-                                                        values[name] = '';
+                                                        case 'month':
+                                                            values[name] = settings.formatter.month(date);
+
+                                                            break;
+
+                                                        case 'year':
+                                                            values[name] = settings.formatter.year(date);
+
+                                                            break;
+
+                                                        default:
+                                                            module.debug('Wrong calendar mode', $calendar, type);
+                                                            values[name] = '';
+                                                    }
+
+                                                    break;
                                                 }
                                             }
                                         } else {

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -403,13 +403,13 @@
                                     escape: 27,
                                 }
                             ;
-                            if (key == keyCode.escape) {
+                            if (key === keyCode.escape) {
                                 module.verbose('Escape key pressed blurring field');
                                 $field[0]
                                     .blur()
                                 ;
                             }
-                            if (!event.ctrlKey && key == keyCode.enter && isInput && !isInDropdown && !isCheckbox) {
+                            if (!event.ctrlKey && key === keyCode.enter && isInput && !isInDropdown && !isCheckbox) {
                                 if (!keyHeldDown) {
                                     $field.one('keyup' + eventNamespace, module.event.field.keyup);
                                     module.submit();

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -2049,10 +2049,10 @@
             },
 
             minCount: function (value, minCount) {
-                if (minCount == 0) {
+                if (minCount === 0) {
                     return true;
                 }
-                if (minCount == 1) {
+                if (minCount === 1) {
                     return value !== '';
                 }
 
@@ -2060,10 +2060,10 @@
             },
 
             exactCount: function (value, exactCount) {
-                if (exactCount == 0) {
+                if (exactCount === 0) {
                     return value === '';
                 }
-                if (exactCount == 1) {
+                if (exactCount === 1) {
                     return value !== '' && value.search(',') === -1;
                 }
 
@@ -2071,10 +2071,10 @@
             },
 
             maxCount: function (value, maxCount) {
-                if (maxCount == 0) {
+                if (maxCount === 0) {
                     return false;
                 }
-                if (maxCount == 1) {
+                if (maxCount === 1) {
                     return value.search(',') === -1;
                 }
 

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1453,16 +1453,16 @@
                         query = query.split(/[ .]/);
                         maxDepth = query.length - 1;
                         $.each(query, function (depth, value) {
-                            var camelCaseValue = depth != maxDepth
+                            var camelCaseValue = depth !== maxDepth
                                 ? value + query[depth + 1].charAt(0).toUpperCase() + query[depth + 1].slice(1)
                                 : query;
-                            if ($.isPlainObject(object[camelCaseValue]) && (depth != maxDepth)) {
+                            if ($.isPlainObject(object[camelCaseValue]) && (depth !== maxDepth)) {
                                 object = object[camelCaseValue];
                             } else if (object[camelCaseValue] !== undefined) {
                                 found = object[camelCaseValue];
 
                                 return false;
-                            } else if ($.isPlainObject(object[value]) && (depth != maxDepth)) {
+                            } else if ($.isPlainObject(object[value]) && (depth !== maxDepth)) {
                                 object = object[value];
                             } else if (object[value] !== undefined) {
                                 found = object[value];

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -345,14 +345,14 @@
                     },
                     fieldDirty: function ($el) {
                         var initialValue = $el.data(metadata.defaultValue);
-                        // Explicitly check for null/undefined here as value may be `false`, so ($el.data(dataInitialValue) || '') would not work
-                        if (initialValue == null) {
+                        // Explicitly check for undefined/null here as value may be `false`, so ($el.data(dataInitialValue) || '') would not work
+                        if (initialValue === undefined || initialValue === null) {
                             initialValue = '';
                         } else if (Array.isArray(initialValue)) {
                             initialValue = initialValue.toString();
                         }
                         var currentValue = $el.val();
-                        if (currentValue == null) {
+                        if (currentValue === undefined) {
                             currentValue = '';
                         } else if (Array.isArray(currentValue)) {
                             // multiple select values are returned as arrays which are never equal, so do string conversion first

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -2050,6 +2050,8 @@
             },
 
             minCount: function (value, minCount) {
+                minCount = Number(minCount);
+
                 if (minCount === 0) {
                     return true;
                 }
@@ -2061,6 +2063,8 @@
             },
 
             exactCount: function (value, exactCount) {
+                exactCount = Number(exactCount);
+
                 if (exactCount === 0) {
                     return value === '';
                 }
@@ -2072,6 +2076,8 @@
             },
 
             maxCount: function (value, maxCount) {
+                maxCount = Number(maxCount);
+
                 if (maxCount === 0) {
                     return false;
                 }

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1867,7 +1867,7 @@
             // is exactly length
             exactLength: function (value, requiredLength) {
                 return value !== undefined
-                    ? value.length == requiredLength
+                    ? value.length === Number(requiredLength)
                     : false;
             },
 
@@ -2072,7 +2072,7 @@
                     return value !== '' && value.search(',') === -1;
                 }
 
-                return value.split(',').length == exactCount;
+                return value.split(',').length === exactCount;
             },
 
             maxCount: function (value, maxCount) {

--- a/src/definitions/behaviors/state.js
+++ b/src/definitions/behaviors/state.js
@@ -233,7 +233,7 @@
                         }
                         $.when(apiRequest)
                             .then(function () {
-                                if (apiRequest.state() == 'resolved') {
+                                if (apiRequest.state() === 'resolved') {
                                     module.debug('API request succeeded');
                                     settings.activateTest = function () {
                                         return true;

--- a/src/definitions/behaviors/state.js
+++ b/src/definitions/behaviors/state.js
@@ -519,17 +519,17 @@
                         query = query.split(/[ .]/);
                         maxDepth = query.length - 1;
                         $.each(query, function (depth, value) {
-                            var camelCaseValue = depth != maxDepth
+                            var camelCaseValue = depth !== maxDepth
                                 ? value + query[depth + 1].charAt(0).toUpperCase() + query[depth + 1].slice(1)
                                 : query
                             ;
-                            if ($.isPlainObject(object[camelCaseValue]) && (depth != maxDepth)) {
+                            if ($.isPlainObject(object[camelCaseValue]) && (depth !== maxDepth)) {
                                 object = object[camelCaseValue];
                             } else if (object[camelCaseValue] !== undefined) {
                                 found = object[camelCaseValue];
 
                                 return false;
-                            } else if ($.isPlainObject(object[value]) && (depth != maxDepth)) {
+                            } else if ($.isPlainObject(object[value]) && (depth !== maxDepth)) {
                                 object = object[value];
                             } else if (object[value] !== undefined) {
                                 found = object[value];

--- a/src/definitions/behaviors/visibility.js
+++ b/src/definitions/behaviors/visibility.js
@@ -189,7 +189,7 @@
                         [].forEach.call(mutations, function (mutation) {
                             if (mutation.removedNodes) {
                                 [].forEach.call(mutation.removedNodes, function (node) {
-                                    if (node == element || $(node).find(element).length > 0) {
+                                    if (node === element || $(node).find(element).length > 0) {
                                         module.debug('Element removed from DOM, tearing down events');
                                         module.destroy();
                                     }
@@ -299,7 +299,7 @@
                                 module.precache(src, function () {
                                     module.set.image(src, function () {
                                         loadedCount++;
-                                        if (loadedCount == moduleCount) {
+                                        if (loadedCount === moduleCount) {
                                             settings.onAllLoaded.call(this);
                                         }
                                         settings.onLoad.call(this);

--- a/src/definitions/behaviors/visibility.js
+++ b/src/definitions/behaviors/visibility.js
@@ -83,10 +83,10 @@
                     module.setup.cache();
 
                     if (module.should.trackChanges()) {
-                        if (settings.type == 'image') {
+                        if (settings.type === 'image') {
                             module.setup.image();
                         }
-                        if (settings.type == 'fixed') {
+                        if (settings.type === 'fixed') {
                             module.setup.fixed();
                         }
 
@@ -131,7 +131,7 @@
                         .off('scroll' + eventNamespace, module.event.scroll)
                         .off('scrollchange' + eventNamespace, module.event.scrollchange)
                     ;
-                    if (settings.type == 'fixed') {
+                    if (settings.type === 'fixed') {
                         module.resetFixed();
                         module.remove.placeholder();
                     }
@@ -432,7 +432,7 @@
                                 : false
                         ;
 
-                        return overflowY == 'auto' || overflowY == 'scroll';
+                        return overflowY === 'auto' || overflowY === 'scroll';
                     },
                     horizontallyScrollableContext: function () {
                         var
@@ -441,13 +441,13 @@
                                 : false
                         ;
 
-                        return overflowX == 'auto' || overflowX == 'scroll';
+                        return overflowX === 'auto' || overflowX === 'scroll';
                     },
                 },
 
                 refresh: function () {
                     module.debug('Refreshing constants (width/height)');
-                    if (settings.type == 'fixed') {
+                    if (settings.type === 'fixed') {
                         module.resetFixed();
                     }
                     module.reset();

--- a/src/definitions/behaviors/visibility.js
+++ b/src/definitions/behaviors/visibility.js
@@ -1127,17 +1127,17 @@
                         query = query.split(/[ .]/);
                         maxDepth = query.length - 1;
                         $.each(query, function (depth, value) {
-                            var camelCaseValue = depth != maxDepth
+                            var camelCaseValue = depth !== maxDepth
                                 ? value + query[depth + 1].charAt(0).toUpperCase() + query[depth + 1].slice(1)
                                 : query
                             ;
-                            if ($.isPlainObject(object[camelCaseValue]) && (depth != maxDepth)) {
+                            if ($.isPlainObject(object[camelCaseValue]) && (depth !== maxDepth)) {
                                 object = object[camelCaseValue];
                             } else if (object[camelCaseValue] !== undefined) {
                                 found = object[camelCaseValue];
 
                                 return false;
-                            } else if ($.isPlainObject(object[value]) && (depth != maxDepth)) {
+                            } else if ($.isPlainObject(object[value]) && (depth !== maxDepth)) {
                                 object = object[value];
                             } else if (object[value] !== undefined) {
                                 found = object[value];

--- a/src/definitions/globals/site.js
+++ b/src/definitions/globals/site.js
@@ -361,17 +361,17 @@
                     query = query.split(/[ .]/);
                     maxDepth = query.length - 1;
                     $.each(query, function (depth, value) {
-                        var camelCaseValue = depth != maxDepth
+                        var camelCaseValue = depth !== maxDepth
                             ? value + query[depth + 1].charAt(0).toUpperCase() + query[depth + 1].slice(1)
                             : query
                         ;
-                        if ($.isPlainObject(object[camelCaseValue]) && (depth != maxDepth)) {
+                        if ($.isPlainObject(object[camelCaseValue]) && (depth !== maxDepth)) {
                             object = object[camelCaseValue];
                         } else if (object[camelCaseValue] !== undefined) {
                             found = object[camelCaseValue];
 
                             return false;
-                        } else if ($.isPlainObject(object[value]) && (depth != maxDepth)) {
+                        } else if ($.isPlainObject(object[value]) && (depth !== maxDepth)) {
                             object = object[value];
                         } else if (object[value] !== undefined) {
                             found = object[value];

--- a/src/definitions/modules/accordion.js
+++ b/src/definitions/modules/accordion.js
@@ -482,16 +482,16 @@
                         query = query.split(/[ .]/);
                         maxDepth = query.length - 1;
                         $.each(query, function (depth, value) {
-                            var camelCaseValue = depth != maxDepth
+                            var camelCaseValue = depth !== maxDepth
                                 ? value + query[depth + 1].charAt(0).toUpperCase() + query[depth + 1].slice(1)
                                 : query;
-                            if ($.isPlainObject(object[camelCaseValue]) && (depth != maxDepth)) {
+                            if ($.isPlainObject(object[camelCaseValue]) && (depth !== maxDepth)) {
                                 object = object[camelCaseValue];
                             } else if (object[camelCaseValue] !== undefined) {
                                 found = object[camelCaseValue];
 
                                 return false;
-                            } else if ($.isPlainObject(object[value]) && (depth != maxDepth)) {
+                            } else if ($.isPlainObject(object[value]) && (depth !== maxDepth)) {
                                 object = object[value];
                             } else if (object[value] !== undefined) {
                                 found = object[value];

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -1524,17 +1524,17 @@
                         query = query.split(/[ .]/);
                         maxDepth = query.length - 1;
                         $.each(query, function (depth, value) {
-                            var camelCaseValue = depth != maxDepth
+                            var camelCaseValue = depth !== maxDepth
                                 ? value + query[depth + 1].charAt(0).toUpperCase() + query[depth + 1].slice(1)
                                 : query
                             ;
-                            if ($.isPlainObject(object[camelCaseValue]) && (depth != maxDepth)) {
+                            if ($.isPlainObject(object[camelCaseValue]) && (depth !== maxDepth)) {
                                 object = object[camelCaseValue];
                             } else if (object[camelCaseValue] !== undefined) {
                                 found = object[camelCaseValue];
 
                                 return false;
-                            } else if ($.isPlainObject(object[value]) && (depth != maxDepth)) {
+                            } else if ($.isPlainObject(object[value]) && (depth !== maxDepth)) {
                                 object = object[value];
                             } else if (object[value] !== undefined) {
                                 found = object[value];

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -1139,19 +1139,19 @@
                             } else if (d !== null && typeof d === 'object') {
                                 if (d[metadata.year]) {
                                     if (typeof d[metadata.year] === 'number') {
-                                        blocked = date.getFullYear() == d[metadata.year];
+                                        blocked = date.getFullYear() === d[metadata.year];
                                     } else if (Array.isArray(d[metadata.year])) {
                                         blocked = d[metadata.year].indexOf(date.getFullYear()) > -1;
                                     }
                                 } else if (d[metadata.month]) {
                                     if (typeof d[metadata.month] === 'number') {
-                                        blocked = date.getMonth() == d[metadata.month];
+                                        blocked = date.getMonth() === d[metadata.month];
                                     } else if (Array.isArray(d[metadata.month])) {
                                         blocked = d[metadata.month].indexOf(date.getMonth()) > -1;
                                     } else if (d[metadata.month] instanceof Date) {
                                         var sdate = module.helper.sanitiseDate(d[metadata.month]);
 
-                                        blocked = (date.getMonth() == sdate.getMonth()) && (date.getFullYear() == sdate.getFullYear());
+                                        blocked = (date.getMonth() === sdate.getMonth()) && (date.getFullYear() === sdate.getFullYear());
                                     }
                                 } else if (d[metadata.date] && mode === 'day') {
                                     if (d[metadata.date] instanceof Date) {
@@ -1188,7 +1188,7 @@
 
                                 if (d[metadata.days]) {
                                     if (typeof d[metadata.days] === 'number') {
-                                        blocked = date.getDay() == d[metadata.days];
+                                        blocked = date.getDay() === d[metadata.days];
                                     } else if (Array.isArray(d[metadata.days])) {
                                         blocked = d[metadata.days].indexOf(date.getDay()) > -1;
                                     }
@@ -1196,7 +1196,7 @@
 
                                 if (d[metadata.hours]) {
                                     if (typeof d[metadata.hours] === 'number') {
-                                        blocked = blocked && date.getHours() == d[metadata.hours];
+                                        blocked = blocked && date.getHours() === d[metadata.hours];
                                     } else if (Array.isArray(d[metadata.hours])) {
                                         blocked = blocked && d[metadata.hours].indexOf(date.getHours()) > -1;
                                     }
@@ -1242,7 +1242,7 @@
                                 }
                                 if (d !== null && typeof d === 'object') {
                                     if (d[metadata.year]) {
-                                        if (typeof d[metadata.year] === 'number' && date.getFullYear() == d[metadata.year]) {
+                                        if (typeof d[metadata.year] === 'number' && date.getFullYear() === d[metadata.year]) {
                                             return d;
                                         }
                                         if (Array.isArray(d[metadata.year])) {
@@ -1251,7 +1251,7 @@
                                             }
                                         }
                                     } else if (d[metadata.month]) {
-                                        if (typeof d[metadata.month] === 'number' && date.getMonth() == d[metadata.month]) {
+                                        if (typeof d[metadata.month] === 'number' && date.getMonth() === d[metadata.month]) {
                                             return d;
                                         }
                                         if (Array.isArray(d[metadata.month])) {
@@ -1260,7 +1260,7 @@
                                             }
                                         } else if (d[metadata.month] instanceof Date) {
                                             var sdate = module.helper.sanitiseDate(d[metadata.month]);
-                                            if ((date.getMonth() == sdate.getMonth()) && (date.getFullYear() == sdate.getFullYear())) {
+                                            if ((date.getMonth() === sdate.getMonth()) && (date.getFullYear() === sdate.getFullYear())) {
                                                 return d;
                                             }
                                         }
@@ -1287,7 +1287,7 @@
                             var d;
                             var hourCheck = function (date, d) {
                                 if (d[metadata.hours]) {
-                                    if (typeof d[metadata.hours] === 'number' && date.getHours() == d[metadata.hours]) {
+                                    if (typeof d[metadata.hours] === 'number' && date.getHours() === d[metadata.hours]) {
                                         return d;
                                     }
                                     if (Array.isArray(d[metadata.hours])) {
@@ -1299,12 +1299,12 @@
                             };
                             for (var i = 0; i < hours.length; i++) {
                                 d = hours[i];
-                                if (typeof d === 'number' && date.getHours() == d) {
+                                if (typeof d === 'number' && date.getHours() === d) {
                                     return null;
                                 }
                                 if (d !== null && typeof d === 'object') {
                                     if (d[metadata.days] && hourCheck(date, d)) {
-                                        if (typeof d[metadata.days] === 'number' && date.getDay() == d[metadata.days]) {
+                                        if (typeof d[metadata.days] === 'number' && date.getDay() === d[metadata.days]) {
                                             return d;
                                         }
                                         if (Array.isArray(d[metadata.days])) {

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -695,11 +695,12 @@
                                     break;
                                 }
                                 // escape key
-                                case 27:
+                                case 27: {
                                     module.popup('hide');
                                     event.stopPropagation();
 
                                     break;
+                                }
                             }
                         }
 

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -662,7 +662,7 @@
                                         ? -1
                                         : (keyCode === 38
                                             ? -bigIncrement
-                                            : (keyCode == 39 ? 1 : bigIncrement)); // eslint-disable-line unicorn/no-nested-ternary
+                                            : (keyCode === 39 ? 1 : bigIncrement)); // eslint-disable-line unicorn/no-nested-ternary
                                     increment *= mode === 'minute' ? settings.minTimeGap : 1;
                                     var focusDate = module.get.focusDate() || module.get.date() || new Date();
                                     var year = focusDate.getFullYear() + (mode === 'year' ? increment : 0);

--- a/src/definitions/modules/checkbox.js
+++ b/src/definitions/modules/checkbox.js
@@ -767,17 +767,17 @@
                         query = query.split(/[ .]/);
                         maxDepth = query.length - 1;
                         $.each(query, function (depth, value) {
-                            var camelCaseValue = depth != maxDepth
+                            var camelCaseValue = depth !== maxDepth
                                 ? value + query[depth + 1].charAt(0).toUpperCase() + query[depth + 1].slice(1)
                                 : query
                             ;
-                            if ($.isPlainObject(object[camelCaseValue]) && (depth != maxDepth)) {
+                            if ($.isPlainObject(object[camelCaseValue]) && (depth !== maxDepth)) {
                                 object = object[camelCaseValue];
                             } else if (object[camelCaseValue] !== undefined) {
                                 found = object[camelCaseValue];
 
                                 return false;
-                            } else if ($.isPlainObject(object[value]) && (depth != maxDepth)) {
+                            } else if ($.isPlainObject(object[value]) && (depth !== maxDepth)) {
                                 object = object[value];
                             } else if (object[value] !== undefined) {
                                 found = object[value];

--- a/src/definitions/modules/checkbox.js
+++ b/src/definitions/modules/checkbox.js
@@ -370,7 +370,7 @@
                         return initialLoad;
                     },
                     radio: function () {
-                        return $input.hasClass(className.radio) || $input.attr('type') == 'radio';
+                        return $input.hasClass(className.radio) || $input.attr('type') === 'radio';
                     },
                     indeterminate: function () {
                         return $input.prop('indeterminate') !== undefined && $input.prop('indeterminate');

--- a/src/definitions/modules/checkbox.js
+++ b/src/definitions/modules/checkbox.js
@@ -217,9 +217,9 @@
                             checkIndex = false
                         ;
 
-                        if (key == keyCode.left || key == keyCode.up) {
+                        if (key === keyCode.left || key === keyCode.up) {
                             checkIndex = (rIndex === 0 ? rLen : rIndex) - 1;
-                        } else if (key == keyCode.right || key == keyCode.down) {
+                        } else if (key === keyCode.right || key === keyCode.down) {
                             checkIndex = rIndex === rLen - 1 ? 0 : rIndex + 1;
                         }
 
@@ -237,21 +237,21 @@
                         }
 
                         shortcutPressed = false;
-                        if (key == keyCode.escape) {
+                        if (key === keyCode.escape) {
                             module.verbose('Escape key pressed blurring field');
                             $input.trigger('blur');
                             shortcutPressed = true;
                             event.stopPropagation();
                         } else if (!event.ctrlKey && module.can.change()) {
-                            if (key == keyCode.space || (key == keyCode.enter && settings.enableEnterKey)) {
+                            if (key === keyCode.space || (key === keyCode.enter && settings.enableEnterKey)) {
                                 module.verbose('Enter/space key pressed, toggling checkbox');
                                 module.toggle();
                                 shortcutPressed = true;
                             } else if ($module.is('.toggle, .slider') && !module.is.radio()) {
-                                if (key == keyCode.left && module.is.checked()) {
+                                if (key === keyCode.left && module.is.checked()) {
                                     module.uncheck();
                                     shortcutPressed = true;
-                                } else if (key == keyCode.right && module.is.unchecked()) {
+                                } else if (key === keyCode.right && module.is.unchecked()) {
                                     module.check();
                                     shortcutPressed = true;
                                 }

--- a/src/definitions/modules/dimmer.js
+++ b/src/definitions/modules/dimmer.js
@@ -575,17 +575,17 @@
                         query = query.split(/[ .]/);
                         maxDepth = query.length - 1;
                         $.each(query, function (depth, value) {
-                            var camelCaseValue = depth != maxDepth
+                            var camelCaseValue = depth !== maxDepth
                                 ? value + query[depth + 1].charAt(0).toUpperCase() + query[depth + 1].slice(1)
                                 : query
                             ;
-                            if ($.isPlainObject(object[camelCaseValue]) && (depth != maxDepth)) {
+                            if ($.isPlainObject(object[camelCaseValue]) && (depth !== maxDepth)) {
                                 object = object[camelCaseValue];
                             } else if (object[camelCaseValue] !== undefined) {
                                 found = object[camelCaseValue];
 
                                 return false;
-                            } else if ($.isPlainObject(object[value]) && (depth != maxDepth)) {
+                            } else if ($.isPlainObject(object[value]) && (depth !== maxDepth)) {
                                 object = object[value];
                             } else if (object[value] !== undefined) {
                                 found = object[value];

--- a/src/definitions/modules/dimmer.js
+++ b/src/definitions/modules/dimmer.js
@@ -106,12 +106,12 @@
 
                 bind: {
                     events: function () {
-                        if (settings.on == 'hover') {
+                        if (settings.on === 'hover') {
                             $dimmable
                                 .on('mouseenter' + eventNamespace, module.show)
                                 .on('mouseleave' + eventNamespace, module.hide)
                             ;
-                        } else if (settings.on == 'click') {
+                        } else if (settings.on === 'click') {
                             $dimmable
                                 .on(clickEvent + eventNamespace, module.toggle)
                             ;
@@ -265,7 +265,7 @@
                         } else {
                             module.verbose('Showing dimmer animation with javascript');
                             module.set.dimmed();
-                            if (settings.opacity == 'auto') {
+                            if (settings.opacity === 'auto') {
                                 settings.opacity = 0.8;
                             }
                             $dimmer
@@ -358,8 +358,8 @@
                         return $dimmer.is(':animated') || $dimmer.hasClass(className.animating);
                     },
                     closable: function () {
-                        if (settings.closable == 'auto') {
-                            return settings.on != 'hover';
+                        if (settings.closable === 'auto') {
+                            return settings.on !== 'hover';
                         }
 
                         return settings.closable;

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -3319,7 +3319,7 @@
                             values = [values];
                         }
                         $.each(values, function (index, existingValue) {
-                            if (String(value).toLowerCase() == String(existingValue).toLowerCase()) {
+                            if (String(value).toLowerCase() === String(existingValue).toLowerCase()) {
                                 hasValue = true;
 
                                 return false;

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1424,82 +1424,93 @@
                                     return;
                                 }
 
-                                if (pressedKey === keys.leftArrow) {
-                                    // activate previous label
-                                    if ((isFocused || caretAtStart) && !hasActiveLabel) {
-                                        module.verbose('Selecting previous label');
-                                        $label.last().addClass(className.active);
-                                    } else if (hasActiveLabel) {
-                                        if (!event.shiftKey) {
+                                switch (pressedKey) {
+                                    case keys.leftArrow:
+                                        // activate previous label
+                                        if ((isFocused || caretAtStart) && !hasActiveLabel) {
                                             module.verbose('Selecting previous label');
-                                            $label.removeClass(className.active);
-                                        } else {
-                                            module.verbose('Adding previous label to selection');
-                                        }
-                                        if (isFirstLabel && !hasMultipleActive) {
-                                            $activeLabel.addClass(className.active);
-                                        } else {
-                                            $activeLabel.prev(selector.siblingLabel)
-                                                .addClass(className.active)
-                                                .end()
-                                            ;
-                                        }
-                                        event.preventDefault();
-                                    }
-                                } else if (pressedKey === keys.rightArrow) {
-                                    // activate first label
-                                    if (isFocused && !hasActiveLabel) {
-                                        $label.first().addClass(className.active);
-                                    }
-                                    // activate next label
-                                    if (hasActiveLabel) {
-                                        if (!event.shiftKey) {
-                                            module.verbose('Selecting next label');
-                                            $label.removeClass(className.active);
-                                        } else {
-                                            module.verbose('Adding next label to selection');
-                                        }
-                                        if (isLastLabel) {
-                                            if (isSearch) {
-                                                if (!isFocusedOnSearch) {
-                                                    module.focusSearch();
-                                                } else {
-                                                    $label.removeClass(className.active);
-                                                }
-                                            } else if (hasMultipleActive) {
-                                                $activeLabel.next(selector.siblingLabel).addClass(className.active);
+                                            $label.last().addClass(className.active);
+                                        } else if (hasActiveLabel) {
+                                            if (!event.shiftKey) {
+                                                module.verbose('Selecting previous label');
+                                                $label.removeClass(className.active);
                                             } else {
+                                                module.verbose('Adding previous label to selection');
+                                            }
+                                            if (isFirstLabel && !hasMultipleActive) {
                                                 $activeLabel.addClass(className.active);
+                                            } else {
+                                                $activeLabel.prev(selector.siblingLabel)
+                                                    .addClass(className.active)
+                                                    .end()
+                                                ;
                                             }
-                                        } else {
-                                            $activeLabel.next(selector.siblingLabel).addClass(className.active);
+                                            event.preventDefault();
                                         }
-                                        event.preventDefault();
-                                    }
-                                } else if (pressedKey === keys.deleteKey || pressedKey === keys.backspace) {
-                                    if (hasActiveLabel) {
-                                        module.verbose('Removing active labels');
-                                        if (isLastLabel) {
-                                            if (isSearch && !isFocusedOnSearch) {
-                                                module.focusSearch();
+
+                                        break;
+
+                                    case keys.rightArrow:
+                                        // activate first label
+                                        if (isFocused && !hasActiveLabel) {
+                                            $label.first().addClass(className.active);
+                                        }
+                                        // activate next label
+                                        if (hasActiveLabel) {
+                                            if (!event.shiftKey) {
+                                                module.verbose('Selecting next label');
+                                                $label.removeClass(className.active);
+                                            } else {
+                                                module.verbose('Adding next label to selection');
+                                            }
+                                            if (isLastLabel) {
+                                                if (isSearch) {
+                                                    if (!isFocusedOnSearch) {
+                                                        module.focusSearch();
+                                                    } else {
+                                                        $label.removeClass(className.active);
+                                                    }
+                                                } else if (hasMultipleActive) {
+                                                    $activeLabel.next(selector.siblingLabel).addClass(className.active);
+                                                } else {
+                                                    $activeLabel.addClass(className.active);
+                                                }
+                                            } else {
+                                                $activeLabel.next(selector.siblingLabel).addClass(className.active);
+                                            }
+                                            event.preventDefault();
+                                        }
+
+                                        break;
+
+                                    case keys.deleteKey:
+                                    case keys.backspace:
+                                        if (hasActiveLabel) {
+                                            module.verbose('Removing active labels');
+                                            if (isLastLabel) {
+                                                if (isSearch && !isFocusedOnSearch) {
+                                                    module.focusSearch();
+                                                }
+                                            }
+                                            $activeLabel.last().next(selector.siblingLabel).addClass(className.active);
+                                            module.remove.activeLabels($activeLabel);
+                                            if (!module.is.visible()) {
+                                                module.show();
+                                            }
+                                            event.preventDefault();
+                                        } else if (caretAtStart && !isSelectedSearch && !hasActiveLabel && pressedKey === keys.backspace) {
+                                            module.verbose('Removing last label on input backspace');
+                                            $activeLabel = $label.last().addClass(className.active);
+                                            module.remove.activeLabels($activeLabel);
+                                            if (!module.is.visible()) {
+                                                module.show();
                                             }
                                         }
-                                        $activeLabel.last().next(selector.siblingLabel).addClass(className.active);
-                                        module.remove.activeLabels($activeLabel);
-                                        if (!module.is.visible()) {
-                                            module.show();
-                                        }
-                                        event.preventDefault();
-                                    } else if (caretAtStart && !isSelectedSearch && !hasActiveLabel && pressedKey === keys.backspace) {
-                                        module.verbose('Removing last label on input backspace');
-                                        $activeLabel = $label.last().addClass(className.active);
-                                        module.remove.activeLabels($activeLabel);
-                                        if (!module.is.visible()) {
-                                            module.show();
-                                        }
-                                    }
-                                } else {
-                                    $activeLabel.removeClass(className.active);
+
+                                        break;
+
+                                    default:
+                                        $activeLabel.removeClass(className.active);
                                 }
                             }
                         },

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -4225,7 +4225,7 @@
                         maybeDescriptionVertical = option[fields.descriptionVertical]
                             ? className.descriptionVertical + ' '
                             : '',
-                        hasDescription = escape(option[fields.description] || '', preserveHTML) != ''
+                        hasDescription = escape(option[fields.description] || '', preserveHTML) !== ''
                     ;
                     html += '<div class="' + deQuote(maybeActionable + maybeDisabled + maybeDescriptionVertical + (option[fields.class] || className.item)) + '" data-value="' + deQuote(option[fields.value], true) + '"' + maybeText + '>';
                     if (isMenu) {

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -3872,17 +3872,17 @@
                         query = query.split(/[ .]/);
                         maxDepth = query.length - 1;
                         $.each(query, function (depth, value) {
-                            var camelCaseValue = depth != maxDepth
+                            var camelCaseValue = depth !== maxDepth
                                 ? value + query[depth + 1].charAt(0).toUpperCase() + query[depth + 1].slice(1)
                                 : query
                             ;
-                            if ($.isPlainObject(object[camelCaseValue]) && (depth != maxDepth)) {
+                            if ($.isPlainObject(object[camelCaseValue]) && (depth !== maxDepth)) {
                                 object = object[camelCaseValue];
                             } else if (object[camelCaseValue] !== undefined) {
                                 found = object[camelCaseValue];
 
                                 return false;
-                            } else if ($.isPlainObject(object[value]) && (depth != maxDepth)) {
+                            } else if ($.isPlainObject(object[value]) && (depth !== maxDepth)) {
                                 object = object[value];
                             } else if (object[value] !== undefined) {
                                 found = object[value];

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1424,7 +1424,7 @@
                                     return;
                                 }
 
-                                if (pressedKey == keys.leftArrow) {
+                                if (pressedKey === keys.leftArrow) {
                                     // activate previous label
                                     if ((isFocused || caretAtStart) && !hasActiveLabel) {
                                         module.verbose('Selecting previous label');
@@ -1446,7 +1446,7 @@
                                         }
                                         event.preventDefault();
                                     }
-                                } else if (pressedKey == keys.rightArrow) {
+                                } else if (pressedKey === keys.rightArrow) {
                                     // activate first label
                                     if (isFocused && !hasActiveLabel) {
                                         $label.first().addClass(className.active);
@@ -1476,7 +1476,7 @@
                                         }
                                         event.preventDefault();
                                     }
-                                } else if (pressedKey == keys.deleteKey || pressedKey == keys.backspace) {
+                                } else if (pressedKey === keys.deleteKey || pressedKey === keys.backspace) {
                                     if (hasActiveLabel) {
                                         module.verbose('Removing active labels');
                                         if (isLastLabel) {
@@ -1490,7 +1490,7 @@
                                             module.show();
                                         }
                                         event.preventDefault();
-                                    } else if (caretAtStart && !isSelectedSearch && !hasActiveLabel && pressedKey == keys.backspace) {
+                                    } else if (caretAtStart && !isSelectedSearch && !hasActiveLabel && pressedKey === keys.backspace) {
                                         module.verbose('Removing last label on input backspace');
                                         $activeLabel = $label.last().addClass(className.active);
                                         module.remove.activeLabels($activeLabel);
@@ -1527,7 +1527,7 @@
                                 hasSelectedItem       = $selectedItem.length > 0,
                                 selectedIsSelectable  = $selectedItem.not(selector.unselectable).length > 0,
                                 delimiterPressed      = event.key === settings.delimiter && module.is.multiple(),
-                                isAdditionWithoutMenu = settings.allowAdditions && (pressedKey == keys.enter || delimiterPressed),
+                                isAdditionWithoutMenu = settings.allowAdditions && (pressedKey === keys.enter || delimiterPressed),
                                 $nextItem,
                                 isSubMenuItem
                             ;
@@ -1548,8 +1548,8 @@
                             // visible menu keyboard shortcuts
                             if (module.is.visible()) {
                                 // enter (select or open sub-menu)
-                                if (pressedKey == keys.enter || delimiterPressed) {
-                                    if (pressedKey == keys.enter && hasSelectedItem && hasSubMenu && !settings.allowCategorySelection) {
+                                if (pressedKey === keys.enter || delimiterPressed) {
+                                    if (pressedKey === keys.enter && hasSelectedItem && hasSubMenu && !settings.allowCategorySelection) {
                                         module.verbose('Pressed enter on unselectable category, opening sub menu');
                                         pressedKey = keys.rightArrow;
                                     } else if (selectedIsSelectable) {
@@ -1567,7 +1567,7 @@
 
                                 // sub-menu actions
                                 if (hasSelectedItem) {
-                                    if (pressedKey == keys.leftArrow) {
+                                    if (pressedKey === keys.leftArrow) {
                                         isSubMenuItem = $parentMenu[0] !== $menu[0];
 
                                         if (isSubMenuItem) {
@@ -1585,7 +1585,7 @@
                                     }
 
                                     // right arrow (show sub-menu)
-                                    if (pressedKey == keys.rightArrow) {
+                                    if (pressedKey === keys.rightArrow) {
                                         if (hasSubMenu) {
                                             module.verbose('Right key pressed, opening sub-menu');
                                             module.animate.show(false, $subMenu);
@@ -1602,7 +1602,7 @@
                                 }
 
                                 // up arrow (traverse menu up)
-                                if (pressedKey == keys.upArrow) {
+                                if (pressedKey === keys.upArrow) {
                                     $nextItem = hasSelectedItem && inVisibleMenu
                                         ? $selectedItem.prevAll(selector.item + ':not(' + selector.unselectable + ')').eq(0)
                                         : $item.eq(0);
@@ -1629,7 +1629,7 @@
                                 }
 
                                 // down arrow (traverse menu down)
-                                if (pressedKey == keys.downArrow) {
+                                if (pressedKey === keys.downArrow) {
                                     $nextItem = hasSelectedItem && inVisibleMenu
                                         ? $selectedItem.nextAll(selector.item + ':not(' + selector.unselectable + ')').eq(0)
                                         : $item.eq(0);
@@ -1656,28 +1656,28 @@
                                 }
 
                                 // page down (show next page)
-                                if (pressedKey == keys.pageUp) {
+                                if (pressedKey === keys.pageUp) {
                                     module.scrollPage('up');
                                     event.preventDefault();
                                 }
-                                if (pressedKey == keys.pageDown) {
+                                if (pressedKey === keys.pageDown) {
                                     module.scrollPage('down');
                                     event.preventDefault();
                                 }
 
                                 // escape (close menu)
-                                if (pressedKey == keys.escape) {
+                                if (pressedKey === keys.escape) {
                                     module.verbose('Escape key pressed, closing dropdown');
                                     module.hide();
                                     event.stopPropagation();
                                 }
                             } else {
                                 // delimiter key
-                                if (pressedKey == keys.enter || delimiterPressed) {
+                                if (pressedKey === keys.enter || delimiterPressed) {
                                     event.preventDefault();
                                 }
                                 // down arrow (open menu)
-                                if (pressedKey == keys.downArrow && !module.is.visible()) {
+                                if (pressedKey === keys.downArrow && !module.is.visible()) {
                                     module.verbose('Down key pressed, showing dropdown');
                                     module.show();
                                     event.preventDefault();

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -663,12 +663,12 @@
                                 ;
                             }
                         } else {
-                            if (settings.on == 'click') {
+                            if (settings.on === 'click') {
                                 $module
                                     .on('click' + eventNamespace, selector.icon, module.event.icon.click)
                                     .on('click' + eventNamespace, module.event.test.toggle)
                                 ;
-                            } else if (settings.on == 'hover') {
+                            } else if (settings.on === 'hover') {
                                 $module
                                     .on('mouseenter' + eventNamespace, module.delay.show)
                                     .on('mouseleave' + eventNamespace, module.delay.hide)
@@ -1818,7 +1818,7 @@
                         return $module.data(metadata.defaultValue);
                     },
                     placeholderText: function () {
-                        if (settings.placeholder != 'auto' && typeof settings.placeholder === 'string') {
+                        if (settings.placeholder !== 'auto' && typeof settings.placeholder === 'string') {
                             return settings.placeholder;
                         }
 
@@ -2368,7 +2368,7 @@
                         currentScroll = $menu.scrollTop(),
                         itemHeight    = $item.eq(0).outerHeight(),
                         itemsPerPage  = Math.floor(menuHeight / itemHeight),
-                        newScroll     = direction == 'up'
+                        newScroll     = direction === 'up'
                             ? currentScroll - (itemHeight * itemsPerPage)
                             : currentScroll + (itemHeight * itemsPerPage),
                         $selectableItem = $item.not(selector.unselectable),
@@ -2376,15 +2376,15 @@
                         $nextSelectedItem,
                         elementIndex
                     ;
-                    elementIndex = direction == 'up'
+                    elementIndex = direction === 'up'
                         ? $selectableItem.index($currentItem) - itemsPerPage
                         : $selectableItem.index($currentItem) + itemsPerPage;
-                    isWithinRange = direction == 'up'
+                    isWithinRange = direction === 'up'
                         ? elementIndex >= 0
                         : elementIndex < $selectableItem.length;
                     $nextSelectedItem = isWithinRange
                         ? $selectableItem.eq(elementIndex)
-                        : (direction == 'up'
+                        : (direction === 'up'
                             ? $selectableItem.first()
                             : $selectableItem.last());
                     if ($nextSelectedItem.length > 0) {
@@ -3458,7 +3458,7 @@
                                 : false
                         ;
 
-                        return overflowY == 'auto' || overflowY == 'scroll';
+                        return overflowY === 'auto' || overflowY === 'scroll';
                     },
                     horizontallyScrollableContext: function () {
                         var
@@ -3467,7 +3467,7 @@
                                 : false
                         ;
 
-                        return overflowX == 'auto' || overflowX == 'scroll';
+                        return overflowX === 'auto' || overflowX === 'scroll';
                     },
                 },
 

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1413,7 +1413,7 @@
                                     hasActiveLabel    = $activeLabel.length > 0,
                                     hasMultipleActive = $activeLabel.length > 1,
                                     isFirstLabel      = labelIndex === 0,
-                                    isLastLabel       = labelIndex + 1 == labelCount,
+                                    isLastLabel       = labelIndex + 1 === labelCount,
                                     isSearch          = module.is.searchSelection(),
                                     isFocusedOnSearch = module.is.focusedOnSearch(),
                                     isFocused         = module.is.focused(),

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1425,7 +1425,7 @@
                                 }
 
                                 switch (pressedKey) {
-                                    case keys.leftArrow:
+                                    case keys.leftArrow: {
                                         // activate previous label
                                         if ((isFocused || caretAtStart) && !hasActiveLabel) {
                                             module.verbose('Selecting previous label');
@@ -1449,8 +1449,8 @@
                                         }
 
                                         break;
-
-                                    case keys.rightArrow:
+                                    }
+                                    case keys.rightArrow: {
                                         // activate first label
                                         if (isFocused && !hasActiveLabel) {
                                             $label.first().addClass(className.active);
@@ -1482,9 +1482,9 @@
                                         }
 
                                         break;
-
+                                    }
                                     case keys.deleteKey:
-                                    case keys.backspace:
+                                    case keys.backspace: {
                                         if (hasActiveLabel) {
                                             module.verbose('Removing active labels');
                                             if (isLastLabel) {
@@ -1508,9 +1508,10 @@
                                         }
 
                                         break;
-
-                                    default:
+                                    }
+                                    default: {
                                         $activeLabel.removeClass(className.active);
+                                    }
                                 }
                             }
                         },

--- a/src/definitions/modules/embed.js
+++ b/src/definitions/modules/embed.js
@@ -488,17 +488,17 @@
                         query = query.split(/[ .]/);
                         maxDepth = query.length - 1;
                         $.each(query, function (depth, value) {
-                            var camelCaseValue = depth != maxDepth
+                            var camelCaseValue = depth !== maxDepth
                                 ? value + query[depth + 1].charAt(0).toUpperCase() + query[depth + 1].slice(1)
                                 : query
                             ;
-                            if ($.isPlainObject(object[camelCaseValue]) && (depth != maxDepth)) {
+                            if ($.isPlainObject(object[camelCaseValue]) && (depth !== maxDepth)) {
                                 object = object[camelCaseValue];
                             } else if (object[camelCaseValue] !== undefined) {
                                 found = object[camelCaseValue];
 
                                 return false;
-                            } else if ($.isPlainObject(object[value]) && (depth != maxDepth)) {
+                            } else if ($.isPlainObject(object[value]) && (depth !== maxDepth)) {
                                 object = object[value];
                             } else if (object[value] !== undefined) {
                                 found = object[value];

--- a/src/definitions/modules/embed.js
+++ b/src/definitions/modules/embed.js
@@ -369,7 +369,7 @@
 
                 is: {
                     video: function () {
-                        return module.get.type() == 'video';
+                        return module.get.type() === 'video';
                     },
                 },
 

--- a/src/definitions/modules/flyout.js
+++ b/src/definitions/modules/flyout.js
@@ -675,7 +675,7 @@
                     $otherFlyouts
                         .flyout('hide', function () {
                             callbackCount++;
-                            if (callbackCount == flyoutCount) {
+                            if (callbackCount === flyoutCount) {
                                 callback();
                             }
                         })
@@ -715,7 +715,7 @@
                         module.set.dimmed();
                     };
                     transitionEnd = function (event) {
-                        if (event.target == $module[0]) {
+                        if (event.target === $module[0]) {
                             $module.off(transitionEvent + elementNamespace, transitionEnd);
                             module.remove.animating();
                             callback.call(element);
@@ -756,7 +756,7 @@
                         module.remove.visible();
                     };
                     transitionEnd = function (event) {
-                        if (event.target == $module[0]) {
+                        if (event.target === $module[0]) {
                             $module.off(transitionEvent + elementNamespace, transitionEnd);
                             module.remove.animating();
                             module.remove.closing();

--- a/src/definitions/modules/flyout.js
+++ b/src/definitions/modules/flyout.js
@@ -166,7 +166,7 @@
                         module.setup.cache();
                     });
 
-                    if (module.get.direction() == 'left' || module.get.direction() == 'right') {
+                    if (module.get.direction() === 'left' || module.get.direction() === 'right') {
                         module.setup.heights();
                         module.bind.resize();
                     }
@@ -440,7 +440,7 @@
                                 + '   -webkit-transform: translate3d(' + distance[direction] + 'px, 0, 0);'
                                 + '           transform: translate3d(' + distance[direction] + 'px, 0, 0);'
                                 + ' }';
-                        } else if (direction === 'top' || direction == 'bottom') {
+                        } else if (direction === 'top' || direction === 'bottom') {
                             style += ''
                                 + ' .ui.visible.' + direction + '.flyout ~ .fixed,'
                                 + ' .ui.visible.' + direction + '.flyout ~ .pusher {'
@@ -459,7 +459,7 @@
                                     + '   -webkit-transform: translate3d(' + distance[direction] + 'px, 0, 0);'
                                     + '           transform: translate3d(' + distance[direction] + 'px, 0, 0);'
                                     + ' }';
-                            } else if (direction === 'top' || direction == 'bottom') {
+                            } else if (direction === 'top' || direction === 'bottom') {
                                 style += ''
                                     + ' body.pushable > .ui.visible.' + direction + '.flyout ~ .pusher::after {'
                                     + '   -webkit-transform: translate3d(0, ' + distance[direction] + 'px, 0);'

--- a/src/definitions/modules/flyout.js
+++ b/src/definitions/modules/flyout.js
@@ -1242,17 +1242,17 @@
                         query = query.split(/[ .]/);
                         maxDepth = query.length - 1;
                         $.each(query, function (depth, value) {
-                            var camelCaseValue = depth != maxDepth
+                            var camelCaseValue = depth !== maxDepth
                                 ? value + query[depth + 1].charAt(0).toUpperCase() + query[depth + 1].slice(1)
                                 : query
                             ;
-                            if ($.isPlainObject(object[camelCaseValue]) && (depth != maxDepth)) {
+                            if ($.isPlainObject(object[camelCaseValue]) && (depth !== maxDepth)) {
                                 object = object[camelCaseValue];
                             } else if (object[camelCaseValue] !== undefined) {
                                 found = object[camelCaseValue];
 
                                 return false;
-                            } else if ($.isPlainObject(object[value]) && (depth != maxDepth)) {
+                            } else if ($.isPlainObject(object[value]) && (depth !== maxDepth)) {
                                 object = object[value];
                             } else if (object[value] !== undefined) {
                                 found = object[value];

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -1248,16 +1248,16 @@
                         query = query.split(/[ .]/);
                         maxDepth = query.length - 1;
                         $.each(query, function (depth, value) {
-                            var camelCaseValue = depth != maxDepth
+                            var camelCaseValue = depth !== maxDepth
                                 ? value + query[depth + 1].charAt(0).toUpperCase() + query[depth + 1].slice(1)
                                 : query;
-                            if ($.isPlainObject(object[camelCaseValue]) && (depth != maxDepth)) {
+                            if ($.isPlainObject(object[camelCaseValue]) && (depth !== maxDepth)) {
                                 object = object[camelCaseValue];
                             } else if (object[camelCaseValue] !== undefined) {
                                 found = object[camelCaseValue];
 
                                 return false;
-                            } else if ($.isPlainObject(object[value]) && (depth != maxDepth)) {
+                            } else if ($.isPlainObject(object[value]) && (depth !== maxDepth)) {
                                 object = object[value];
                             } else if (object[value] !== undefined) {
                                 found = object[value];

--- a/src/definitions/modules/nag.js
+++ b/src/definitions/modules/nag.js
@@ -279,7 +279,7 @@
                                 storedValue = null;
                             }
                         }
-                        if (storedValue == 'undefined' || storedValue == 'null' || storedValue === undefined || storedValue === null) {
+                        if (storedValue === 'undefined' || storedValue === 'null' || storedValue === undefined || storedValue === null) {
                             storedValue = undefined;
                         }
 

--- a/src/definitions/modules/nag.js
+++ b/src/definitions/modules/nag.js
@@ -409,17 +409,17 @@
                         query = query.split(/[ .]/);
                         maxDepth = query.length - 1;
                         $.each(query, function (depth, value) {
-                            var camelCaseValue = depth != maxDepth
+                            var camelCaseValue = depth !== maxDepth
                                 ? value + query[depth + 1].charAt(0).toUpperCase() + query[depth + 1].slice(1)
                                 : query
                             ;
-                            if ($.isPlainObject(object[camelCaseValue]) && (depth != maxDepth)) {
+                            if ($.isPlainObject(object[camelCaseValue]) && (depth !== maxDepth)) {
                                 object = object[camelCaseValue];
                             } else if (object[camelCaseValue] !== undefined) {
                                 found = object[camelCaseValue];
 
                                 return false;
-                            } else if ($.isPlainObject(object[value]) && (depth != maxDepth)) {
+                            } else if ($.isPlainObject(object[value]) && (depth !== maxDepth)) {
                                 object = object[value];
                             } else if (object[value] !== undefined) {
                                 found = object[value];

--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -1256,17 +1256,17 @@
                         query = query.split(/[ .]/);
                         maxDepth = query.length - 1;
                         $.each(query, function (depth, value) {
-                            var camelCaseValue = depth != maxDepth
+                            var camelCaseValue = depth !== maxDepth
                                 ? value + query[depth + 1].charAt(0).toUpperCase() + query[depth + 1].slice(1)
                                 : query
                             ;
-                            if ($.isPlainObject(object[camelCaseValue]) && (depth != maxDepth)) {
+                            if ($.isPlainObject(object[camelCaseValue]) && (depth !== maxDepth)) {
                                 object = object[camelCaseValue];
                             } else if (object[camelCaseValue] !== undefined) {
                                 found = object[camelCaseValue];
 
                                 return false;
-                            } else if ($.isPlainObject(object[value]) && (depth != maxDepth)) {
+                            } else if ($.isPlainObject(object[value]) && (depth !== maxDepth)) {
                                 object = object[value];
                             } else if (object[value] !== undefined) {
                                 found = object[value];

--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -587,10 +587,10 @@
                         return id;
                     },
                     startEvent: function () {
-                        if (settings.on == 'hover') {
+                        if (settings.on === 'hover') {
                             return 'mouseenter';
                         }
-                        if (settings.on == 'focus') {
+                        if (settings.on === 'focus') {
                             return 'focus';
                         }
 
@@ -600,10 +600,10 @@
                         return 'scroll';
                     },
                     endEvent: function () {
-                        if (settings.on == 'hover') {
+                        if (settings.on === 'hover') {
                             return 'mouseleave';
                         }
-                        if (settings.on == 'focus') {
+                        if (settings.on === 'focus') {
                             return 'blur';
                         }
 
@@ -698,7 +698,7 @@
                                 'bottom left': 'left center',
                                 'left center': 'top left',
                             },
-                            adjacentsAvailable = verticalPosition == 'top' || verticalPosition == 'bottom',
+                            adjacentsAvailable = verticalPosition === 'top' || verticalPosition === 'bottom',
                             oppositeTried = false,
                             adjacentTried = false,
                             nextPosition  = false
@@ -798,7 +798,7 @@
 
                         if (module.is.rtl()) {
                             position = position.replace(/left|right/g, function (match) {
-                                return match == 'left'
+                                return match === 'left'
                                     ? 'right'
                                     : 'left';
                             });
@@ -980,12 +980,12 @@
                 bind: {
                     events: function () {
                         module.debug('Binding popup events to module');
-                        if (settings.on == 'click') {
+                        if (settings.on === 'click') {
                             $module
                                 .on(clickEvent + eventNamespace, module.toggle)
                             ;
                         }
-                        if (settings.on == 'hover') {
+                        if (settings.on === 'hover') {
                             $module
                                 .on('touchstart' + eventNamespace, module.event.touchstart)
                             ;
@@ -1011,12 +1011,12 @@
                         }
                     },
                     close: function () {
-                        if (settings.hideOnScroll === true || (settings.hideOnScroll == 'auto' && settings.on != 'click')) {
+                        if (settings.hideOnScroll === true || (settings.hideOnScroll === 'auto' && settings.on !== 'click')) {
                             module.bind.closeOnScroll();
                         }
                         if (module.is.closable()) {
                             module.bind.clickaway();
-                        } else if (settings.on == 'hover' && openedWithTouch) {
+                        } else if (settings.on === 'hover' && openedWithTouch) {
                             module.bind.touchClose();
                         }
                     },
@@ -1079,8 +1079,8 @@
 
                 is: {
                     closable: function () {
-                        if (settings.closable == 'auto') {
-                            return settings.on != 'hover';
+                        if (settings.closable === 'auto') {
+                            return settings.on !== 'hover';
                         }
 
                         return settings.closable;

--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -811,7 +811,7 @@
                         }
 
                         switch (position) {
-                            case 'top left':
+                            case 'top left': {
                                 positioning = {
                                     top: 'auto',
                                     bottom: parent.height - target.top + distanceAway,
@@ -820,7 +820,8 @@
                                 };
 
                                 break;
-                            case 'top center':
+                            }
+                            case 'top center': {
                                 positioning = {
                                     bottom: parent.height - target.top + distanceAway,
                                     left: target.left + (target.width / 2) - (popup.width / 2) + offset,
@@ -829,7 +830,8 @@
                                 };
 
                                 break;
-                            case 'top right':
+                            }
+                            case 'top right': {
                                 positioning = {
                                     bottom: parent.height - target.top + distanceAway,
                                     right: parent.width - target.left - target.width - offset,
@@ -838,7 +840,8 @@
                                 };
 
                                 break;
-                            case 'left center':
+                            }
+                            case 'left center': {
                                 positioning = {
                                     top: target.top + (target.height / 2) - (popup.height / 2) + offset,
                                     right: parent.width - target.left + distanceAway,
@@ -847,7 +850,8 @@
                                 };
 
                                 break;
-                            case 'right center':
+                            }
+                            case 'right center': {
                                 positioning = {
                                     top: target.top + (target.height / 2) - (popup.height / 2) + offset,
                                     left: target.left + target.width + distanceAway,
@@ -856,7 +860,8 @@
                                 };
 
                                 break;
-                            case 'bottom left':
+                            }
+                            case 'bottom left': {
                                 positioning = {
                                     top: target.top + target.height + distanceAway,
                                     left: target.left + offset,
@@ -865,7 +870,8 @@
                                 };
 
                                 break;
-                            case 'bottom center':
+                            }
+                            case 'bottom center': {
                                 positioning = {
                                     top: target.top + target.height + distanceAway,
                                     left: target.left + (target.width / 2) - (popup.width / 2) + offset,
@@ -874,7 +880,8 @@
                                 };
 
                                 break;
-                            case 'bottom right':
+                            }
+                            case 'bottom right': {
                                 positioning = {
                                     top: target.top + target.height + distanceAway,
                                     right: parent.width - target.left - target.width - offset,
@@ -883,6 +890,7 @@
                                 };
 
                                 break;
+                            }
                         }
                         if (positioning === undefined) {
                             module.error(error.invalidPosition, position);

--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -212,7 +212,7 @@
                         [].forEach.call(mutations, function (mutation) {
                             if (mutation.removedNodes) {
                                 [].forEach.call(mutation.removedNodes, function (node) {
-                                    if (node == element || $(node).find(element).length > 0) {
+                                    if (node === element || $(node).find(element).length > 0) {
                                         module.debug('Element removed from DOM, tearing down events');
                                         module.destroy();
                                     }
@@ -497,7 +497,7 @@
                         var
                             $popupOffsetParent = module.get.offsetParent($popup),
                             targetElement      = $target[0],
-                            isWindowEl         = $boundary[0] == window,
+                            isWindowEl         = $boundary[0] === window,
                             targetOffset       = $target.offset(),
                             parentOffset       = settings.inline || (settings.popup && settings.movePopup)
                                 ? $target.offsetParent().offset()
@@ -806,7 +806,7 @@
                         }
 
                         // if last attempt use specified last resort position
-                        if (searchDepth == settings.maxSearchDepth && typeof settings.lastResort === 'string') {
+                        if (searchDepth === settings.maxSearchDepth && typeof settings.lastResort === 'string') {
                             position = settings.lastResort;
                         }
 

--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -764,11 +764,11 @@
 
                         if (module.should.centerArrow(calculations)) {
                             module.verbose('Adjusting offset to center arrow on small target element');
-                            if (position == 'top left' || position == 'bottom left') {
+                            if (position === 'top left' || position === 'bottom left') {
                                 offset += target.width / 2;
                                 offset -= settings.arrowPixelsFromEdge;
                             }
-                            if (position == 'top right' || position == 'bottom right') {
+                            if (position === 'top right' || position === 'bottom right') {
                                 offset -= target.width / 2;
                                 offset += settings.arrowPixelsFromEdge;
                             }
@@ -782,10 +782,10 @@
 
                         if (settings.inline) {
                             module.debug('Adding margin to calculation', target.margin);
-                            if (position == 'left center' || position == 'right center') {
+                            if (position === 'left center' || position === 'right center') {
                                 offset += target.margin.top;
                                 distanceAway += -target.margin.left;
-                            } else if (position == 'top left' || position == 'top center' || position == 'top right') {
+                            } else if (position === 'top left' || position === 'top center' || position === 'top right') {
                                 offset += target.margin.left;
                                 distanceAway -= target.margin.top;
                             } else {

--- a/src/definitions/modules/progress.js
+++ b/src/definitions/modules/progress.js
@@ -862,17 +862,17 @@
                         query = query.split(/[ .]/);
                         maxDepth = query.length - 1;
                         $.each(query, function (depth, value) {
-                            var camelCaseValue = depth != maxDepth
+                            var camelCaseValue = depth !== maxDepth
                                 ? value + query[depth + 1].charAt(0).toUpperCase() + query[depth + 1].slice(1)
                                 : query
                             ;
-                            if ($.isPlainObject(object[camelCaseValue]) && (depth != maxDepth)) {
+                            if ($.isPlainObject(object[camelCaseValue]) && (depth !== maxDepth)) {
                                 object = object[camelCaseValue];
                             } else if (object[camelCaseValue] !== undefined) {
                                 found = object[camelCaseValue];
 
                                 return false;
-                            } else if ($.isPlainObject(object[value]) && (depth != maxDepth)) {
+                            } else if ($.isPlainObject(object[value]) && (depth !== maxDepth)) {
                                 object = object[value];
                             } else if (object[value] !== undefined) {
                                 found = object[value];

--- a/src/definitions/modules/progress.js
+++ b/src/definitions/modules/progress.js
@@ -309,7 +309,7 @@
                     },
 
                     updateInterval: function () {
-                        if (settings.updateInterval == 'auto') {
+                        if (settings.updateInterval === 'auto') {
                             return settings.duration;
                         }
 
@@ -610,10 +610,10 @@
                             var $progress = $(element);
                             if (text !== undefined) {
                                 $progress.text(module.get.text(text, index));
-                            } else if (settings.label == 'ratio' && module.has.total()) {
+                            } else if (settings.label === 'ratio' && module.has.total()) {
                                 module.verbose('Adding ratio to bar label');
                                 $progress.text(module.get.text(settings.text.ratio, index));
-                            } else if (settings.label == 'percent') {
+                            } else if (settings.label === 'percent') {
                                 module.verbose('Adding percentage to bar label');
                                 $progress.text(module.get.text(settings.text.percent, index));
                             }

--- a/src/definitions/modules/progress.js
+++ b/src/definitions/modules/progress.js
@@ -460,7 +460,7 @@
                                 if (isMultiple && allZero) {
                                     $bar.css('background', 'transparent');
                                 }
-                                if (firstNonZeroIndex == -1) {
+                                if (firstNonZeroIndex === -1) {
                                     firstNonZeroIndex = index;
                                 }
                                 lastNonZeroIndex = index;
@@ -475,10 +475,10 @@
                         values.forEach(function (_, index) {
                             var $bar = $($bars[index]);
                             $bar.css({
-                                borderTopLeftRadius: index == firstNonZeroIndex ? '' : '0',
-                                borderBottomLeftRadius: index == firstNonZeroIndex ? '' : '0',
-                                borderTopRightRadius: index == lastNonZeroIndex ? '' : '0',
-                                borderBottomRightRadius: index == lastNonZeroIndex ? '' : '0',
+                                borderTopLeftRadius: index === firstNonZeroIndex ? '' : '0',
+                                borderBottomLeftRadius: index === firstNonZeroIndex ? '' : '0',
+                                borderTopRightRadius: index === lastNonZeroIndex ? '' : '0',
+                                borderBottomRightRadius: index === lastNonZeroIndex ? '' : '0',
                             });
                         });
                         $module

--- a/src/definitions/modules/rating.js
+++ b/src/definitions/modules/rating.js
@@ -414,17 +414,17 @@
                         query = query.split(/[ .]/);
                         maxDepth = query.length - 1;
                         $.each(query, function (depth, value) {
-                            var camelCaseValue = depth != maxDepth
+                            var camelCaseValue = depth !== maxDepth
                                 ? value + query[depth + 1].charAt(0).toUpperCase() + query[depth + 1].slice(1)
                                 : query
                             ;
-                            if ($.isPlainObject(object[camelCaseValue]) && (depth != maxDepth)) {
+                            if ($.isPlainObject(object[camelCaseValue]) && (depth !== maxDepth)) {
                                 object = object[camelCaseValue];
                             } else if (object[camelCaseValue] !== undefined) {
                                 found = object[camelCaseValue];
 
                                 return false;
-                            } else if ($.isPlainObject(object[value]) && (depth != maxDepth)) {
+                            } else if ($.isPlainObject(object[value]) && (depth !== maxDepth)) {
                                 object = object[value];
                             } else if (object[value] !== undefined) {
                                 found = object[value];

--- a/src/definitions/modules/rating.js
+++ b/src/definitions/modules/rating.js
@@ -147,7 +147,7 @@
                                 ? $icon.length === 1
                                 : settings.clearable
                         ;
-                        if (canClear && currentRating == rating) {
+                        if (canClear && currentRating === rating) {
                             module.clearRating();
                         } else {
                             module.set.rating(rating);

--- a/src/definitions/modules/rating.js
+++ b/src/definitions/modules/rating.js
@@ -143,7 +143,7 @@
                             $activeIcon   = $(this),
                             currentRating = module.get.rating(),
                             rating        = $icon.index($activeIcon) + 1,
-                            canClear      = settings.clearable == 'auto'
+                            canClear      = settings.clearable === 'auto'
                                 ? $icon.length === 1
                                 : settings.clearable
                         ;

--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -237,7 +237,7 @@
                             if (href) {
                                 event.preventDefault();
                                 module.verbose('Opening search link found in result', $link);
-                                if (target == '_blank' || event.ctrlKey) {
+                                if (target === '_blank' || event.ctrlKey) {
                                     window.open(href);
                                 } else {
                                     window.location.href = href;
@@ -596,7 +596,7 @@
                             module.debug('Using specified max results', results);
                             results = results.slice(0, settings.maxResults);
                         }
-                        if (settings.type == 'category') {
+                        if (settings.type === 'category') {
                             results = module.create.categoryResults(results);
                         }
                         searchHTML = module.generateResults({
@@ -1052,7 +1052,7 @@
                     if (isProperObject || isProperArray) {
                         if (settings.maxResults > 0) {
                             if (isProperObject) {
-                                if (settings.type == 'standard') {
+                                if (settings.type === 'standard') {
                                     module.error(error.maxResults);
                                 }
                             } else {

--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -634,9 +634,9 @@
                             // avoid duplicates when pushing results
                             addResult = function (array, result) {
                                 var
-                                    notResult      = $.inArray(result, results) == -1,
-                                    notFuzzyResult = $.inArray(result, fuzzyResults) == -1,
-                                    notExactResults = $.inArray(result, exactResults) == -1
+                                    notResult      = $.inArray(result, results) === -1,
+                                    notFuzzyResult = $.inArray(result, fuzzyResults) === -1,
+                                    notExactResults = $.inArray(result, exactResults) === -1
                                 ;
                                 if (notResult && notFuzzyResult && notExactResults) {
                                     array.push(result);

--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -289,7 +289,7 @@
                         newIndex
                     ;
                     // search shortcuts
-                    if (keyCode == keys.escape) {
+                    if (keyCode === keys.escape) {
                         if (!module.is.visible()) {
                             module.verbose('Escape key pressed, blurring search field');
                             $prompt.trigger('blur');
@@ -300,7 +300,7 @@
                         resultsDismissed = true;
                     }
                     if (module.is.visible()) {
-                        if (keyCode == keys.enter) {
+                        if (keyCode === keys.enter) {
                             module.verbose('Enter key pressed, selecting active result');
                             if ($result.filter('.' + className.active).length > 0) {
                                 module.event.result.click.call($result.filter('.' + className.active), event);
@@ -308,7 +308,7 @@
 
                                 return false;
                             }
-                        } else if (keyCode == keys.upArrow && hasActiveResult) {
+                        } else if (keyCode === keys.upArrow && hasActiveResult) {
                             module.verbose('Up key pressed, changing active result');
                             newIndex = currentIndex - 1 < 0
                                 ? currentIndex
@@ -325,7 +325,7 @@
                             ;
                             module.ensureVisible($result.eq(newIndex));
                             event.preventDefault();
-                        } else if (keyCode == keys.downArrow) {
+                        } else if (keyCode === keys.downArrow) {
                             module.verbose('Down key pressed, changing active result');
                             newIndex = currentIndex + 1 >= resultSize
                                 ? currentIndex
@@ -345,7 +345,7 @@
                         }
                     } else {
                         // query shortcuts
-                        if (keyCode == keys.enter) {
+                        if (keyCode === keys.enter) {
                             module.verbose('Enter key pressed, executing query');
                             module.query();
                             module.set.buttonPressed();

--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -1190,17 +1190,17 @@
                         query = query.split(/[ .]/);
                         maxDepth = query.length - 1;
                         $.each(query, function (depth, value) {
-                            var camelCaseValue = depth != maxDepth
+                            var camelCaseValue = depth !== maxDepth
                                 ? value + query[depth + 1].charAt(0).toUpperCase() + query[depth + 1].slice(1)
                                 : query
                             ;
-                            if ($.isPlainObject(object[camelCaseValue]) && (depth != maxDepth)) {
+                            if ($.isPlainObject(object[camelCaseValue]) && (depth !== maxDepth)) {
                                 object = object[camelCaseValue];
                             } else if (object[camelCaseValue] !== undefined) {
                                 found = object[camelCaseValue];
 
                                 return false;
-                            } else if ($.isPlainObject(object[value]) && (depth != maxDepth)) {
+                            } else if ($.isPlainObject(object[value]) && (depth !== maxDepth)) {
                                 object = object[value];
                             } else if (object[value] !== undefined) {
                                 found = object[value];

--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -782,7 +782,7 @@
                             html = $results.html()
                         ;
 
-                        return html != '';
+                        return html !== '';
                     },
                 },
 

--- a/src/definitions/modules/shape.js
+++ b/src/definitions/modules/shape.js
@@ -704,17 +704,17 @@
                         query = query.split(/[ .]/);
                         maxDepth = query.length - 1;
                         $.each(query, function (depth, value) {
-                            var camelCaseValue = depth != maxDepth
+                            var camelCaseValue = depth !== maxDepth
                                 ? value + query[depth + 1].charAt(0).toUpperCase() + query[depth + 1].slice(1)
                                 : query
                             ;
-                            if ($.isPlainObject(object[camelCaseValue]) && (depth != maxDepth)) {
+                            if ($.isPlainObject(object[camelCaseValue]) && (depth !== maxDepth)) {
                                 object = object[camelCaseValue];
                             } else if (object[camelCaseValue] !== undefined) {
                                 found = object[camelCaseValue];
 
                                 return false;
-                            } else if ($.isPlainObject(object[value]) && (depth != maxDepth)) {
+                            } else if ($.isPlainObject(object[value]) && (depth !== maxDepth)) {
                                 object = object[value];
                             } else if (object[value] !== undefined) {
                                 found = object[value];

--- a/src/definitions/modules/shape.js
+++ b/src/definitions/modules/shape.js
@@ -185,7 +185,7 @@
 
                 is: {
                     complete: function () {
-                        return $side.filter('.' + className.active)[0] == $nextSide[0];
+                        return $side.filter('.' + className.active)[0] === $nextSide[0];
                     },
                     animating: function () {
                         return $module.hasClass(className.animating);

--- a/src/definitions/modules/sidebar.js
+++ b/src/definitions/modules/sidebar.js
@@ -456,7 +456,7 @@
                     $otherSidebars
                         .sidebar('hide', function () {
                             callbackCount++;
-                            if (callbackCount == sidebarCount) {
+                            if (callbackCount === sidebarCount) {
                                 callback();
                             }
                         })
@@ -504,7 +504,7 @@
                         module.set.dimmed();
                     };
                     transitionEnd = function (event) {
-                        if (event.target == $transition[0]) {
+                        if (event.target === $transition[0]) {
                             $transition.off(transitionEvent + elementNamespace, transitionEnd);
                             module.remove.animating();
                             callback.call(element);
@@ -544,7 +544,7 @@
                         module.remove.visible();
                     };
                     transitionEnd = function (event) {
-                        if (event.target == $transition[0]) {
+                        if (event.target === $transition[0]) {
                             $transition.off(transitionEvent + elementNamespace, transitionEnd);
                             module.remove.animating();
                             module.remove.closing();

--- a/src/definitions/modules/sidebar.js
+++ b/src/definitions/modules/sidebar.js
@@ -249,7 +249,7 @@
                                 + '   -webkit-transform: translate3d(' + distance[direction] + 'px, 0, 0);'
                                 + '           transform: translate3d(' + distance[direction] + 'px, 0, 0);'
                                 + ' }';
-                        } else if (direction === 'top' || direction == 'bottom') {
+                        } else if (direction === 'top' || direction === 'bottom') {
                             style += ''
                                 + ' .ui.visible.' + direction + '.sidebar ~ .fixed,'
                                 + ' .ui.visible.' + direction + '.sidebar ~ .pusher {'
@@ -268,7 +268,7 @@
                                     + '   -webkit-transform: translate3d(' + distance[direction] + 'px, 0, 0);'
                                     + '           transform: translate3d(' + distance[direction] + 'px, 0, 0);'
                                     + ' }';
-                            } else if (direction === 'top' || direction == 'bottom') {
+                            } else if (direction === 'top' || direction === 'bottom') {
                                 style += ''
                                     + ' body.pushable > .ui.visible.' + direction + '.sidebar ~ .pusher::after {'
                                     + '   -webkit-transform: translate3d(0, ' + distance[direction] + 'px, 0);'
@@ -399,7 +399,7 @@
                             module.debug('Other sidebars currently visible');
                             if (settings.exclusive) {
                                 // if not overlay queue animation after hide
-                                if (settings.transition != 'overlay') {
+                                if (settings.transition !== 'overlay') {
                                     module.hideOthers(module.show);
 
                                     return;
@@ -521,7 +521,7 @@
                 pullPage: function (callback) {
                     var
                         transition = module.get.transition(),
-                        $transition = transition == 'overlay' || module.othersActive()
+                        $transition = transition === 'overlay' || module.othersActive()
                             ? $module
                             : $pusher,
                         animate,
@@ -725,10 +725,10 @@
                             transition
                         ;
                         transition = module.is.mobile()
-                            ? (settings.mobileTransition == 'auto'
+                            ? (settings.mobileTransition === 'auto'
                                 ? settings.defaultTransition.mobile[direction]
                                 : settings.mobileTransition)
-                            : (settings.transition == 'auto'
+                            : (settings.transition === 'auto'
                                 ? settings.defaultTransition.computer[direction]
                                 : settings.transition);
                         module.verbose('Determined transition', transition);

--- a/src/definitions/modules/sidebar.js
+++ b/src/definitions/modules/sidebar.js
@@ -964,17 +964,17 @@
                         query = query.split(/[ .]/);
                         maxDepth = query.length - 1;
                         $.each(query, function (depth, value) {
-                            var camelCaseValue = depth != maxDepth
+                            var camelCaseValue = depth !== maxDepth
                                 ? value + query[depth + 1].charAt(0).toUpperCase() + query[depth + 1].slice(1)
                                 : query
                             ;
-                            if ($.isPlainObject(object[camelCaseValue]) && (depth != maxDepth)) {
+                            if ($.isPlainObject(object[camelCaseValue]) && (depth !== maxDepth)) {
                                 object = object[camelCaseValue];
                             } else if (object[camelCaseValue] !== undefined) {
                                 found = object[camelCaseValue];
 
                                 return false;
-                            } else if ($.isPlainObject(object[value]) && (depth != maxDepth)) {
+                            } else if ($.isPlainObject(object[value]) && (depth !== maxDepth)) {
                                 object = object[value];
                             } else if (object[value] !== undefined) {
                                 found = object[value];

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -576,7 +576,7 @@
                         ;
                         if (step != 0) {
                             var split = String(step).split('.');
-                            decimalPlaces = split.length == 2 ? split[1].length : 0;
+                            decimalPlaces = split.length === 2 ? split[1].length : 0;
                         } else {
                             decimalPlaces = settings.decimalPlaces;
                         }

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -352,7 +352,7 @@
                             ;
                             $currThumb = initialPosition > newPos ? $thumb : $secondThumb;
                         }
-                        if (module.get.step() == 0 || module.is.smooth()) {
+                        if (module.get.step() === 0 || module.is.smooth()) {
                             var
                                 thumbVal = module.thumbVal,
                                 secondThumbVal = module.secondThumbVal,
@@ -574,7 +574,7 @@
                             decimalPlaces,
                             step = module.get.step()
                         ;
-                        if (step != 0) {
+                        if (step !== 0) {
                             var split = String(step).split('.');
                             decimalPlaces = split.length === 2 ? split[1].length : 0;
                         } else {

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -852,16 +852,16 @@
                                 ? (module.is.reversed() ? keys.leftArrow : keys.rightArrow)
                                 : keys.rightArrow
                         ;
-                        if (key == downArrow || key == leftArrow) {
+                        if (key === downArrow || key === leftArrow) {
                             return SINGLE_BACKSTEP;
                         }
-                        if (key == upArrow || key == rightArrow) {
+                        if (key === upArrow || key === rightArrow) {
                             return SINGLE_STEP;
                         }
-                        if (key == keys.pageDown) {
+                        if (key === keys.pageDown) {
                             return BIG_BACKSTEP;
                         }
-                        if (key == keys.pageUp) {
+                        if (key === keys.pageUp) {
                             return BIG_STEP;
                         }
 

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -1218,17 +1218,17 @@
                         query = query.split(/[ .]/);
                         maxDepth = query.length - 1;
                         $.each(query, function (depth, value) {
-                            var camelCaseValue = depth != maxDepth
+                            var camelCaseValue = depth !== maxDepth
                                 ? value + query[depth + 1].charAt(0).toUpperCase() + query[depth + 1].slice(1)
                                 : query
                             ;
-                            if ($.isPlainObject(object[camelCaseValue]) && (depth != maxDepth)) {
+                            if ($.isPlainObject(object[camelCaseValue]) && (depth !== maxDepth)) {
                                 object = object[camelCaseValue];
                             } else if (object[camelCaseValue] !== undefined) {
                                 found = object[camelCaseValue];
 
                                 return false;
-                            } else if ($.isPlainObject(object[value]) && (depth != maxDepth)) {
+                            } else if ($.isPlainObject(object[value]) && (depth !== maxDepth)) {
                                 object = object[value];
                             } else if (object[value] !== undefined) {
                                 found = object[value];

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -435,7 +435,7 @@
                         }
                     },
                     activateFocus: function (event) {
-                        if (!module.is.focused() && module.is.hover() && module.determine.keyMovement(event) != NO_STEP) {
+                        if (!module.is.focused() && module.is.hover() && module.determine.keyMovement(event) !== NO_STEP) {
                             event.preventDefault();
                             module.event.keydown(event, true);
                             $module.trigger('focus');

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -411,7 +411,7 @@
                         }
                         if (first || module.is.focused()) {
                             var step = module.determine.keyMovement(event);
-                            if (step != NO_STEP) {
+                            if (step !== NO_STEP) {
                                 event.preventDefault();
                                 switch (step) {
                                     case SINGLE_STEP: {
@@ -447,7 +447,7 @@
                     },
                     resize: function (_event) {
                         // To avoid a useless performance cost, we only call the label refresh when its necessary
-                        if (gapRatio != module.get.gapRatio()) {
+                        if (gapRatio !== module.get.gapRatio()) {
                             module.setup.labels();
                             gapRatio = module.get.gapRatio();
                         }
@@ -463,7 +463,9 @@
                     module.setup.labels();
                 },
                 takeStep: function (multiplier) {
-                    multiplier = multiplier != undefined ? multiplier : 1;
+                    if (!multiplier) {
+                        multiplier = 1;
+                    }
                     var
                         step = module.get.step(),
                         currValue = module.get.currentThumbValue()
@@ -481,7 +483,9 @@
                 },
 
                 backStep: function (multiplier) {
-                    multiplier = multiplier != undefined ? multiplier : 1;
+                    if (!multiplier) {
+                        multiplier = 1;
+                    }
                     var
                         step = module.get.step(),
                         currValue = module.get.currentThumbValue()
@@ -836,7 +840,7 @@
                             difference = step === 0 ? value : Math.round(value / step) * step
                         ;
                         module.verbose('Determined value based upon position: ' + position + ' as: ' + value);
-                        if (value != difference) {
+                        if (value !== difference) {
                             module.verbose('Rounding value to closest step: ' + difference);
                         }
                         // Use precision to avoid ugly Javascript floating point rounding issues
@@ -1002,7 +1006,7 @@
                     position: function (newValue, $element) {
                         var
                             newPos = module.handleNewValuePosition(newValue),
-                            $targetThumb = $element != undefined ? $element : $currThumb,
+                            $targetThumb = $element || $currThumb,
                             thumbVal = module.thumbVal || module.get.min(),
                             secondThumbVal = module.secondThumbVal || module.get.min()
                         ;

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -414,22 +414,26 @@
                             if (step != NO_STEP) {
                                 event.preventDefault();
                                 switch (step) {
-                                    case SINGLE_STEP:
+                                    case SINGLE_STEP: {
                                         module.takeStep();
 
                                         break;
-                                    case BIG_STEP:
+                                    }
+                                    case BIG_STEP: {
                                         module.takeStep(module.get.multiplier());
 
                                         break;
-                                    case SINGLE_BACKSTEP:
+                                    }
+                                    case SINGLE_BACKSTEP: {
                                         module.backStep();
 
                                         break;
-                                    case BIG_BACKSTEP:
+                                    }
+                                    case BIG_BACKSTEP: {
                                         module.backStep(module.get.multiplier());
 
                                         break;
+                                    }
                                 }
                             }
                         }
@@ -616,12 +620,15 @@
                         }
 
                         switch (settings.labelType) {
-                            case settings.labelTypes.number:
+                            case settings.labelTypes.number: {
                                 return Math.round(((value * (module.get.step() === 0 ? 1 : module.get.step())) + module.get.min()) * precision) / precision;
-                            case settings.labelTypes.letter:
+                            }
+                            case settings.labelTypes.letter: {
                                 return alphabet[value % 26];
-                            default:
+                            }
+                            default: {
                                 return value;
+                            }
                         }
                     },
                     value: function () {
@@ -632,7 +639,7 @@
                     },
                     thumbValue: function (which) {
                         switch (which) {
-                            case 'second':
+                            case 'second': {
                                 if (module.is.range()) {
                                     return module.secondThumbVal;
                                 }
@@ -640,9 +647,10 @@
                                 module.error(error.notrange);
 
                                 break;
-
-                            default:
+                            }
+                            default: {
                                 return module.thumbVal;
+                            }
                         }
                     },
                     multiplier: function () {
@@ -650,7 +658,7 @@
                     },
                     thumbPosition: function (which) {
                         switch (which) {
-                            case 'second':
+                            case 'second': {
                                 if (module.is.range()) {
                                     return secondPos;
                                 }
@@ -658,9 +666,10 @@
                                 module.error(error.notrange);
 
                                 break;
-
-                            default:
+                            }
+                            default: {
                                 return position;
+                            }
                         }
                     },
                     gapRatio: function () {

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -467,7 +467,7 @@
                     module.verbose('Taking a step');
                     if (step > 0) {
                         module.set.value(currValue + step * multiplier);
-                    } else if (step == 0) {
+                    } else if (step === 0) {
                         var
                             precision = module.get.precision(),
                             newValue = currValue + (multiplier / precision)
@@ -485,7 +485,7 @@
                     module.verbose('Going back a step');
                     if (step > 0) {
                         module.set.value(currValue - step * multiplier);
-                    } else if (step == 0) {
+                    } else if (step === 0) {
                         var
                             precision = module.get.precision(),
                             newValue = currValue - (multiplier / precision)
@@ -748,7 +748,7 @@
                             trackLength = module.get.trackLength(),
                             step = module.get.step(),
                             position = Math.round(ratio * trackLength),
-                            adjustedPos = step == 0 ? position : Math.round(position / step) * step
+                            adjustedPos = step === 0 ? position : Math.round(position / step) * step
                         ;
 
                         return adjustedPos;
@@ -824,7 +824,7 @@
                             range = module.get.max() - module.get.min(),
                             step = module.get.step(),
                             value = ratio * range,
-                            difference = step == 0 ? value : Math.round(value / step) * step
+                            difference = step === 0 ? value : Math.round(value / step) * step
                         ;
                         module.verbose('Determined value based upon position: ' + position + ' as: ' + value);
                         if (value != difference) {

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -337,7 +337,7 @@
                         }
                     },
                     move: function (event) {
-                        if (event.type == 'mousemove') {
+                        if (event.type === 'mousemove') {
                             event.preventDefault(); // prevent text selection etc.
                         }
                         if (module.is.disabled()) {
@@ -345,7 +345,7 @@
                             return;
                         }
                         var value = module.determine.valueFromEvent(event);
-                        if (event.type == 'mousemove' && $currThumb === undefined) {
+                        if (event.type === 'mousemove' && $currThumb === undefined) {
                             var
                                 eventPos = module.determine.eventPos(event),
                                 newPos = module.determine.pos(eventPos)

--- a/src/definitions/modules/sticky.js
+++ b/src/definitions/modules/sticky.js
@@ -190,7 +190,7 @@
                         [].forEach.call(mutations, function (mutation) {
                             if (mutation.removedNodes) {
                                 [].forEach.call(mutation.removedNodes, function (node) {
-                                    if (node == element || $(node).find(element).length > 0) {
+                                    if (node === element || $(node).find(element).length > 0) {
                                         module.debug('Element removed from DOM, tearing down events');
                                         module.destroy();
                                     }
@@ -280,7 +280,7 @@
                         }
                         module.cache = {
                             fits: (element.height + settings.offset) <= scrollContext.height,
-                            sameHeight: element.height == context.height,
+                            sameHeight: element.height === context.height,
                             scrollContext: {
                                 height: scrollContext.height,
                             },
@@ -418,7 +418,7 @@
                     },
                     scroll: function (scroll) {
                         module.debug('Setting scroll on element', scroll);
-                        if (module.elementScroll == scroll) {
+                        if (module.elementScroll === scroll) {
                             return;
                         }
                         if (module.is.top()) {
@@ -444,7 +444,7 @@
 
                 is: {
                     standardScroll: function () {
-                        return $scroll[0] == window;
+                        return $scroll[0] === window;
                     },
                     top: function () {
                         return $module.hasClass(className.top);

--- a/src/definitions/modules/sticky.js
+++ b/src/definitions/modules/sticky.js
@@ -795,17 +795,17 @@
                         query = query.split(/[ .]/);
                         maxDepth = query.length - 1;
                         $.each(query, function (depth, value) {
-                            var camelCaseValue = depth != maxDepth
+                            var camelCaseValue = depth !== maxDepth
                                 ? value + query[depth + 1].charAt(0).toUpperCase() + query[depth + 1].slice(1)
                                 : query
                             ;
-                            if ($.isPlainObject(object[camelCaseValue]) && (depth != maxDepth)) {
+                            if ($.isPlainObject(object[camelCaseValue]) && (depth !== maxDepth)) {
                                 object = object[camelCaseValue];
                             } else if (object[camelCaseValue] !== undefined) {
                                 found = object[camelCaseValue];
 
                                 return false;
-                            } else if ($.isPlainObject(object[value]) && (depth != maxDepth)) {
+                            } else if ($.isPlainObject(object[value]) && (depth !== maxDepth)) {
                                 object = object[value];
                             } else if (object[value] !== undefined) {
                                 found = object[value];

--- a/src/definitions/modules/tab.js
+++ b/src/definitions/modules/tab.js
@@ -193,7 +193,7 @@
 
                         return false;
                     }
-                    if (settings.historyType == 'state') {
+                    if (settings.historyType === 'state') {
                         module.debug('Using HTML5 to manage state');
                         if (settings.path !== false) {
                             $.address
@@ -450,7 +450,7 @@
                         evaluateScripts = evaluateScripts !== undefined
                             ? evaluateScripts
                             : settings.evaluateScripts;
-                        if (typeof settings.cacheType === 'string' && settings.cacheType.toLowerCase() == 'dom' && typeof html !== 'string') {
+                        if (typeof settings.cacheType === 'string' && settings.cacheType.toLowerCase() === 'dom' && typeof html !== 'string') {
                             $tab
                                 .empty()
                                 .append($(html).clone(true))
@@ -481,7 +481,7 @@
                                     'X-Remote': true,
                                 },
                                 onSuccess: function (response) {
-                                    if (settings.cacheType == 'response') {
+                                    if (settings.cacheType === 'response') {
                                         module.cache.add(fullTabPath, response);
                                     }
                                     module.update.content(tabPath, response);
@@ -496,7 +496,7 @@
 
                                     if (settings.loadOnce) {
                                         module.cache.add(fullTabPath, true);
-                                    } else if (typeof settings.cacheType === 'string' && settings.cacheType.toLowerCase() == 'dom' && $tab.children().length > 0) {
+                                    } else if (typeof settings.cacheType === 'string' && settings.cacheType.toLowerCase() === 'dom' && $tab.children().length > 0) {
                                         setTimeout(function () {
                                             var
                                                 $clone = $tab.children().clone(true)
@@ -525,7 +525,7 @@
                             module.activate.tab(tabPath);
                             module.debug('Adding cached content', fullTabPath);
                             if (!settings.loadOnce) {
-                                if (settings.evaluateScripts == 'once') {
+                                if (settings.evaluateScripts === 'once') {
                                     module.update.content(tabPath, cachedContent, false);
                                 } else {
                                     module.update.content(tabPath, cachedContent);
@@ -554,7 +554,7 @@
                     tab: function (tabPath) {
                         var
                             $tab          = module.get.tabElement(tabPath),
-                            $deactiveTabs = settings.deactivate == 'siblings'
+                            $deactiveTabs = settings.deactivate === 'siblings'
                                 ? $tab.siblings($tabs)
                                 : $tabs.not($tab),
                             isActive      = $tab.hasClass(className.active)
@@ -575,7 +575,7 @@
                     navigation: function (tabPath) {
                         var
                             $navigation         = module.get.navElement(tabPath),
-                            $deactiveNavigation = settings.deactivate == 'siblings'
+                            $deactiveNavigation = settings.deactivate === 'siblings'
                                 ? $navigation.siblings($allModules)
                                 : $allModules.not($navigation),
                             isActive    = $navigation.hasClass(className.active)

--- a/src/definitions/modules/tab.js
+++ b/src/definitions/modules/tab.js
@@ -12,7 +12,7 @@
     'use strict';
 
     function isWindow(obj) {
-        return obj != null && obj === obj.window;
+        return obj !== null && obj === obj.window;
     }
 
     function isFunction(obj) {
@@ -392,7 +392,7 @@
                                 settings.onFirstLoad.call($tab[0], currentPath, parameterArray, historyEvent);
                             }
                             settings.onLoad.call($tab[0], currentPath, parameterArray, historyEvent);
-                        } else if (tabPath.search('/') == -1 && tabPath !== '') {
+                        } else if (tabPath.search('/') === -1 && tabPath !== '') {
                             // look for in page anchor
                             tabPath = module.escape.string(tabPath);
                             $anchor = $('#' + tabPath + ', a[name="' + tabPath + '"]');

--- a/src/definitions/modules/tab.js
+++ b/src/definitions/modules/tab.js
@@ -94,12 +94,12 @@
                     }
 
                     var activeTab = module.determine.activeTab();
-                    if (settings.autoTabActivation && instance === undefined && activeTab == null) {
+                    if (settings.autoTabActivation && instance === undefined && activeTab === null) {
                         activeTab = settings.autoTabActivation === true ? module.get.initialPath() : settings.autoTabActivation;
                         module.debug('No active tab detected, setting tab active', activeTab);
                         module.changeTab(activeTab);
                     }
-                    if (activeTab != null && settings.history) {
+                    if (activeTab !== null && settings.history) {
                         var autoUpdate = $.address.autoUpdate();
                         $.address.autoUpdate(false);
                         $.address.value(activeTab);

--- a/src/definitions/modules/tab.js
+++ b/src/definitions/modules/tab.js
@@ -701,7 +701,7 @@
                 utilities: {
                     filterArray: function (keepArray, removeArray) {
                         return $.grep(keepArray, function (keepValue) {
-                            return $.inArray(keepValue, removeArray) == -1;
+                            return $.inArray(keepValue, removeArray) === -1;
                         });
                     },
                     last: function (array) {

--- a/src/definitions/modules/tab.js
+++ b/src/definitions/modules/tab.js
@@ -837,17 +837,17 @@
                         query = query.split(/[ .]/);
                         maxDepth = query.length - 1;
                         $.each(query, function (depth, value) {
-                            var camelCaseValue = depth != maxDepth
+                            var camelCaseValue = depth !== maxDepth
                                 ? value + query[depth + 1].charAt(0).toUpperCase() + query[depth + 1].slice(1)
                                 : query
                             ;
-                            if ($.isPlainObject(object[camelCaseValue]) && (depth != maxDepth)) {
+                            if ($.isPlainObject(object[camelCaseValue]) && (depth !== maxDepth)) {
                                 object = object[camelCaseValue];
                             } else if (object[camelCaseValue] !== undefined) {
                                 found = object[camelCaseValue];
 
                                 return false;
-                            } else if ($.isPlainObject(object[value]) && (depth != maxDepth)) {
+                            } else if ($.isPlainObject(object[value]) && (depth !== maxDepth)) {
                                 object = object[value];
                             } else if (object[value] !== undefined) {
                                 found = object[value];

--- a/src/definitions/modules/tab.js
+++ b/src/definitions/modules/tab.js
@@ -338,7 +338,7 @@
                             currentPath        = module.utilities.arrayToPath(currentPathArray),
 
                             isTab              = module.is.tab(currentPath),
-                            isLastIndex        = index + 1 == pathArray.length,
+                            isLastIndex        = index + 1 === pathArray.length,
 
                             $tab               = module.get.tabElement(currentPath),
                             $anchor,

--- a/src/definitions/modules/toast.js
+++ b/src/definitions/modules/toast.js
@@ -734,17 +734,17 @@
                         query = query.split(/[ .]/);
                         maxDepth = query.length - 1;
                         $.each(query, function (depth, value) {
-                            var camelCaseValue = depth != maxDepth
+                            var camelCaseValue = depth !== maxDepth
                                 ? value + query[depth + 1].charAt(0).toUpperCase() + query[depth + 1].slice(1)
                                 : query
                             ;
-                            if ($.isPlainObject(object[camelCaseValue]) && (depth != maxDepth)) {
+                            if ($.isPlainObject(object[camelCaseValue]) && (depth !== maxDepth)) {
                                 object = object[camelCaseValue];
                             } else if (object[camelCaseValue] !== undefined) {
                                 found = object[camelCaseValue];
 
                                 return false;
-                            } else if ($.isPlainObject(object[value]) && (depth != maxDepth)) {
+                            } else if ($.isPlainObject(object[value]) && (depth !== maxDepth)) {
                                 object = object[value];
                             } else if (object[value] !== undefined) {
                                 found = object[value];

--- a/src/definitions/modules/transition.js
+++ b/src/definitions/modules/transition.js
@@ -142,7 +142,7 @@
                     interval = interval !== undefined
                         ? interval
                         : settings.interval;
-                    shouldReverse = settings.reverse == 'auto' && direction == className.outward;
+                    shouldReverse = settings.reverse === 'auto' && direction == className.outward;
                     delay = shouldReverse || settings.reverse === true
                         ? ($allModules.length - index) * interval
                         : index * interval;
@@ -703,7 +703,7 @@
                             if (currentAnimation != inAnimation) {
                                 module.debug('Direction exists for animation', animation);
                                 directionExists = true;
-                            } else if (currentAnimation == 'none' || !currentAnimation) {
+                            } else if (currentAnimation === 'none' || !currentAnimation) {
                                 module.debug('No animation defined in css', animation);
 
                                 return;

--- a/src/definitions/modules/transition.js
+++ b/src/definitions/modules/transition.js
@@ -142,7 +142,7 @@
                     interval = interval !== undefined
                         ? interval
                         : settings.interval;
-                    shouldReverse = settings.reverse === 'auto' && direction == className.outward;
+                    shouldReverse = settings.reverse === 'auto' && direction === className.outward;
                     delay = shouldReverse || settings.reverse === true
                         ? ($allModules.length - index) * interval
                         : index * interval;
@@ -329,7 +329,7 @@
                     },
                     direction: function (direction) {
                         direction = direction || module.get.direction();
-                        if (direction == className.inward) {
+                        if (direction === className.inward) {
                             module.set.inward();
                         } else {
                             module.set.outward();
@@ -700,7 +700,7 @@
                             }
 
                             $clone.remove();
-                            if (currentAnimation != inAnimation) {
+                            if (currentAnimation !== inAnimation) {
                                 module.debug('Direction exists for animation', animation);
                                 directionExists = true;
                             } else if (currentAnimation === 'none' || !currentAnimation) {

--- a/src/definitions/modules/transition.js
+++ b/src/definitions/modules/transition.js
@@ -943,17 +943,17 @@
                         query = query.split(/[ .]/);
                         maxDepth = query.length - 1;
                         $.each(query, function (depth, value) {
-                            var camelCaseValue = depth != maxDepth
+                            var camelCaseValue = depth !== maxDepth
                                 ? value + query[depth + 1].charAt(0).toUpperCase() + query[depth + 1].slice(1)
                                 : query
                             ;
-                            if ($.isPlainObject(object[camelCaseValue]) && (depth != maxDepth)) {
+                            if ($.isPlainObject(object[camelCaseValue]) && (depth !== maxDepth)) {
                                 object = object[camelCaseValue];
                             } else if (object[camelCaseValue] !== undefined) {
                                 found = object[camelCaseValue];
 
                                 return false;
-                            } else if ($.isPlainObject(object[value]) && (depth != maxDepth)) {
+                            } else if ($.isPlainObject(object[value]) && (depth !== maxDepth)) {
                                 object = object[value];
                             } else if (object[value] !== undefined) {
                                 found = object[value];

--- a/tasks/admin/components/init.js
+++ b/tasks/admin/components/init.js
@@ -85,7 +85,7 @@ module.exports = function (callback) {
         }
 
         // clean folder
-        if (release.outputRoot.search('../repos') == 0) {
+        if (release.outputRoot.startsWith('../repos')) {
             console.info('Cleaning dir', outputDirectory);
             del.sync([outputDirectory + '**/*'], { silent: true, force: true });
         }

--- a/tasks/admin/components/update.js
+++ b/tasks/admin/components/update.js
@@ -76,7 +76,7 @@ module.exports = function (callback) {
                 ? require(outputDirectory + 'package.json') // eslint-disable-line import/no-dynamic-require
                 : false,
 
-            isNewVersion  = version && componentPackage.version != version,
+            isNewVersion  = version && componentPackage.version !== version,
 
             commitMessage = isNewVersion
                 ? 'Updated component to version ' + version

--- a/tasks/admin/distributions/create.js
+++ b/tasks/admin/distributions/create.js
@@ -131,7 +131,7 @@ module.exports = function (callback) {
                 ;
             });
 
-            if (distribution == 'CSS') {
+            if (distribution === 'CSS') {
                 tasks.push(function () {
                     let
                         themes,
@@ -150,7 +150,7 @@ module.exports = function (callback) {
 
                     return mergeStream(themes, components, releases);
                 });
-            } else if (distribution == 'LESS') {
+            } else if (distribution === 'LESS') {
                 tasks.push(function () {
                     let
                         definitions,

--- a/tasks/admin/distributions/create.js
+++ b/tasks/admin/distributions/create.js
@@ -108,9 +108,8 @@ module.exports = function (callback) {
             createList = function (files) {
                 let filenames = '';
                 for (let file in files) {
-                    filenames += file == (files.length - 1)
-                        ? "'" + files[file] + "'"
-                        : "'" + files[file] + "',\n    ";
+                    filenames += "'" + files[file] + "'"
+                        + (file === files.length - 1 ? '' : ',\n    ');
                 }
 
                 return filenames;

--- a/tasks/admin/distributions/init.js
+++ b/tasks/admin/distributions/init.js
@@ -84,7 +84,7 @@ module.exports = function (callback) {
         }
 
         // clean folder
-        if (release.outputRoot.search('../repos') == 0) {
+        if (release.outputRoot.startsWith('../repos')) {
             console.info('Cleaning dir', outputDirectory);
             del.sync([outputDirectory + '**/*'], { silent: true, force: true });
         }

--- a/tasks/admin/distributions/update.js
+++ b/tasks/admin/distributions/update.js
@@ -72,7 +72,7 @@ module.exports = function (callback) {
                 ? require(outputDirectory + 'package.json') // eslint-disable-line import/no-dynamic-require
                 : false,
 
-            isNewVersion  = version && distributionPackage.version != version,
+            isNewVersion  = version && distributionPackage.version !== version,
 
             commitMessage = isNewVersion
                 ? 'Updated distribution to version ' + version

--- a/tasks/config/project/config.js
+++ b/tasks/config/project/config.js
@@ -28,7 +28,7 @@ module.exports = {
                     configPath = path.normalize(directory);
                 } else {
                     // reached file system root, let's stop
-                    if (nextDirectory == directory) {
+                    if (nextDirectory === directory) {
                         return;
                     }
                     // otherwise recurse

--- a/tasks/config/project/config.js
+++ b/tasks/config/project/config.js
@@ -116,7 +116,7 @@ module.exports = {
         // remove duplicates from component array
         if (Array.isArray(config.components)) {
             config.components = config.components.filter(function (component, index) {
-                return config.components.indexOf(component) == index;
+                return config.components.indexOf(component) === index;
             });
         }
 

--- a/tasks/config/project/install.js
+++ b/tasks/config/project/install.js
@@ -118,7 +118,7 @@ module.exports = {
                         root: nextDirectory,
                     };
                 }
-                if (path.resolve(directory) == path.resolve(nextDirectory)) {
+                if (path.resolve(directory) === path.resolve(nextDirectory)) {
                     return false;
                 }
 

--- a/tasks/config/project/install.js
+++ b/tasks/config/project/install.js
@@ -34,16 +34,16 @@ let when = {
     },
 
     allowOverwrite: function (questions) {
-        return questions.overwrite === undefined || questions.overwrite == 'yes';
+        return questions.overwrite === undefined || questions.overwrite === 'yes';
     },
     notAuto: function (questions) {
-        return questions.install !== 'auto' && (questions.overwrite === undefined || questions.overwrite == 'yes');
+        return questions.install !== 'auto' && (questions.overwrite === undefined || questions.overwrite === 'yes');
     },
     custom: function (questions) {
-        return questions.install === 'custom' && (questions.overwrite === undefined || questions.overwrite == 'yes');
+        return questions.install === 'custom' && (questions.overwrite === undefined || questions.overwrite === 'yes');
     },
     express: function (questions) {
-        return questions.install === 'express' && (questions.overwrite === undefined || questions.overwrite == 'yes');
+        return questions.install === 'express' && (questions.overwrite === undefined || questions.overwrite === 'yes');
     },
 
     // customize
@@ -100,19 +100,19 @@ module.exports = {
                     folder        = pathArray[pathArray.length - 1],
                     nextDirectory = path.join(directory, path.sep, '..')
                 ;
-                if (folder == 'bower_components') {
+                if (folder === 'bower_components') {
                     return {
                         name: 'Bower',
                         root: nextDirectory,
                     };
                 }
-                if (folder == 'node_modules') {
+                if (folder === 'node_modules') {
                     return {
                         name: 'NPM',
                         root: nextDirectory,
                     };
                 }
-                if (folder == 'composer') {
+                if (folder === 'composer') {
                     return {
                         name: 'Composer',
                         root: nextDirectory,

--- a/tasks/config/project/release.js
+++ b/tasks/config/project/release.js
@@ -27,7 +27,7 @@ try {
 }
 
 // looks for version in config or package.json (whichever is available)
-version = npmPackage && npmPackage.version !== undefined && npmPackage.name == 'fomantic-ui'
+version = npmPackage && npmPackage.version !== undefined && npmPackage.name === 'fomantic-ui'
     ? npmPackage.version
     : config.version;
 

--- a/tasks/config/tasks.js
+++ b/tasks/config/tasks.js
@@ -115,13 +115,13 @@ module.exports = {
                         element
                     ;
                     if (error && error.filename && /theme.less/.test(error.filename)) {
-                        if (error.line == 9) {
+                        if (error.line === 9) {
                             element = regExp.variable.exec(error.message)[1];
                             if (element) {
                                 console.error('Missing theme.config value for', element);
                             }
                             console.error('Most likely new UI was added in an update. You will need to add missing elements from theme.config.example');
-                        } else if (error.line == 84) {
+                        } else if (error.line === 84) {
                             element = regExp.element.exec(error.message)[1];
                             theme = regExp.theme.exec(error.message)[1];
                             console.error(theme + ' is not an available theme for ' + element);

--- a/tasks/docs/metadata.js
+++ b/tasks/docs/metadata.js
@@ -24,7 +24,7 @@ function startsWith(str, prefix) {
 function inArray(needle, haystack) {
     let length = haystack.length;
     for (let i = 0; i < length; i++) {
-        if (haystack[i] == needle) {
+        if (haystack[i] === needle) {
             return true;
         }
     }

--- a/tasks/install.js
+++ b/tasks/install.js
@@ -209,7 +209,7 @@ module.exports = function (callback) {
         --------------- */
 
         // if config exists and user specifies not to proceed
-        if (answers.overwrite !== undefined && answers.overwrite == 'no') {
+        if (answers.overwrite !== undefined && answers.overwrite === 'no') {
             callback();
 
             return;
@@ -270,7 +270,7 @@ module.exports = function (callback) {
             for (let destination in installPaths) {
                 if (Object.prototype.hasOwnProperty.call(installPaths, destination)) {
                     // config goes in project root, rest in install folder
-                    installPaths[destination] = destination == 'config' || destination == 'configFolder'
+                    installPaths[destination] = destination === 'config' || destination === 'configFolder'
                         ? path.normalize(path.join(manager.root, installPaths[destination]))
                         : path.normalize(path.join(installFolder, installPaths[destination]));
                 }

--- a/test/modules/module.spec.js
+++ b/test/modules/module.spec.js
@@ -32,7 +32,7 @@ function moduleTests(ui) {
         // module available in scope
         $module = $(element);
 
-        if ($module.size() == 1) { // one module available in fixture
+        if ($module.size() === 1) { // one module available in fixture
             $oneModule = $module;
             $clone = $module.clone().appendTo($(sandbox()));
             $modules = $clone.add($module);


### PR DESCRIPTION
For comparing (non empty) strings, we can use `===` reliably (instead of `==`).