### PR TITLE
fix(calendar): calendar breaks when initialDate is string

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -255,7 +255,7 @@
                             today = new Date(),
                             date = module.get.date(),
                             focusDate = module.get.focusDate(),
-                            display = module.helper.dateInRange(focusDate || date || settings.initialDate || today)
+                            display = module.helper.dateInRange(focusDate || date || parser.date(settings.initialDate, settings) || today)
                         ;
 
                         if (!focusDate) {


### PR DESCRIPTION
## Description
Whenever a given initialDate is made out of a string, a possible later ' clean' breaks the calendar refresh by console error.
That's because the initialDate is taken as a month reference when no date is given (via clear), but it was forgotten to parse the initialDate beforehand (was working fine as long as it's a JS Date object already)

## Testcase
```javascript
  $('#mycal').calendar({
    type: 'date',
    initialDate: '2022-12-20'
  });

setTimeout(function(){
  $('#mycal').calendar('clear');
},2000);
```