### PR TITLE
feat(lint): enforce LF line break in all JS and LESS files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,6 +36,7 @@ module.exports = {
         indent: ['error', 4, {
             SwitchCase: 1,
         }],
+        'linebreak-style': ['error', 'unix'],
         'max-len': 'off',
         'no-console': 'off',
         'no-continue': 'off',

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -12,6 +12,7 @@ module.exports = {
         'block-closing-brace-newline-before': null, // fix bad formatting with "each()"
         'declaration-block-trailing-semicolon': null, // fix bad formatting with "each()"
         indentation: null, // TODO change to "4" once https://github.com/fomantic/Fomantic-UI/pull/2593#discussion_r1045131096 is fixed
+        linebreaks: 'unix',
         'max-line-length': null,
         'no-descending-specificity': null,
         'no-extra-semicolons': null, // fix GH-1832 - workaround for wikimedia/less.php parser


### PR DESCRIPTION
Assert GH-2362 and reject any CRLF present by CI.