### PR TITLE
feat(lint): use Date.now() instead of new Date().getTime()

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -146,7 +146,6 @@ module.exports = {
         'unicorn/no-useless-switch-case': 'off',
         'unicorn/no-useless-undefined': 'off',
         'unicorn/prefer-array-find': 'off',
-        'unicorn/prefer-date-now': 'off',
         'unicorn/prefer-default-parameters': 'off',
         'unicorn/prefer-logical-operator-over-ternary': 'off',
         'unicorn/prefer-native-coercion-functions': 'off',

--- a/src/definitions/behaviors/api.js
+++ b/src/definitions/behaviors/api.js
@@ -30,7 +30,7 @@
                 ? $(window)
                 : $(this),
             moduleSelector = $allModules.selector || '',
-            time           = new Date().getTime(),
+            time           = Date.now(),
             performance    = [],
 
             query          = arguments[0],
@@ -537,7 +537,7 @@
                         done: function (response, textStatus, xhr) {
                             var
                                 context            = this,
-                                elapsedTime        = (new Date().getTime() - requestStartTime),
+                                elapsedTime        = (Date.now() - requestStartTime),
                                 timeLeft           = (settings.loadingDuration - elapsedTime),
                                 translatedResponse = (isFunction(settings.onResponse))
                                     ? module.is.expectingJSON() && !settings.rawResponse
@@ -566,7 +566,7 @@
                         fail: function (xhr, status, httpMessage) {
                             var
                                 context     = this,
-                                elapsedTime = (new Date().getTime() - requestStartTime),
+                                elapsedTime = (Date.now() - requestStartTime),
                                 timeLeft    = (settings.loadingDuration - elapsedTime)
                             ;
                             timeLeft = (timeLeft > 0)
@@ -727,7 +727,7 @@
                     loading: function () {
                         module.verbose('Adding loading state to element', $context);
                         $context.addClass(className.loading);
-                        requestStartTime = new Date().getTime();
+                        requestStartTime = Date.now();
                     },
                 },
 
@@ -949,7 +949,7 @@
                             previousTime
                         ;
                         if (settings.performance) {
-                            currentTime = new Date().getTime();
+                            currentTime = Date.now();
                             previousTime = time || currentTime;
                             executionTime = currentTime - previousTime;
                             time = currentTime;

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -24,7 +24,7 @@
             $allModules      = $(this),
             moduleSelector   = $allModules.selector || '',
 
-            time             = new Date().getTime(),
+            time             = Date.now(),
             performance      = [],
 
             query            = arguments[0],
@@ -1382,7 +1382,7 @@
                             previousTime
                         ;
                         if (settings.performance) {
-                            currentTime = new Date().getTime();
+                            currentTime = Date.now();
                             previousTime = time || currentTime;
                             executionTime = currentTime - previousTime;
                             time = currentTime;

--- a/src/definitions/behaviors/state.js
+++ b/src/definitions/behaviors/state.js
@@ -25,7 +25,7 @@
 
             moduleSelector  = $allModules.selector || '',
 
-            time            = new Date().getTime(),
+            time            = Date.now(),
             performance     = [],
 
             query           = arguments[0],
@@ -464,7 +464,7 @@
                             previousTime
                         ;
                         if (settings.performance) {
-                            currentTime = new Date().getTime();
+                            currentTime = Date.now();
                             previousTime = time || currentTime;
                             executionTime = currentTime - previousTime;
                             time = currentTime;

--- a/src/definitions/behaviors/visibility.js
+++ b/src/definitions/behaviors/visibility.js
@@ -24,7 +24,7 @@
             $allModules    = $(this),
             moduleSelector = $allModules.selector || '',
 
-            time           = new Date().getTime(),
+            time           = Date.now(),
             performance    = [],
 
             query          = arguments[0],
@@ -1072,7 +1072,7 @@
                             previousTime
                         ;
                         if (settings.performance) {
-                            currentTime = new Date().getTime();
+                            currentTime = Date.now();
                             previousTime = time || currentTime;
                             executionTime = currentTime - previousTime;
                             time = currentTime;

--- a/src/definitions/globals/site.js
+++ b/src/definitions/globals/site.js
@@ -21,7 +21,7 @@
 
     $.site = $.fn.site = function (parameters) {
         var
-            time           = new Date().getTime(),
+            time           = Date.now(),
             performance    = [],
 
             query          = arguments[0],
@@ -309,7 +309,7 @@
                         previousTime
                     ;
                     if (settings.performance) {
-                        currentTime = new Date().getTime();
+                        currentTime = Date.now();
                         previousTime = time || currentTime;
                         executionTime = currentTime - previousTime;
                         time = currentTime;

--- a/src/definitions/modules/accordion.js
+++ b/src/definitions/modules/accordion.js
@@ -23,7 +23,7 @@
         var
             $allModules     = $(this),
 
-            time            = new Date().getTime(),
+            time            = Date.now(),
             performance     = [],
 
             query           = arguments[0],
@@ -427,7 +427,7 @@
                             previousTime
                         ;
                         if (settings.performance) {
-                            currentTime = new Date().getTime();
+                            currentTime = Date.now();
                             previousTime = time || currentTime;
                             executionTime = currentTime - previousTime;
                             time = currentTime;

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -26,7 +26,7 @@
 
             moduleSelector = $allModules.selector || '',
 
-            time           = new Date().getTime(),
+            time           = Date.now(),
             performance    = [],
 
             query          = arguments[0],
@@ -1435,7 +1435,7 @@
                             previousTime
                         ;
                         if (settings.performance) {
-                            currentTime = new Date().getTime();
+                            currentTime = Date.now();
                             previousTime = time || currentTime;
                             executionTime = currentTime - previousTime;
                             time = currentTime;

--- a/src/definitions/modules/checkbox.js
+++ b/src/definitions/modules/checkbox.js
@@ -24,7 +24,7 @@
             $allModules    = $(this),
             moduleSelector = $allModules.selector || '',
 
-            time           = new Date().getTime(),
+            time           = Date.now(),
             performance    = [],
 
             query          = arguments[0],
@@ -712,7 +712,7 @@
                             previousTime
                         ;
                         if (settings.performance) {
-                            currentTime = new Date().getTime();
+                            currentTime = Date.now();
                             previousTime = time || currentTime;
                             executionTime = currentTime - previousTime;
                             time = currentTime;

--- a/src/definitions/modules/dimmer.js
+++ b/src/definitions/modules/dimmer.js
@@ -23,7 +23,7 @@
         var
             $allModules     = $(this),
 
-            time            = new Date().getTime(),
+            time            = Date.now(),
             performance     = [],
 
             query           = arguments[0],
@@ -519,7 +519,7 @@
                             previousTime
                         ;
                         if (settings.performance) {
-                            currentTime = new Date().getTime();
+                            currentTime = Date.now();
                             previousTime = time || currentTime;
                             executionTime = currentTime - previousTime;
                             time = currentTime;

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -26,7 +26,7 @@
 
             moduleSelector = $allModules.selector || '',
 
-            time           = new Date().getTime(),
+            time           = Date.now(),
             performance    = [],
 
             query          = arguments[0],
@@ -3801,7 +3801,7 @@
                             previousTime
                         ;
                         if (settings.performance) {
-                            currentTime = new Date().getTime();
+                            currentTime = Date.now();
                             previousTime = time || currentTime;
                             executionTime = currentTime - previousTime;
                             time = currentTime;

--- a/src/definitions/modules/embed.js
+++ b/src/definitions/modules/embed.js
@@ -25,7 +25,7 @@
 
             moduleSelector  = $allModules.selector || '',
 
-            time            = new Date().getTime(),
+            time            = Date.now(),
             performance     = [],
 
             query           = arguments[0],
@@ -436,7 +436,7 @@
                             previousTime
                         ;
                         if (settings.performance) {
-                            currentTime = new Date().getTime();
+                            currentTime = Date.now();
                             previousTime = time || currentTime;
                             executionTime = currentTime - previousTime;
                             time = currentTime;

--- a/src/definitions/modules/flyout.js
+++ b/src/definitions/modules/flyout.js
@@ -30,7 +30,7 @@
 
             moduleSelector  = $allModules.selector || '',
 
-            time            = new Date().getTime(),
+            time            = Date.now(),
             performance     = [],
 
             query           = arguments[0],
@@ -1181,7 +1181,7 @@
                             previousTime
                         ;
                         if (settings.performance) {
-                            currentTime = new Date().getTime();
+                            currentTime = Date.now();
                             previousTime = time || currentTime;
                             executionTime = currentTime - previousTime;
                             time = currentTime;

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -28,7 +28,7 @@
 
             moduleSelector = $allModules.selector || '',
 
-            time           = new Date().getTime(),
+            time           = Date.now(),
             performance    = [],
 
             query          = arguments[0],
@@ -1189,7 +1189,7 @@
                             previousTime
                         ;
                         if (settings.performance) {
-                            currentTime = new Date().getTime();
+                            currentTime = Date.now();
                             previousTime = time || currentTime;
                             executionTime = currentTime - previousTime;
                             time = currentTime;

--- a/src/definitions/modules/nag.js
+++ b/src/definitions/modules/nag.js
@@ -24,7 +24,7 @@
             $allModules    = $(this),
             moduleSelector = $allModules.selector || '',
 
-            time           = new Date().getTime(),
+            time           = Date.now(),
             performance    = [],
 
             query          = arguments[0],
@@ -352,7 +352,7 @@
                             previousTime
                         ;
                         if (settings.performance) {
-                            currentTime = new Date().getTime();
+                            currentTime = Date.now();
                             previousTime = time || currentTime;
                             executionTime = currentTime - previousTime;
                             time = currentTime;

--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -32,7 +32,7 @@
                 ? 'touchstart'
                 : 'click',
 
-            time           = new Date().getTime(),
+            time           = Date.now(),
             performance    = [],
 
             query          = arguments[0],
@@ -1191,7 +1191,7 @@
                             previousTime
                         ;
                         if (settings.performance) {
-                            currentTime = new Date().getTime();
+                            currentTime = Date.now();
                             previousTime = time || currentTime;
                             executionTime = currentTime - previousTime;
                             time = currentTime;

--- a/src/definitions/modules/progress.js
+++ b/src/definitions/modules/progress.js
@@ -25,7 +25,7 @@
 
             moduleSelector = $allModules.selector || '',
 
-            time           = new Date().getTime(),
+            time           = Date.now(),
             performance    = [],
 
             query          = arguments[0],
@@ -807,7 +807,7 @@
                             previousTime
                         ;
                         if (settings.performance) {
-                            currentTime = new Date().getTime();
+                            currentTime = Date.now();
                             previousTime = time || currentTime;
                             executionTime = currentTime - previousTime;
                             time = currentTime;

--- a/src/definitions/modules/rating.js
+++ b/src/definitions/modules/rating.js
@@ -24,7 +24,7 @@
             $allModules     = $(this),
             moduleSelector  = $allModules.selector || '',
 
-            time            = new Date().getTime(),
+            time            = Date.now(),
             performance     = [],
 
             query           = arguments[0],
@@ -356,7 +356,7 @@
                             previousTime
                         ;
                         if (settings.performance) {
-                            currentTime = new Date().getTime();
+                            currentTime = Date.now();
                             previousTime = time || currentTime;
                             executionTime = currentTime - previousTime;
                             time = currentTime;

--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -24,7 +24,7 @@
             $allModules     = $(this),
             moduleSelector  = $allModules.selector || '',
 
-            time            = new Date().getTime(),
+            time            = Date.now(),
             performance     = [],
 
             query           = arguments[0],
@@ -1129,7 +1129,7 @@
                             previousTime
                         ;
                         if (settings.performance) {
-                            currentTime = new Date().getTime();
+                            currentTime = Date.now();
                             previousTime = time || currentTime;
                             executionTime = currentTime - previousTime;
                             time = currentTime;

--- a/src/definitions/modules/shape.js
+++ b/src/definitions/modules/shape.js
@@ -23,7 +23,7 @@
         var
             $allModules     = $(this),
 
-            time            = new Date().getTime(),
+            time            = Date.now(),
             performance     = [],
 
             query           = arguments[0],
@@ -646,7 +646,7 @@
                             previousTime
                         ;
                         if (settings.performance) {
-                            currentTime = new Date().getTime();
+                            currentTime = Date.now();
                             previousTime = time || currentTime;
                             executionTime = currentTime - previousTime;
                             time = currentTime;

--- a/src/definitions/modules/sidebar.js
+++ b/src/definitions/modules/sidebar.js
@@ -30,7 +30,7 @@
 
             moduleSelector  = $allModules.selector || '',
 
-            time            = new Date().getTime(),
+            time            = Date.now(),
             performance     = [],
 
             query           = arguments[0],
@@ -907,7 +907,7 @@
                             previousTime
                         ;
                         if (settings.performance) {
-                            currentTime = new Date().getTime();
+                            currentTime = Date.now();
                             previousTime = time || currentTime;
                             executionTime = currentTime - previousTime;
                             time = currentTime;

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -27,7 +27,7 @@
 
             moduleSelector = $allModules.selector || '',
 
-            time           = new Date().getTime(),
+            time           = Date.now(),
             performance    = [],
 
             query          = arguments[0],
@@ -1146,7 +1146,7 @@
                             previousTime
                         ;
                         if (settings.performance) {
-                            currentTime = new Date().getTime();
+                            currentTime = Date.now();
                             previousTime = time || currentTime;
                             executionTime = currentTime - previousTime;
                             time = currentTime;

--- a/src/definitions/modules/sticky.js
+++ b/src/definitions/modules/sticky.js
@@ -25,7 +25,7 @@
             $document      = $(document),
             moduleSelector = $allModules.selector || '',
 
-            time           = new Date().getTime(),
+            time           = Date.now(),
             performance    = [],
 
             query          = arguments[0],
@@ -740,7 +740,7 @@
                             previousTime
                         ;
                         if (settings.performance) {
-                            currentTime = new Date().getTime();
+                            currentTime = Date.now();
                             previousTime = time || currentTime;
                             executionTime = currentTime - previousTime;
                             time = currentTime;

--- a/src/definitions/modules/tab.js
+++ b/src/definitions/modules/tab.js
@@ -31,7 +31,7 @@
                 : $(this),
             $document      = $(document),
             moduleSelector  = $allModules.selector || '',
-            time            = new Date().getTime(),
+            time            = Date.now(),
             performance     = [],
 
             query           = arguments[0],
@@ -784,7 +784,7 @@
                             previousTime
                         ;
                         if (settings.performance) {
-                            currentTime = new Date().getTime();
+                            currentTime = Date.now();
                             previousTime = time || currentTime;
                             executionTime = currentTime - previousTime;
                             time = currentTime;

--- a/src/definitions/modules/toast.js
+++ b/src/definitions/modules/toast.js
@@ -24,7 +24,7 @@
             $allModules    = $(this),
             moduleSelector = $allModules.selector || '',
 
-            time           = new Date().getTime(),
+            time           = Date.now(),
             performance    = [],
 
             query          = arguments[0],
@@ -660,7 +660,7 @@
                             previousTime
                         ;
                         if (settings.performance) {
-                            currentTime = new Date().getTime();
+                            currentTime = Date.now();
                             previousTime = time || currentTime;
                             executionTime = currentTime - previousTime;
                             time = currentTime;

--- a/src/definitions/modules/transition.js
+++ b/src/definitions/modules/transition.js
@@ -24,7 +24,7 @@
             $allModules     = $(this),
             moduleSelector  = $allModules.selector || '',
 
-            time            = new Date().getTime(),
+            time            = Date.now(),
             performance     = [],
 
             moduleArguments = arguments,
@@ -878,7 +878,7 @@
                             previousTime
                         ;
                         if (settings.performance) {
-                            currentTime = new Date().getTime();
+                            currentTime = Date.now();
                             previousTime = time || currentTime;
                             executionTime = currentTime - previousTime;
                             time = currentTime;


### PR DESCRIPTION
Modernize code using eslint advisory introduced in GH-2596. This PR focuses on fixing `unicorn/prefer-date-now` rule.

Needs https://github.com/fomantic/Fomantic-UI/pull/2602 merged first.