### PR TITLE
feat(icon): support custom naming and selector

### DIFF
--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -513,11 +513,14 @@ and ((@variationIconBordered) or (@variationIconCircular)) {
     }
 }
 
-.generateIcons(@map, @fontFamily) {
+.generateIcons(@map, @fontFamily: false, @pseudo: before) {
     each(@map, {
         @escapedKey: replace(@key, "^([0-9])", "\3$1 ");
-        @normalizedKey: replace(@escapedKey, "_", ".", "g");
-        i.icon.@{normalizedKey}::before {
+        @normalizedKey: replace(@escapedKey, "_", @iconClassSeparator, "g");
+        @unorderedKey: e(%(".%s::%s",@normalizedKey, @pseudo));
+        @orderedKey: e(%('[%s*="%s"]::%s', @iconForcedAttribute, @normalizedKey, @pseudo));
+        @selectorKey: if(@iconForcedOrder or @iconClassSeparator = ' ', @orderedKey, @unorderedKey);
+        i.icon@{selectorKey} {
             content: "@{value}";
             & when not (@fontFamily = false) {
                 font-family: @fontFamily;
@@ -526,19 +529,9 @@ and ((@variationIconBordered) or (@variationIconCircular)) {
     });
 };
 
-.generateSecondaryIcons(@map) {
-    each(@map, {
-        @escapedKey: replace(@key, "^([0-9])", "\3$1 ");
-        @normalizedKey: replace(@escapedKey, "_", ".", "g");
-        i.icon.@{normalizedKey}::after {
-            content: "@{value}";
-        }
-    });
-};
-
 & when (@variationIconDeprecated) {
     /* Deprecated *In/Out Naming Conflict) */
-    .generateIcons(@icon-deprecated-map, false);
+    .generateIcons(@icon-deprecated-map);
 }
 
 & when (@variationIconSolid) {
@@ -547,10 +540,10 @@ and ((@variationIconBordered) or (@variationIconCircular)) {
     *******************************/
 
     /* Icons */
-    .generateIcons(@icon-map, false);
+    .generateIcons(@icon-map);
     & when (@variationIconAliases) {
         /* Aliases */
-        .generateIcons(@icon-aliases-map, false);
+        .generateIcons(@icon-aliases-map);
     }
 }
 
@@ -564,10 +557,10 @@ and ((@variationIconBordered) or (@variationIconCircular)) {
     }
 
     /* Icons */
-    .generateIcons(@icon-outline-map, false);
+    .generateIcons(@icon-outline-map);
     & when (@variationIconAliases) {
         /* Aliases */
-        .generateIcons(@icon-outline-aliases-map, false);
+        .generateIcons(@icon-outline-aliases-map);
     }
 }
 
@@ -580,10 +573,10 @@ and ((@variationIconBordered) or (@variationIconCircular)) {
     i.icon.thin {
         font-family: @thinFontName;
     }
-    .generateIcons(@icon-thin-map, false);
+    .generateIcons(@icon-thin-map);
     & when (@variationIconAliases) {
         /* Aliases */
-        .generateIcons(@icon-thin-aliases-map, false);
+        .generateIcons(@icon-thin-aliases-map);
     }
 }
 
@@ -630,13 +623,13 @@ and ((@variationIconBordered) or (@variationIconCircular)) {
         opacity: @duotoneSecondaryOpacity;
     }
 
-    .generateIcons(@icon-duotone-map, false);
-    .generateSecondaryIcons(@icon-duotone-secondary-map);
+    .generateIcons(@icon-duotone-map);
+    .generateIcons(@icon-duotone-secondary-map, false, after);
 
     & when (@variationIconAliases) {
         /* Aliases */
-        .generateIcons(@icon-duotone-aliases-map, false);
-        .generateSecondaryIcons(@icon-duotone-secondary-aliases-map);
+        .generateIcons(@icon-duotone-aliases-map);
+        .generateIcons(@icon-duotone-secondary-aliases-map, false, after);
     }
 
     /*

--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -519,7 +519,7 @@ and ((@variationIconBordered) or (@variationIconCircular)) {
         @normalizedKey: replace(@escapedKey, "_", @iconClassSeparator, "g");
         @unorderedKey: e(%(".%s::%s",@normalizedKey, @pseudo));
         @orderedKey: e(%('[%s*="%s"]::%s', @iconForcedAttribute, @normalizedKey, @pseudo));
-        @selectorKey: if(@iconForcedOrder or @iconClassSeparator = ' ', @orderedKey, @unorderedKey);
+        @selectorKey: if(@iconForcedOrder or @iconClassSeparator = " ", @orderedKey, @unorderedKey);
         i.icon@{selectorKey} {
             content: "@{value}";
             & when not (@fontFamily = false) {

--- a/src/themes/default/elements/icon.variables
+++ b/src/themes/default/elements/icon.variables
@@ -78,7 +78,10 @@ Icons are order A-Z in their group, Solid, Outline, Thin (Pro only) and Brand
     };
 };
 
-// Underscores in map keys will be replaced by dots to separate classnames at compile time
+// Underscores in map keys will be replaced by @iconClassSeparator to separate classnames at compile time
+@iconClassSeparator: ".";
+@iconForcedOrder: false;
+@iconForcedAttribute: class;
 
 /* Deprecated (In/Out Naming Conflict) */
 @icon-deprecated-map: {


### PR DESCRIPTION
## Description
This PR allows for custom selector strategies for icons.

Especially for Fontawesome Pro there are icons which share the exact same words but in a different order ("foo-bar" and "bar-foo" are 2 different icons). This wouldn't work using the default fui logic 

```less
i.icon.foo.bar::before {}
```

Now, it's possible to adjust 3 new variables which would allow different icon class selectors

#### 1. Ordered selector
```less
@iconClassSeparator: " "; // a space separator automatically forces order
// or
@iconForcedOrder: true;
```
results in
```less
i.icon[class*="foo bar"]::before {}
```

####  2. Dashed one word selector
```less
@iconClassSeparator: "-";
```
results in
```less
i.icon.foo-bar::before {}
```

#### 3. Use data attribute instead of classname (this was originally planned as default for 3.0) and optionall use a custom class separator
```less
@iconClassSeparator: "_";
@iconForcedOrder: true;
@iconForcedAttribute: data-icon
```
results in
```less
i.icon[data-icon*="foo_bar"]::before {}
```

I also simplified the generateIcon function so it can be reused for duotone icons (because the only difference is the pseudo selector)

## Testcase
http://lesscss.org/less-preview/#eyJjb2RlIjoiQGljb24tbWFwOiB7XG4gICAgd2lraXBlZGlhOiBcIlxcZjI2NlwiO1xuICAgIHdvcmRwcmVzc19iZWdpbm5lcjogXCJcXGYyOTdcIjtcbiAgICB3b3JkcHJlc3NfZm9ybXM6IFwiXFxmMjk4XCI7XG4gICAgeWM6IFwiXFxmMjNiXCI7XG4gICAgeWNvbWJpbmF0b3I6IFwiXFxmMjNiXCI7XG4gICAgeW91dHViZV9wbGF5OiBcIlxcZjE2N1wiO1xufTtcblxuICAgICAgXG5AaWNvbkNsYXNzU2VwYXJhdG9yOiBcIi5cIjtcbkBpY29uRm9yY2VkT3JkZXI6IGZhbHNlO1xuQGljb25Gb3JjZWRBdHRyaWJ1dGU6IGNsYXNzO1xuXG4uZ2VuZXJhdGVJY29ucyhAaWNvbi1tYXApO1xuXG4uZ2VuZXJhdGVJY29ucyhAbWFwLCBAZm9udEZhbWlseTogZmFsc2UsIEBwc2V1ZG86IGJlZm9yZSkge1xuICAgIGVhY2goQG1hcCwge1xuICAgICAgICBAZXNjYXBlZEtleTogcmVwbGFjZShAa2V5LCBcIl4oWzAtOV0pXCIsIFwiXFwzJDEgXCIpO1xuICAgICAgICBAbm9ybWFsaXplZEtleTogcmVwbGFjZShAZXNjYXBlZEtleSwgXCJfXCIsIEBpY29uQ2xhc3NTZXBhcmF0b3IsIFwiZ1wiKTtcbiAgICAgICAgQHVub3JkZXJlZEtleTogZSglKFwiLiVzOjolc1wiLEBub3JtYWxpemVkS2V5LCBAcHNldWRvKSk7XG4gICAgICAgIEBvcmRlcmVkS2V5OiBlKCUoJ1slcyo9XCIlc1wiXTo6JXMnLCBAaWNvbkZvcmNlZEF0dHJpYnV0ZSwgQG5vcm1hbGl6ZWRLZXksIEBwc2V1ZG8pKTtcbiAgICAgICAgQHNlbGVjdG9yS2V5OiBpZihAaWNvbkZvcmNlZE9yZGVyIG9yIEBpY29uQ2xhc3NTZXBhcmF0b3IgPSAnICcsIEBvcmRlcmVkS2V5LCBAdW5vcmRlcmVkS2V5KTtcbiAgICAgICAgaS5pY29uQHtzZWxlY3RvcktleX0ge1xuICAgICAgICAgICAgY29udGVudDogXCJAe3ZhbHVlfVwiO1xuICAgICAgICAgICAgJiB3aGVuIG5vdCAoQGZvbnRGYW1pbHkgPSBmYWxzZSkge1xuICAgICAgICAgICAgICAgIGZvbnQtZmFtaWx5OiBAZm9udEZhbWlseTtcbiAgICAgICAgICAgIH1cbiAgICAgICAgfVxuICAgIH0pO1xufTsiLCJhY3RpdmVWZXJzaW9uIjoiNC4xLjMifQ==