### PR TITLE
feat(build): adjust autoprefixer config to match 2.9.0 browser support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Fomantic includes an interactive installer to help setup your project.
 * IE 11[^2]
 * Microsoft Edge 12-44[^2]
 
-[^1]: Fomantic-UI should basically still work in iOS Safari 9+, Android 4.4+, but, starting from v2.9.0, we won't support them anymore if anything works different than in recent versions.
+[^1]: Fomantic-UI should basically still work in iOS Safari 9+, Android 6+, but, starting from v2.9.0, we won't support them anymore if anything works different than in recent versions.
 [^2]: Fomantic-UI should basically still work in IE11 / old Edge, but, starting from v2.9.0, we won't support them anymore in terms of dedicated bugfixes.
 
 ---

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@octokit/core": "^3.6.0",
     "@octokit/rest": "^16.16.0",
     "better-console": "^1.0.1",
-    "browserslist": "^4.19.1",
+    "browserslist": "^4.21.4",
     "del": "^6.1.1",
     "extend": "^3.0.2",
     "gulp": "^4.0.0",

--- a/tasks/config/tasks.js
+++ b/tasks/config/tasks.js
@@ -9,13 +9,19 @@ let defaultBrowsers = browserslist(browserslist.defaults);
 let userBrowsers = browserslist();
 let hasBrowserslistConfig = JSON.stringify(defaultBrowsers) !== JSON.stringify(userBrowsers);
 
-let overrideBrowserslist = hasBrowserslistConfig ? undefined : [
-    'last 2 versions',
-    '> 1%',
-    'opera 12.1',
-    'bb 10',
-    'android 4',
-];
+var prefix = config.prefix || {};
+if (!prefix.overrideBrowserslist && !hasBrowserslistConfig) {
+    prefix.overrideBrowserslist = [
+        'last 2 Chrome versions',
+        'last 2 Firefox versions',
+        'last 2 Safari versions',
+        'last 4 iOS major versions',
+        'last 4 Android major versions',
+        'last 4 ChromeAndroid versions',
+        'Edge 12',
+        'ie 11',
+    ];
+}
 
 // Node 12 does not support ??, so a little polyfill
 let nullish = (value, fallback) => (value !== undefined && value !== null ? value : fallback);
@@ -136,10 +142,8 @@ module.exports = {
             },
         },
 
-        /* What Browsers to Prefix */
-        prefix: {
-            overrideBrowserslist: overrideBrowserslist,
-        },
+        /* Browserslist Prefix config */
+        prefix: prefix,
 
         /* File Renames */
         rename: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -774,7 +774,7 @@ braces@^3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
-browserslist@^4.19.1, browserslist@^4.21.4:
+browserslist@^4.21.4:
   version "4.21.4"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.4.tgz#e7496bbc67b9e39dd0f98565feccdcb0d4ff6987"
   integrity sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==


### PR DESCRIPTION
## Description
The default browserlist settings were still supporting old legacy browsers which we reduced in 2.9.0.
This PR adjust the browserlist setting so much less prefixes (if any) are added to the css files.
This PR also allows to configure a whole autoprefixer prefix-config instead of only the overrideBrowserslist attribute.