### PR TITLE
fix(ci): color git diff output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         yarn add -D github:fomantic/prettier#2.8.1-patched
         && npx prettier --loglevel warn '!dist' '!test/coverage' '!src/semantic.less' '**/*.{css,less,overrides,variables}' --write
         && git restore package.json yarn.lock
-        && git add . -N && git diff --exit-code
+        && git add . -N && git diff --color --exit-code
   test:
     name: Test build process on node ${{ matrix.node-version }}
     runs-on: ubuntu-latest

--- a/src/definitions/elements/flag.less
+++ b/src/definitions/elements/flag.less
@@ -21,8 +21,12 @@
              Flag
 *******************************/
 
-bodytest {
-    shoulebefoundbyprettier: test
+body {
+    margin:
+     1px
+   2px
+     3px
+  4px
     ;
 }
 i.flag:not(.icon) {

--- a/src/definitions/elements/flag.less
+++ b/src/definitions/elements/flag.less
@@ -21,13 +21,6 @@
              Flag
 *******************************/
 
-body {
-    margin:
-     1px
-   2px
-     3px
-  4px;
-}
 i.flag:not(.icon) {
     speak: none;
     backface-visibility: hidden;

--- a/src/definitions/elements/flag.less
+++ b/src/definitions/elements/flag.less
@@ -21,6 +21,10 @@
              Flag
 *******************************/
 
+bodytest {
+    shoulebefoundbyprettier: test
+    ;
+}
 i.flag:not(.icon) {
     speak: none;
     backface-visibility: hidden;

--- a/src/definitions/elements/flag.less
+++ b/src/definitions/elements/flag.less
@@ -26,8 +26,7 @@ body {
      1px
    2px
      3px
-  4px
-    ;
+  4px;
 }
 i.flag:not(.icon) {
     speak: none;


### PR DESCRIPTION
## Description
in case prettier finds an error, the git  diff is hard to recognize the actual difference so one knows what to fix.
I added the `--color` switch so the changes are easier recognizable in the actions log

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/209202931-f5858aa6-5a84-4d07-87f7-1ed1afae3bd1.png)
