### PR TITLE
fix(chore): dont assign exoego for autoreview anymore

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -7,5 +7,4 @@ reviewers:
   - ColinFrick
   - prudho
   - lubber-de
-  - exoego
   - ko2in


### PR DESCRIPTION
## Description
As exoego left the team, he should not get autoassigned to reviews anymore