### PR TITLE
fix(chore): fix eslint default config major versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
     - name: Install dependencies
-      run: yarn && yarn add -D eslint-config-airbnb-base eslint-plugin-unicorn eslint-plugin-jest@^26.9.0 @typescript-eslint/eslint-plugin @typescript-eslint/parser typescript
+      run: yarn && yarn add -D eslint-config-airbnb-base@^15 eslint-plugin-unicorn@^45 eslint-plugin-jest@^26.9.0 @typescript-eslint/eslint-plugin @typescript-eslint/parser typescript
     - name: Lint JS and LESS files
       run: npm run lint
     - name: Assert LESS files formatting using Prettier


### PR DESCRIPTION
## Description
This PR adjusts the default config versions for eslint airbnb and unicorn to the current major versions which are approved to work with our custom rules setting, as our own rules extend their defaults.
By the current logic, always the latest versions are taken, which would mean our CI could break if new major versions of the default rules introduce some changes not reflected in our code.
