### PR TITLE
fix(dropdown): dont reopen menu on forceselection and search blur

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1361,7 +1361,7 @@
                             var
                                 $choice        = $(this),
                                 $target        = event
-                                    ? $(event.target)
+                                    ? $(event.target || '')
                                     : $(''),
                                 $subMenu       = $choice.find(selector.menu),
                                 text           = module.get.choiceText($choice),
@@ -1379,7 +1379,7 @@
                                         module.remove.userAddition();
                                     }
                                     module.remove.filteredItem();
-                                    if (!module.is.visible()) {
+                                    if (!module.is.visible() && $target.length > 0) {
                                         module.show();
                                     }
                                     module.remove.searchTerm();


### PR DESCRIPTION
## Description
blurring from a search dropdown having `forceSelection:true` let into reopening, thus focusing, the dropdown again. This was due to calling the `item.click` function internally without a given event. In such cases the menu should never be opened again

## Testcase
- On the page, click the dropdown and click on a list item to select it
- Click on another field on the page

### Broken
https://jsfiddle.net/qjd7ur6L/

### Fixed
https://jsfiddle.net/lubber/thzxcjp4/4/

## Closes
#2537 