### PR TITLE
feat(dropdown): dont animate labels when no transition is given

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -2829,7 +2829,7 @@
                         if (settings.label.variation) {
                             $label.addClass(settings.label.variation);
                         }
-                        if (shouldAnimate === true) {
+                        if (shouldAnimate === true && settings.label.transition) {
                             module.debug('Animating in label', $label);
                             $label
                                 .addClass(className.hidden)


### PR DESCRIPTION
## Description

This PR allows to disable animation transitions for labels of a multiple dropdown via
```javascript
$('.ui.dropdown').dropdown({
  label: {
  	transition: false
  }
});
```
This might be useful in situations where the dropdown element is reattached in the DOM while the animation still takes place (and was triggered via javascript for example by "set selected"

## Testcase
https://jsfiddle.net/lubber/pjw105ht/5/

## Closes
#2646 
