### PR TITLE
feat(search): all and some words for fullTextSearch

### DIFF
--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -674,7 +674,10 @@
                                         // content starts with value (first in results)
                                         addResult(results, content);
                                     } else if (settings.fullTextSearch === 'exact' && module.exactSearch(searchTerm, text)) {
-                                        // content fuzzy matches (last in results)
+                                        addResult(exactResults, content);
+                                    } else if (settings.fullTextSearch === 'some' && module.wordSearch(searchTerm, text)) {
+                                        addResult(exactResults, content);
+                                    } else if (settings.fullTextSearch === 'all' && module.wordSearch(searchTerm, text, true)) {
                                         addResult(exactResults, content);
                                     } else if (settings.fullTextSearch === true && module.fuzzySearch(searchTerm, text)) {
                                         // content fuzzy matches (last in results)
@@ -694,6 +697,21 @@
                     term = term.toLowerCase();
 
                     return term.indexOf(query) > -1;
+                },
+                wordSearch: function (query, term, matchAll) {
+                    var allWords = query.split(/\s+/),
+                        w,
+                        wL = allWords.length,
+                        found = false
+                    ;
+                    for (w = 0; w < wL; w++) {
+                        found = module.exactSearch(allWords[w], term);
+                        if (found && !matchAll) {
+                            break;
+                        }
+                    }
+
+                    return found;
                 },
                 fuzzySearch: function (query, term) {
                     var

--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -670,7 +670,7 @@
                                     text = typeof content[field] === 'string'
                                         ? module.remove.diacritics(content[field])
                                         : content[field].toString();
-                                    if (text.search(matchRegExp) !== -1) {
+                                    if (settings.fullTextSearch !== 'all' && text.search(matchRegExp) !== -1) {
                                         // content starts with value (first in results)
                                         addResult(results, content);
                                     } else if (settings.fullTextSearch === 'exact' && module.exactSearch(searchTerm, text)) {
@@ -706,7 +706,7 @@
                     ;
                     for (w = 0; w < wL; w++) {
                         found = module.exactSearch(allWords[w], term);
-                        if (found && !matchAll) {
+                        if ((!found && matchAll) || (found && !matchAll)) {
                             break;
                         }
                     }

--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -660,8 +660,10 @@
                             return [];
                         }
                         // iterate through search fields looking for matches
-                        $.each(searchFields, function (index, field) {
-                            $.each(source, function (label, content) {
+                        var lastSearchFieldIndex = searchFields.length - 1;
+                        $.each(source, function (label, content) {
+                            var concatenatedContent = [];
+                            $.each(searchFields, function (index, field) {
                                 var
                                     fieldExists = (typeof content[field] === 'string') || (typeof content[field] === 'number')
                                 ;
@@ -670,6 +672,13 @@
                                     text = typeof content[field] === 'string'
                                         ? module.remove.diacritics(content[field])
                                         : content[field].toString();
+                                    if (settings.fullTextSearch === 'all') {
+                                        concatenatedContent.push(text);
+                                        if (index < lastSearchFieldIndex) {
+                                            return true;
+                                        }
+                                        text = concatenatedContent.join(' ');
+                                    }
                                     if (settings.fullTextSearch !== 'all' && text.search(matchRegExp) !== -1) {
                                         // content starts with value (first in results)
                                         addResult(results, content);


### PR DESCRIPTION
## Description

Added two new fullTextSearch options `some` and `all`

### some
Will do the same as `exact` but supports multiple search values separated by whitespace. At least one word must match

### all
Same as `some` but **all** words have to match in **all** given searchfields of each record altogether

## Testcase
- Enter "sout" and "bra"

#### No results
https://jsfiddle.net/lubber/gc8mfunL/8/

#### Found
Brazil is found in South America
https://jsfiddle.net/lubber/gc8mfunL/9/

## Screenshots
#### No results
![image](https://user-images.githubusercontent.com/18379884/212079282-26812e7d-53d2-4856-a386-745757087e41.png)

#### Found
![image](https://user-images.githubusercontent.com/18379884/212080152-be8246c7-4f0f-48ff-84b2-9f692da810f4.png)

## Closes
This is used/needed for the icon search at https://fomantic-ui.com/elements/icon.html to fix
https://github.com/fomantic/Fomantic-UI-Docs/issues/390
https://github.com/fomantic/Fomantic-UI-Docs/issues/403
