### PR TITLE
fix(chore): unify invoke method, removed unused error strings

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1470,6 +1470,8 @@
 
                                 return false;
                             } else {
+                                module.error(error.method, query);
+
                                 return false;
                             }
                         });

--- a/src/definitions/behaviors/state.js
+++ b/src/definitions/behaviors/state.js
@@ -626,7 +626,6 @@
 
         // error
         error: {
-            beforeSend: 'The before send function has cancelled state change',
             method: 'The method you called is not defined.',
         },
 

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -1256,6 +1256,8 @@
 
                                 return false;
                             } else {
+                                module.error(error.method, query);
+
                                 return false;
                             }
                         });

--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -1282,6 +1282,8 @@
 
                                 return false;
                             } else {
+                                module.error(error.method, query);
+
                                 return false;
                             }
                         });

--- a/src/definitions/modules/rating.js
+++ b/src/definitions/modules/rating.js
@@ -40,6 +40,7 @@
 
                 namespace       = settings.namespace,
                 className       = settings.className,
+                error           = settings.error,
                 metadata        = settings.metadata,
                 selector        = settings.selector,
                 cssVars         = settings.cssVars,
@@ -431,6 +432,8 @@
 
                                 return false;
                             } else {
+                                module.error(error.method, query);
+
                                 return false;
                             }
                         });
@@ -492,7 +495,6 @@
 
         error: {
             method: 'The method you called is not defined',
-            noMaximum: 'No maximum rating specified. Cannot generate HTML automatically',
         },
 
         metadata: {

--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -1234,6 +1234,8 @@
 
                                 return false;
                             } else {
+                                module.error(error.method, query);
+
                                 return false;
                             }
                         });
@@ -1368,8 +1370,6 @@
             source: 'Cannot search. No source used, and Fomantic API module was not included',
             noResultsHeader: 'No Results',
             noResults: 'Your search returned no results',
-            logging: 'Error in debug logging, exiting.',
-            noEndpoint: 'No search endpoint was specified',
             noTemplate: 'A valid template name was not specified.',
             oldSearchSyntax: 'searchFullText setting has been renamed fullTextSearch for consistency, please adjust your settings.',
             serverError: 'There was an issue querying the server.',

--- a/src/definitions/modules/shape.js
+++ b/src/definitions/modules/shape.js
@@ -709,6 +709,8 @@
 
                                 return false;
                             } else {
+                                module.error(error.method, query);
+
                                 return false;
                             }
                         });

--- a/src/definitions/modules/sticky.js
+++ b/src/definitions/modules/sticky.js
@@ -377,8 +377,6 @@
                             tagName = $container[0].tagName
                         ;
                         if (tagName === 'HTML' || tagName === 'body') {
-                            // this can trigger for too many reasons
-                            // module.error(error.container, tagName, $module);
                             module.determineContainer();
                         } else {
                             var tallestHeight = Math.max(module.cache.context.height, module.cache.element.height);
@@ -804,6 +802,8 @@
 
                                 return false;
                             } else {
+                                module.error(error.method, query);
+
                                 return false;
                             }
                         });
@@ -896,7 +896,6 @@
         onBottom: function () {},
 
         error: {
-            container: 'Sticky element must be inside a relative container',
             visible: 'Element is hidden, you must call refresh after element becomes visible. Use silent setting to suppress this warning in production.',
             method: 'The method you called is not defined.',
             invalidContext: 'Context specified does not exist',

--- a/src/definitions/modules/transition.js
+++ b/src/definitions/modules/transition.js
@@ -960,6 +960,8 @@
 
                                 return false;
                             } else {
+                                module.error(error.method, query);
+
                                 return false;
                             }
                         });
@@ -1075,7 +1077,6 @@
         // possible errors
         error: {
             noAnimation: 'Element is no longer attached to DOM. Unable to animate.  Use silent setting to suppress this warning in production.',
-            repeated: 'That animation is already occurring, cancelling repeated animation',
             method: 'The method you called is not defined',
             support: 'This browser does not support CSS animations',
         },


### PR DESCRIPTION
## Description
Some modules missed the error message when a given behavior does not exist, although the error string was already present in the code.
On the other hand there were some unused error strings, which i removed.