### PR TITLE
fix(menu): labeled right menu icon size

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -1277,7 +1277,7 @@ Floated Menu / Item
     }
 
     /* Icon */
-    .ui.labeled.icon.menu .right.menu > .item > i.icon:not(.dropdown),
+    .ui.labeled.icon.menu > .right.menu > .item > i.icon:not(.dropdown),
     .ui.labeled.icon.menu > .item > i.icon:not(.dropdown) {
         height: 1em;
         display: block;

--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -1277,6 +1277,7 @@ Floated Menu / Item
     }
 
     /* Icon */
+    .ui.labeled.icon.menu .right.menu > .item > i.icon:not(.dropdown),
     .ui.labeled.icon.menu > .item > i.icon:not(.dropdown) {
         height: 1em;
         display: block;


### PR DESCRIPTION
## Description

icons inside "right menu" of a "labeled menu" were not properly displayed since #111
As a labeled menu can contain dropdowns with themselves can also contain a right menu, we have to be careful of nested selectors here. That's why i did not simply revert the original patch (and we would need to remove and test losts of !important settings which most probably breaks a lot of other use cases)

## Testcase
Remove CSS to see the issue
https://jsfiddle.net/lubber/6hf9zxuw/4/

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/18379884/212466533-4a32bdbe-f5f4-4bc7-95b0-e3960e9b9680.png)

### After
![image](https://user-images.githubusercontent.com/18379884/212466515-31353054-0123-4df0-b5f5-7a0b5d9340ac.png)

## Closes
#2653 
