### PR TITLE
fix(transition): reverted missing invoke method error

### DIFF
--- a/src/definitions/modules/transition.js
+++ b/src/definitions/modules/transition.js
@@ -960,7 +960,6 @@
 
                                 return false;
                             } else {
-                                module.error(error.method, query);
 
                                 return false;
                             }
@@ -1077,7 +1076,6 @@
         // possible errors
         error: {
             noAnimation: 'Element is no longer attached to DOM. Unable to animate.  Use silent setting to suppress this warning in production.',
-            method: 'The method you called is not defined',
             support: 'This browser does not support CSS animations',
         },
 

--- a/src/definitions/modules/transition.js
+++ b/src/definitions/modules/transition.js
@@ -960,7 +960,6 @@
 
                                 return false;
                             } else {
-
                                 return false;
                             }
                         });


### PR DESCRIPTION
## Description

The invoke method in transition module works slightly different than in all other modules as a non existend string behavior is used as animationname instead. This PR removes the console message when an animation name is not found as invoked behavior string.

## Closes
#2659 