### PR TITLE
feat(lint): upgrade prettier to 2.8.3-patched

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       run: npm run lint
     - name: Assert LESS files formatting using Prettier
       run: >
-        yarn add -D github:fomantic/prettier#2.8.1-patched
+        yarn add -D github:fomantic/prettier#2.8.3-patched
         && npx prettier --loglevel warn '!dist' '!test/coverage' '!src/semantic.less' '**/*.{css,less,overrides,variables}' --write
         && git restore package.json yarn.lock
         && git add . -N && git diff --color --exit-code


### PR DESCRIPTION
prettier v2.8.3 was fixed officially excl. one last patch - see https://github.com/fomantic/prettier/releases/tag/2.8.3-patched