### PR TITLE
fix(theme): dont conditional import variables to avoid scoping

### DIFF
--- a/src/theme.less
+++ b/src/theme.less
@@ -16,14 +16,10 @@
 @import "@{themesFolder}/default/globals/site.variables";
 
 /* Packaged site.variables */
-& when not (@site = "default") {
-    @import (optional) "@{themesFolder}/@{site}/globals/site.variables";
-}
+@import (optional) "@{themesFolder}/@{site}/globals/site.variables";
 
 /* Component's site.variables */
-& when not (@theme = "default") {
-    @import (optional) "@{themesFolder}/@{theme}/globals/site.variables";
-}
+@import (optional) "@{themesFolder}/@{theme}/globals/site.variables";
 
 /* Site theme site.variables */
 @import (optional) "@{siteFolder}/globals/site.variables";
@@ -49,14 +45,10 @@
 @import "@{themesFolder}/default/globals/colors.less";
 
 /* Packaged colors.less */
-& when not (@site = "default") {
-    @import (optional) "@{themesFolder}/@{site}/globals/colors.less";
-}
+@import (optional) "@{themesFolder}/@{site}/globals/colors.less";
 
 /* Packaged Theme */
-& when not (@theme = "default") {
-    @import (optional) "@{themesFolder}/@{theme}/globals/colors.less";
-}
+@import (optional) "@{themesFolder}/@{theme}/globals/colors.less";
 
 /* Site Theme */
 @import (optional) "@{siteFolder}/globals/colors.less";


### PR DESCRIPTION
## Description

The theme.less file imports variables from a 3 layer logic, meant to possibly override previous defined variables for custom theming.
In 2.9 we implemented conditional checks if an element has got a custom theme to avoid importing the files multiple times.
Unfortunately this activated scoping, which means variables from a theme did not override the default variables anymore or, even worse, a custom element cannot access the same custom site.variables.

This PR now removes the conditional checks again. It does not hurt even if the same variable files are imported multiple time, as everything which is not LESS variable inside those files is removed by the gulp pipeline after building.

## Closes
#2666 