### PR TITLE
fix(build): fix path creation to avoid always using default settings

### DIFF
--- a/tasks/config/project/install.js
+++ b/tasks/config/project/install.js
@@ -127,7 +127,7 @@ module.exports = {
             }
         ;
         // start walk from current directory if none specified
-        directory = directory || path.join((__dirname, path.sep));
+        directory = directory || path.join(__dirname, path.sep);
 
         return walk(directory);
     },


### PR DESCRIPTION
## Description

The config path was not detected anymore in 2.9.1 leading into always using the defaults and, for example, autoinstall via semantic.json was not working anymore

## Closes
#2660 