### PR TITLE
fix(modal): remove active class on hide

### DIFF
--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -673,6 +673,7 @@
                                     },
                                     onComplete: function () {
                                         module.unbind.scrollLock();
+                                        module.remove.active();
                                         if (settings.allowMultiple) {
                                             $previousModal.addClass(className.front);
                                             $module.removeClass(className.front);

--- a/src/definitions/modules/transition.js
+++ b/src/definitions/modules/transition.js
@@ -216,7 +216,7 @@
                             module.restore.conditions();
                             module.hide();
                         } else if (module.is.inward()) {
-                            module.verbose('Animation is outward, showing element');
+                            module.verbose('Animation is inward, showing element');
                             module.restore.conditions();
                             module.show();
                         } else {


### PR DESCRIPTION
## Description
Also remove the `active` class when a modal is hidden. This makes sure the modal doesnt keep an in between added active class if `hide` was called when the `show` transition has not already ended. The class is already removed at the start of the hiding process and it is still needed there because of CSS settings which will otherwise disturb the hide animation.
This PR fixes such a specific use case 

## Closes
#2528 