### PR TITLE
fix(dropdown): compact menu items were cut

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -1,9 +1,8 @@
-/*
- * # Fomantic - Menu
+/*!
+ * # Fomantic-UI - Menu
  * https://github.com/fomantic/Fomantic-UI/
  *
  *
- * Copyright 2015 Contributor
  * Released under the MIT license
  * https://opensource.org/licenses/MIT
  *

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -425,6 +425,12 @@ select.ui.dropdown {
         /* Compact */
         .ui.compact.selection.dropdown {
             min-width: 0;
+            & > .menu {
+                width: auto;
+            }
+            &:not(.multiline) {
+                width: max-content;
+            }
         }
     }
 


### PR DESCRIPTION
## Description
Whenever a `compact selection dropdown` has got large menu items and a shorter menu item was selected, the whole dropdown menu was shrinked to the selected item width which in turn cropped all other items when the menu was opened again

This PR make sure by default the items text is not cropped and shown in one line.
In case somebody wants to wrap item text by whitespace one could add `multiline` to the menu node.

@BBX999 This closes your issue in the SUI repo where i am not allowed to post anymore 

## Screenshot

### Broken
![compactdropdownbroken](https://user-images.githubusercontent.com/18379884/215071622-f4fa5bf3-4be3-4b3b-88ad-f1a9392dec54.gif)

### Fixed
![compactdropdownfixedgif](https://user-images.githubusercontent.com/18379884/215071645-7cd29fb4-564d-479e-b1fb-9b61b9fcf653.gif)

## Testcase
Remove the CSS to see the issue
https://jsfiddle.net/lubber/s56mgjc3/4/

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/7107