### PR TITLE
fix(build): allow gulp install from direct checkout folder

### DIFF
--- a/tasks/install.js
+++ b/tasks/install.js
@@ -77,8 +77,8 @@ module.exports = function (callback) {
         return;
     }
 
-    if (!manager) {
-        console.log('\u001B[92mgulp install\u001B[0m must run inside \u001B[92mnode_modules' + path.sep + 'fomantic-ui\u001B[0m');
+    if (!fs.existsSync(source.site)) {
+        console.log('Missing _site folder. \u001B[92mgulp install\u001B[0m must run inside \u001B[92mnode_modules' + path.sep + 'fomantic-ui\u001B[0m');
         console.error('Aborting.');
         callback();
 


### PR DESCRIPTION
## Description

The strict check for running gulp install inside node_modules was breaking the nightly build. The only necessary check was to look for the _site folder, so i adjusted that , so gulp install also works when FUI for example was just cloned from git wihtout being inside node_modules)