### PR TITLE
feat(formvalidation): support object list in add errors

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -596,7 +596,7 @@
                         // refresh selector cache
                         (instance || module).refresh();
                     },
-                    field: function (identifier) {
+                    field: function (identifier, strict) {
                         module.verbose('Finding field with identifier', identifier);
                         identifier = module.escape.string(identifier);
                         var t;
@@ -618,7 +618,7 @@
                         }
                         module.error(error.noField.replace('{identifier}', identifier));
 
-                        return $('<input/>');
+                        return strict ? [] : $('<input/>');
                     },
                     fields: function (fields) {
                         var
@@ -641,30 +641,14 @@
                             ? $label.text()
                             : $field.prop('placeholder') || (useIdAsFallback ? identifier : settings.text.unspecifiedField);
                     },
-                    fieldValue: function (identifier, $module) {
+                    fieldValue: function (identifier) {
                         // use either id or name of field
                         var
                             matchingValue,
-                            matchingElement
+                            matchingElement = module.get.field(identifier, true)
                         ;
-                        matchingElement = $module.find('[data-validate="' + identifier + '"]');
                         if (matchingElement.length > 0) {
                             matchingValue = matchingElement.val();
-                        } else {
-                            matchingElement = $module.find('#' + identifier);
-                            if (matchingElement.length > 0) {
-                                matchingValue = matchingElement.val();
-                            } else {
-                                matchingElement = $module.find('[name="' + identifier + '"]');
-                                if (matchingElement.length > 0) {
-                                    matchingValue = matchingElement.val();
-                                } else {
-                                    matchingElement = $module.find('[name="' + identifier + '[]"]');
-                                    if (matchingElement.length > 0) {
-                                        matchingValue = matchingElement;
-                                    }
-                                }
-                            }
                         }
 
                         return matchingValue;
@@ -822,16 +806,8 @@
 
                     field: function (identifier) {
                         module.verbose('Checking for existence of a field with identifier', identifier);
-                        identifier = module.escape.string(identifier);
-                        if (typeof identifier !== 'string') {
-                            module.error(error.identifier, identifier);
-                        }
 
-                        return (
-                            $field.filter('#' + identifier).length > 0
-                                || $field.filter('[name="' + identifier + '"]').length > 0
-                                || $field.filter('[data-' + metadata.validate + '="' + identifier + '"]').length > 0
-                        );
+                        return module.get.field(identifier, true).length > 0;
                     },
 
                 },
@@ -1696,7 +1672,6 @@
         },
 
         error: {
-            identifier: 'You must specify a string identifier for each field',
             method: 'The method you called is not defined.',
             noRule: 'There is no rule matching the one you specified',
             noField: 'Field identifier {identifier} not found',
@@ -1959,7 +1934,7 @@
 
             // matches another field
             match: function (value, identifier, $module, module) {
-                var matchingValue = module.get.fieldValue(identifier, $module);
+                var matchingValue = module.get.fieldValue(identifier);
 
                 return matchingValue !== undefined
                     ? value.toString() === matchingValue.toString()
@@ -1968,7 +1943,7 @@
 
             // different than another field
             different: function (value, identifier, $module, module) {
-                var matchingValue = module.get.fieldValue(identifier, $module);
+                var matchingValue = module.get.fieldValue(identifier);
 
                 return matchingValue !== undefined
                     ? value.toString() !== matchingValue.toString()

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -627,7 +627,7 @@
 
                         return $fields;
                     },
-                    fieldLabel: function(identifier) {
+                    fieldLabel: function (identifier) {
                         var $field = typeof identifier === 'string'
                                 ? module.get.field(identifier)
                                 : identifier,
@@ -824,7 +824,7 @@
                     },
                 },
 
-                checkErrors: function(errors, internal) {
+                checkErrors: function (errors, internal) {
                     if (!errors || errors.length === 0) {
                         if (!internal) {
                             module.error(settings.error.noErrorMessage);

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -618,14 +618,14 @@
                         }
                         module.error(error.noField.replace('{identifier}', identifier));
 
-                        return strict ? [] : $('<input/>');
+                        return strict ? $() : $('<input/>');
                     },
-                    fields: function (fields) {
+                    fields: function (fields, strict) {
                         var
                             $fields = $()
                         ;
                         $.each(fields, function (index, name) {
-                            $fields = $fields.add(module.get.field(name));
+                            $fields = $fields.add(module.get.field(name, strict));
                         });
 
                         return $fields;
@@ -640,18 +640,6 @@
                         return $label.length === 1
                             ? $label.text()
                             : $field.prop('placeholder') || (useIdAsFallback ? identifier : settings.text.unspecifiedField);
-                    },
-                    fieldValue: function (identifier) {
-                        // use either id or name of field
-                        var
-                            matchingValue,
-                            matchingElement = module.get.field(identifier, true)
-                        ;
-                        if (matchingElement.length > 0) {
-                            matchingValue = matchingElement.val();
-                        }
-
-                        return matchingValue;
                     },
                     validation: function ($field) {
                         var
@@ -675,20 +663,22 @@
 
                         return fieldValidation || false;
                     },
-                    value: function (field) {
+                    value: function (field, strict) {
                         var
                             fields = [],
-                            results
+                            results,
+                            resultKeys
                         ;
                         fields.push(field);
-                        results = module.get.values.call(element, fields);
+                        results = module.get.values.call(element, fields, strict);
+                        resultKeys = Object.keys(results);
 
-                        return results[field];
+                        return resultKeys.length > 0 ? results[resultKeys[0]] : undefined;
                     },
-                    values: function (fields) {
+                    values: function (fields, strict) {
                         var
                             $fields = Array.isArray(fields)
-                                ? module.get.fields(fields)
+                                ? module.get.fields(fields, strict)
                                 : $field,
                             values = {}
                         ;
@@ -1371,7 +1361,7 @@
                                         ? String(value + '').trim()
                                         : String(value + ''));
 
-                                return ruleFunction.call(field, value, ancillary, $module, module);
+                                return ruleFunction.call(field, value, ancillary, module);
                             }
                         ;
                         if (!isFunction(ruleFunction)) {
@@ -1933,8 +1923,8 @@
             },
 
             // matches another field
-            match: function (value, identifier, $module, module) {
-                var matchingValue = module.get.fieldValue(identifier);
+            match: function (value, identifier, module) {
+                var matchingValue = module.get.value(identifier, true);
 
                 return matchingValue !== undefined
                     ? value.toString() === matchingValue.toString()
@@ -1942,8 +1932,8 @@
             },
 
             // different than another field
-            different: function (value, identifier, $module, module) {
-                var matchingValue = module.get.fieldValue(identifier);
+            different: function (value, identifier, module) {
+                var matchingValue = module.get.value(identifier, true);
 
                 return matchingValue !== undefined
                     ? value.toString() !== matchingValue.toString()

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -549,6 +549,9 @@
                             prompt = prompt.replace(/{min}/g, parts[0]);
                             prompt = prompt.replace(/{max}/g, parts[1]);
                         }
+                        if (ancillary && ['match', 'different'].indexOf(ruleName) >= 0) {
+                            prompt = prompt.replace(/{ruleValue}/g, module.get.fieldLabel(ancillary, true));
+                        }
                         if (requiresValue) {
                             prompt = prompt.replace(/{value}/g, $field.val());
                         }
@@ -627,7 +630,7 @@
 
                         return $fields;
                     },
-                    fieldLabel: function (identifier) {
+                    fieldLabel: function (identifier, useIdAsFallback) {
                         var $field = typeof identifier === 'string'
                                 ? module.get.field(identifier)
                                 : identifier,
@@ -636,7 +639,7 @@
 
                         return $label.length === 1
                             ? $label.text()
-                            : $field.prop('placeholder') || settings.text.unspecifiedField;
+                            : $field.prop('placeholder') || (useIdAsFallback ? identifier : settings.text.unspecifiedField);
                     },
                     fieldValue: function (identifier, $module) {
                         // use either id or name of field

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -638,6 +638,34 @@
                             ? $label.text()
                             : $field.prop('placeholder') || settings.text.unspecifiedField;
                     },
+                    fieldValue: function (identifier, $module) {
+                        // use either id or name of field
+                        var
+                            matchingValue,
+                            matchingElement
+                        ;
+                        matchingElement = $module.find('[data-validate="' + identifier + '"]');
+                        if (matchingElement.length > 0) {
+                            matchingValue = matchingElement.val();
+                        } else {
+                            matchingElement = $module.find('#' + identifier);
+                            if (matchingElement.length > 0) {
+                                matchingValue = matchingElement.val();
+                            } else {
+                                matchingElement = $module.find('[name="' + identifier + '"]');
+                                if (matchingElement.length > 0) {
+                                    matchingValue = matchingElement.val();
+                                } else {
+                                    matchingElement = $module.find('[name="' + identifier + '[]"]');
+                                    if (matchingElement.length > 0) {
+                                        matchingValue = matchingElement;
+                                    }
+                                }
+                            }
+                        }
+
+                        return matchingValue;
+                    },
                     validation: function ($field) {
                         var
                             fieldValidation,
@@ -1928,29 +1956,7 @@
 
             // matches another field
             match: function (value, identifier, $module) {
-                var
-                    matchingValue,
-                    matchingElement
-                ;
-                matchingElement = $module.find('[data-validate="' + identifier + '"]');
-                if (matchingElement.length > 0) {
-                    matchingValue = matchingElement.val();
-                } else {
-                    matchingElement = $module.find('#' + identifier);
-                    if (matchingElement.length > 0) {
-                        matchingValue = matchingElement.val();
-                    } else {
-                        matchingElement = $module.find('[name="' + identifier + '"]');
-                        if (matchingElement.length > 0) {
-                            matchingValue = matchingElement.val();
-                        } else {
-                            matchingElement = $module.find('[name="' + identifier + '[]"]');
-                            if (matchingElement.length > 0) {
-                                matchingValue = matchingElement;
-                            }
-                        }
-                    }
-                }
+                var matchingValue = module.get.fieldValue(identifier, $module);
 
                 return matchingValue !== undefined
                     ? value.toString() === matchingValue.toString()
@@ -1959,30 +1965,7 @@
 
             // different than another field
             different: function (value, identifier, $module) {
-                // use either id or name of field
-                var
-                    matchingValue,
-                    matchingElement
-                ;
-                matchingElement = $module.find('[data-validate="' + identifier + '"]');
-                if (matchingElement.length > 0) {
-                    matchingValue = matchingElement.val();
-                } else {
-                    matchingElement = $module.find('#' + identifier);
-                    if (matchingElement.length > 0) {
-                        matchingValue = matchingElement.val();
-                    } else {
-                        matchingElement = $module.find('[name="' + identifier + '"]');
-                        if (matchingElement.length > 0) {
-                            matchingValue = matchingElement.val();
-                        } else {
-                            matchingElement = $module.find('[name="' + identifier + '[]"]');
-                            if (matchingElement.length > 0) {
-                                matchingValue = matchingElement;
-                            }
-                        }
-                    }
-                }
+                var matchingValue = module.get.fieldValue(identifier, $module);
 
                 return matchingValue !== undefined
                     ? value.toString() !== matchingValue.toString()

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1392,7 +1392,7 @@
                                         ? String(value + '').trim()
                                         : String(value + ''));
 
-                                return ruleFunction.call(field, value, ancillary, $module);
+                                return ruleFunction.call(field, value, ancillary, $module, module);
                             }
                         ;
                         if (!isFunction(ruleFunction)) {
@@ -1955,7 +1955,7 @@
             },
 
             // matches another field
-            match: function (value, identifier, $module) {
+            match: function (value, identifier, $module, module) {
                 var matchingValue = module.get.fieldValue(identifier, $module);
 
                 return matchingValue !== undefined
@@ -1964,7 +1964,7 @@
             },
 
             // different than another field
-            different: function (value, identifier, $module) {
+            different: function (value, identifier, $module, module) {
                 var matchingValue = module.get.fieldValue(identifier, $module);
 
                 return matchingValue !== undefined


### PR DESCRIPTION
## Description

This PR fixes formvalidation and  supports
- named objects as `errors` for the `add errors` behavior. This will either create individual prompts when `inline:true` or provide them as before via central error message box. But will support to put the field name infront.
- also fetches falsy values for "errors" as well now
- tries to get the field label for `match` and `different` rules
- centralizes the "get value" which was used inside match/different rules twice and did not check for non standard inputs like dropdown, calender or radio
- reuse / centralize /simplfy field selector 
- given an non name identifier (such as id) to the "get value" behavior (was not working if id!=name)
- init a select-dropdown
- support native checkboxes

## Testcase
Add errors using an object
https://jsfiddle.net/lubber/vcxsd3gt/5/

Match rule returns field label instead of id
@Eng3l This fixes your issue in the SUI repo, where i am not allowed to post anymore
https://jsfiddle.net/lubber/sbd0fmz4/2/

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/215163316-67317e07-f909-4b94-8d07-29409ca97852.png)|![image](https://user-images.githubusercontent.com/18379884/215163209-8bf95ac7-9500-4dc6-8a18-7d9d493696d2.png)|

## Closes
#2677 
https://github.com/Semantic-Org/Semantic-UI/issues/6130

