### PR TITLE
feat(menu): wrapping variant

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -796,7 +796,7 @@ Floated Menu / Item
     .ui.compact.menu .item:last-child {
         border-radius: 0 @borderRadius @borderRadius 0;
     }
-    .ui.pagination.menu .item:last-child::before {
+    .ui.pagination.menu:not(.wrapping) .item:last-child::before {
         display: none;
     }
 
@@ -1490,11 +1490,16 @@ Floated Menu / Item
 }
 
 & when (@variationMenuCentered) {
-    .ui.center.aligned.menu,
-    .ui.centered.menu {
+    .ui.center.aligned.menu:not(.fluid),
+    .ui.centered.menu:not(.fluid) {
         display: inline-flex;
         transform: translateX(-50%);
         margin-left: 50%;
+    }
+    .ui.center.aligned.menu .item,
+    .ui.centered.menu .item {
+        flex: 1 0 auto;
+        justify-content: center;
     }
 }
 
@@ -1911,6 +1916,35 @@ Floated Menu / Item
             margin-left: 0;
             margin-right: 0;
             width: 100%;
+        }
+    }
+}
+
+& when (@variationMenuWrapping) {
+    .ui.wrapping.menu {
+        flex-wrap: wrap;
+        & .item::before {
+            right: auto;
+            left: 0;
+        }
+        & .item:first-child::before {
+            display: none;
+        }
+        &:not(.tabular) .item {
+            &:last-of-type,
+            &:last-child {
+                border-right: @dividerSize solid @dividerBackground;
+            }
+        }
+    }
+    & when (@variationMenuWrapped) {
+        .ui.wrapped.menu:not(.tabular) .item {
+            &:first-child {
+                border-bottom-left-radius: 0;
+            }
+            &:last-child {
+                border-top-right-radius: 0;
+            }
         }
     }
 }

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -325,6 +325,8 @@
 @variationMenuAttached: true;
 @variationMenuIcon: true;
 @variationMenuEqualWidth: true;
+@variationMenuWrapping: true;
+@variationMenuWrapped: true;
 @variationMenuSizes: @variationAllSizes;
 @variationMenuColors: @variationAllColors;
 


### PR DESCRIPTION
## Description

- Added a `wrapping` variant for menu just like we already implemented for a button group
- Optional `wrapped` class adjusts border radius (just as in button group)
- enhanced `centered` to work together with  `fluid` to allow centered menu items which stay inside a full width fluid menu (works great with wrapping :)

## Testcase  
https://jsfiddle.net/lubber/8r9czsux/59/

## Closes
#2345 
#595 