### PR TITLE
feat(segment,grid): left and right attached variant

### DIFF
--- a/src/definitions/collections/grid.less
+++ b/src/definitions/collections/grid.less
@@ -1972,4 +1972,13 @@
     }
 }
 
+& when (@variationGridAttached) {
+    .ui.grid .left.attached.column {
+        padding-left: 0;
+    }
+    .ui.grid .right.attached.column {
+        padding-right: 0;
+    }
+}
+
 .loadUIOverrides();

--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -761,6 +761,14 @@
     .ui.tab.segment[class*="bottom attached"]:last-child {
         margin-bottom: @verticalMargin;
     }
+    .ui.left.attached.segment {
+        border-left:none;
+        margin-left: 0;
+    }
+    .ui.right.attached.segment {
+        border-right:none;
+        margin-right: 0;
+    }
 }
 
 & when (@variationSegmentFitted) {

--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -761,11 +761,11 @@
     .ui.tab.segment[class*="bottom attached"]:last-child {
         margin-bottom: @verticalMargin;
     }
-    .ui.left.attached.segment {
+    .ui[class*="left attached"].segment {
         border-left: none;
         margin-left: 0;
     }
-    .ui.right.attached.segment {
+    .ui[class*="right attached"].segment {
         border-right: none;
         margin-right: 0;
     }

--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -762,11 +762,11 @@
         margin-bottom: @verticalMargin;
     }
     .ui.left.attached.segment {
-        border-left:none;
+        border-left: none;
         margin-left: 0;
     }
     .ui.right.attached.segment {
-        border-right:none;
+        border-right: none;
         margin-right: 0;
     }
 }

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -294,6 +294,7 @@
 @variationGridDivided: true;
 @variationGridVertical: true;
 @variationGridAligned: true;
+@variationGridAttached: true;
 @variationGridStretched: true;
 @variationGridJustified: true;
 @variationGridReversed: true;


### PR DESCRIPTION
## Description

This PR finally allows to have a `vertical tabular menu` flawlessly attached to a left or right segment inside a grid column.
To accomplish this the tabular menu has to stay inside a `left/right attached column` and a `left/right attached segment` has to stay in a `left/right attached column`

## Testcase
https://jsfiddle.net/lubber/L9go6tab/13/

## Screenshot

### After
![image](https://user-images.githubusercontent.com/18379884/215575229-fe8b69b2-7f3a-4299-afc6-e5ebe6b0893b.png)


### Before
![image](https://user-images.githubusercontent.com/18379884/215575324-df593fe6-cd0c-4e69-82ad-e392f86de9b5.png)


## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5874