### PR TITLE
feat(segment): wrapping in addition to stackable

### DIFF
--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -437,6 +437,7 @@
             border-radius: @groupedBorderRadius;
             border: @groupedBorder;
         }
+        .ui.wrapping.horizontal.segments,
         .ui.stackable.horizontal.segments {
             flex-wrap: wrap;
         }
@@ -473,7 +474,7 @@
         .ui.segments > .horizontal.segments:first-child {
             border-top: none;
         }
-        .ui.horizontal.segments:not(.stackable) > .segment:first-child {
+        .ui.horizontal.segments:not(.stackable):not(.wrapping) > .segment:first-child {
             border-left: none;
         }
         .ui.horizontal.segments > .segment:first-child {


### PR DESCRIPTION
## Description

This PR adds an alias `wrapping` to the current `stackable horizontal segments` for consistency as we already use `wrapping` for button groups or menu items which actually wrap single elements instead of stacking _all_ of them at once which is meant by "stackable" in every other element.

The `horizontal stackable` variant gets deprecated and will be removed in 2.10

