### PR TITLE
fix(form): use namespace to be able to destroy events

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -171,7 +171,12 @@
                         $(window).on('beforeunload' + eventNamespace, module.event.beforeUnload);
                     }
 
-                    $field.on('change click keyup keydown blur', function (e) {
+                    $field.on(
+                        'change' + eventNamespace +
+                        ' click' + eventNamespace +
+                        ' keyup' + eventNamespace +
+                        ' keydown' + eventNamespace +
+                        ' blur' + eventNamespace, function (e) {
                         module.determine.isDirty();
                     });
 

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -171,12 +171,11 @@
                         $(window).on('beforeunload' + eventNamespace, module.event.beforeUnload);
                     }
 
-                    $field.on(
-                        'change' + eventNamespace +
-                        ' click' + eventNamespace +
-                        ' keyup' + eventNamespace +
-                        ' keydown' + eventNamespace +
-                        ' blur' + eventNamespace, function (e) {
+                    $field.on('change' + eventNamespace
+                        + ' click' + eventNamespace
+                        + ' keyup' + eventNamespace
+                        + ' keydown' + eventNamespace
+                        + ' blur' + eventNamespace, function (e) {
                         module.determine.isDirty();
                     });
 


### PR DESCRIPTION
## Description

Some form events were not detroyable because attached namespace was missing which leads into memory leaks

## Closes
#2695 