### PR TITLE
fix(dropdown): possible XSS through select option text

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -2065,7 +2065,7 @@
                                     values.push({
                                         name: name,
                                         value: value,
-                                        text: text,
+                                        text: module.escape.htmlEntities(text, true),
                                         disabled: disabled,
                                     });
                                 }
@@ -3448,7 +3448,7 @@
                             selectChanged = false
                         ;
                         $.each(mutations, function (index, mutation) {
-                            if ($(mutation.target).is('select, option, optgroup') || $(mutation.addedNodes).is('select')) {
+                            if ($(mutation.target).is('option, optgroup') || $(mutation.addedNodes).is('select') || ($(mutation.target).is('select') && mutation.type !== 'attributes')) {
                                 selectChanged = true;
 
                                 return false;
@@ -3757,7 +3757,7 @@
 
                         return text.replace(regExp.escape, '\\$&');
                     },
-                    htmlEntities: function (string) {
+                    htmlEntities: function (string, forceAmpersand) {
                         var
                             badChars     = /["'<>`]/g,
                             shouldEscape = /["&'<>`]/,
@@ -3773,7 +3773,7 @@
                             }
                         ;
                         if (shouldEscape.test(string)) {
-                            string = string.replace(/&(?![\d#a-z]{1,12};)/gi, '&amp;');
+                            string = string.replace(forceAmpersand ? /&/g : /&(?![\d#a-z]{1,12};)/gi, '&amp;');
 
                             return string.replace(badChars, escapedChar);
                         }


### PR DESCRIPTION
## Description

This PR fixes a possible XSS through an entity encoded select option text when converted into a FUI dropdown.
Even if `preserveHTML: false` would prevent this, a select tag cannot contain html at all and if it contains entity encoded HTML instead, it  should not be reconverted into html.

The PR also fixes recreating the dropdown menu twice when no values are selected in a multiple dropdown

Thanks to @brian-codes for reporting

## Testcase
- Select the obvious evil dropdown entry

### Broken
The alert message appears upon selection
https://jsfiddle.net/lubber/f5to49ew/3/

### Fixed
All fine
https://jsfiddle.net/lubber/f5to49ew/5/

## Closes
https://github.com/fomantic/Fomantic-UI/discussions/2692#discussioncomment-5009642

