### PR TITLE
fix(toast): destroy toast after onremove callback

### DIFF
--- a/src/definitions/modules/toast.js
+++ b/src/definitions/modules/toast.js
@@ -117,11 +117,11 @@
                     if ($toastBox) {
                         module.debug('Removing toast', $toastBox);
                         module.unbind.events();
+                        settings.onRemove.call($toastBox, element);
                         $toastBox.remove();
                         $toastBox = undefined;
                         $toast = undefined;
                         $animationObject = undefined;
-                        settings.onRemove.call($toastBox, element);
                         $progress = undefined;
                         $progressBar = undefined;
                         $close = undefined;


### PR DESCRIPTION
## Description
The `onRemove` callback was called after the this reference was destroyed