### PR TITLE
fix(form): support inline fields group label for required attribute

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1196,8 +1196,8 @@
                                 $el        = $(el),
                                 $elGroup   = $el.closest($group),
                                 isCheckbox = $el.filter(selector.checkbox).length > 0,
-                                isRequired = $el.prop('required') || $elGroup.hasClass(className.required) || $elGroup.parent().hasClass(className.required) || $elGroup.parent().parent().hasClass(className.required),
-                                isDisabled = $el.is(':disabled') || $elGroup.hasClass(className.disabled) || $elGroup.parent().hasClass(className.disabled) || $elGroup.parent().parent().hasClass(className.disabled),
+                                isRequired = $el.prop('required') || $elGroup.hasClass(className.required) || $elGroup.parent().hasClass(className.required),
+                                isDisabled = $el.is(':disabled') || $elGroup.hasClass(className.disabled) || $elGroup.parent().hasClass(className.disabled),
                                 validation = module.get.validation($el),
                                 hasEmptyRule = validation
                                     ? $.grep(validation.rules, function (rule) {

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1196,8 +1196,8 @@
                                 $el        = $(el),
                                 $elGroup   = $el.closest($group),
                                 isCheckbox = $el.filter(selector.checkbox).length > 0,
-                                isRequired = $el.prop('required') || $elGroup.hasClass(className.required) || $elGroup.parent().hasClass(className.required),
-                                isDisabled = $el.is(':disabled') || $elGroup.hasClass(className.disabled) || $elGroup.parent().hasClass(className.disabled),
+                                isRequired = $el.prop('required') || $elGroup.hasClass(className.required) || $elGroup.parent().hasClass(className.required) || $elGroup.parent().parent().hasClass(className.required),
+                                isDisabled = $el.is(':disabled') || $elGroup.hasClass(className.disabled) || $elGroup.parent().hasClass(className.disabled) || $elGroup.parent().parent().hasClass(className.disabled),
                                 validation = module.get.validation($el),
                                 hasEmptyRule = validation
                                     ? $.grep(validation.rules, function (rule) {

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -637,7 +637,7 @@
                         var $field = typeof identifier === 'string'
                                 ? module.get.field(identifier)
                                 : identifier,
-                            $label = $field.closest(selector.group).find('label').eq(0)
+                            $label = $field.closest(selector.group).find('label:not(:empty)').eq(0)
                         ;
 
                         return $label.length === 1

--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -804,10 +804,11 @@
          Required Field
     --------------------- */
 
-    .ui.form .required.fields:not(.grouped) > .field > label::after,
+    .ui.form .required.fields:not(.grouped):not(.inline) > .field > label::after,
+    .ui.form .required.fields.inline > label::after,
     .ui.form .required.fields.grouped > label::after,
     .ui.form .required.field > label::after,
-    .ui.form .required.fields:not(.grouped) > .field > .checkbox::after,
+    .ui.form .required.fields:not(.grouped):not(.inline) > .field > .checkbox::after,
     .ui.form .required.field > .checkbox::after,
     .ui.form label.required::after {
         margin: @requiredMargin;
@@ -815,7 +816,8 @@
         color: @requiredColor;
     }
 
-    .ui.form .required.fields:not(.grouped) > .field > label::after,
+    .ui.form .required.fields:not(.grouped):not(.inline) > .field > label::after,
+    .ui.form .required.fields.inline > label::after,
     .ui.form .required.fields.grouped > label::after,
     .ui.form .required.field > label::after,
     .ui.form label.required::after {
@@ -823,7 +825,7 @@
         vertical-align: top;
     }
 
-    .ui.form .required.fields:not(.grouped) > .field > .checkbox::after,
+    .ui.form .required.fields:not(.grouped):not(.inline) > .field > .checkbox::after,
     .ui.form .required.field > .checkbox::after {
         position: absolute;
         top: 0;

--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -843,6 +843,12 @@
     }
 }
 
+.ui.ui.ui.ui.form .fields > label:empty::after,
+.ui.ui.ui.ui.form .field > label:empty::after {
+    content:" ";
+    display: inline-block;
+}
+
 /*******************************
            Variations
 *******************************/

--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -527,6 +527,11 @@
             color: @c;
         }
 
+        // needs separate selector because not supported by every browser
+        .ui.form .fields:has(.@{state}) > label {
+            color: @c;
+        }
+
         .ui.form .fields.@{state} .field .ui.label,
         .ui.form .field.@{state} .ui.label {
             background-color: @lbg;
@@ -727,6 +732,11 @@
         & when (@variationFormInverted) {
             .ui.inverted.form .fields.@{state} .field label,
             .ui.inverted.form .@{state}.field label {
+                color: @lbg;
+            }
+
+            // needs separate selector because not supported by every browser
+            .ui.inverted.form .fields:has(.@{state}) > label {
                 color: @lbg;
             }
         }

--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -845,7 +845,7 @@
 
 .ui.ui.ui.ui.form .fields > label:empty::after,
 .ui.ui.ui.ui.form .field > label:empty::after {
-    content:" ";
+    content: " ";
     display: inline-block;
 }
 


### PR DESCRIPTION
## Description
A required Inline fields label does not get an asterisk and does not get a state color

To fix the state color i had to make use of the `:has()` class selector. This [isnt supported by all browsers](https://developer.mozilla.org/en-US/docs/Web/CSS/:has#browser_compatibility), so in those browsers this feature wont work. 

I also fixed positioning of fields when an empty label is used

## Testcase
Remove CSS to see issue
https://jsfiddle.net/lubber/6po2btaw/23/

