### PR TITLE
fix(formvalidation): support file inputs for validation

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -507,7 +507,7 @@
                         return rule.type;
                     },
                     changeEvent: function (type, $input) {
-                        return ['file','checkbox','radio','hidden'].indexOf(type) >= 0 || $input.is('select') ? 'change' : 'input';
+                        return ['file', 'checkbox', 'radio', 'hidden'].indexOf(type) >= 0 || $input.is('select') ? 'change' : 'input';
                     },
                     fieldsFromShorthand: function (fields) {
                         var


### PR DESCRIPTION
## Description
This PR reverts #1950 as the cause of the original issue was related to the separate dirty events which were refactored before 2.8.8 was released.
I also added some checks for reset and set values as file inputs would otherwise return a js error as file input cannot be set any value other than an empty string.

Additionally this PR simplifies the input change event detection as we dont support older browsers than ie11 and avoid memory leaks when attachEvents behavior is used and the form gets detroyed.

## Testcase
https://jsfiddle.net/lubber/tc9ox8dj/

## Closes
#2712 

