### PR TITLE
[build] fix variable inheritance

### DIFF
--- a/src/theme.less
+++ b/src/theme.less
@@ -19,7 +19,9 @@
 @import (optional) "@{themesFolder}/@{site}/globals/site.variables";
 
 /* Component's site.variables */
-@import (optional) "@{themesFolder}/@{theme}/globals/site.variables";
+& when not (@theme = 'default') {
+    @import (optional) "@{themesFolder}/@{theme}/globals/site.variables";
+}
 
 /* Site theme site.variables */
 @import (optional) "@{siteFolder}/globals/site.variables";


### PR DESCRIPTION
<!--
 Please read our Contributing Guide and Code of Conduct before you
 submit a pull request.
  
 Contributing Guide: https://github.com/fomantic/Fomantic-UI/blob/master/CONTRIBUTING.md
 Code of Conduct: https://github.com/fomantic/Fomantic-UI/blob/master/CODE_OF_CONDUCT.md

 ----

 Please use the following pull request title format:
 "[<scope>] <summary of what you fixed/changed>"
-->

## Description

As described in https://github.com/fomantic/Fomantic-UI/pull/2671, you introduced conditional checks when loading theme variables in 2.9. This activated scoping, which I experienced also.

That PR didn't entirely resolve it for me though. In some cases (when importing variables from one theme in another), I still got errors. Turns out, the code was not entirely reverted to how it was in 2.8:

https://github.com/lubber-de/Fomantic-UI/blob/e39a0ae5183c12808ba1eee82082efbb15f4d450/src/theme.less#L21-L24

This PR restores the conditional for the component's default site.variables, which is apparently still needed for proper variable inheritance.
