### PR TITLE
fix(theme): variable inheritance without default imported twice

### DIFF
--- a/src/definitions/collections/breadcrumb.less
+++ b/src/definitions/collections/breadcrumb.less
@@ -115,4 +115,4 @@
     });
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/collections/breadcrumb.less
+++ b/src/definitions/collections/breadcrumb.less
@@ -115,4 +115,5 @@
     });
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -1160,4 +1160,5 @@
     });
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -1160,4 +1160,4 @@
     });
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/collections/grid.less
+++ b/src/definitions/collections/grid.less
@@ -1981,4 +1981,4 @@
     }
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/collections/grid.less
+++ b/src/definitions/collections/grid.less
@@ -1981,4 +1981,5 @@
     }
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -2011,4 +2011,5 @@ Floated Menu / Item
     }
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -2011,4 +2011,4 @@ Floated Menu / Item
     }
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/collections/message.less
+++ b/src/definitions/collections/message.less
@@ -442,4 +442,4 @@
     });
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/collections/message.less
+++ b/src/definitions/collections/message.less
@@ -442,4 +442,5 @@
     });
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/collections/table.less
+++ b/src/definitions/collections/table.less
@@ -1929,4 +1929,5 @@
     });
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/collections/table.less
+++ b/src/definitions/collections/table.less
@@ -1929,4 +1929,4 @@
     });
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/button.less
+++ b/src/definitions/elements/button.less
@@ -2005,4 +2005,4 @@
         }
     }
 }
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/button.less
+++ b/src/definitions/elements/button.less
@@ -2005,4 +2005,6 @@
         }
     }
 }
+
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/container.less
+++ b/src/definitions/elements/container.less
@@ -294,4 +294,4 @@
     }
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/container.less
+++ b/src/definitions/elements/container.less
@@ -294,4 +294,5 @@
     }
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/divider.less
+++ b/src/definitions/elements/divider.less
@@ -282,4 +282,4 @@
     });
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/divider.less
+++ b/src/definitions/elements/divider.less
@@ -282,4 +282,5 @@
     });
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/emoji.less
+++ b/src/definitions/elements/emoji.less
@@ -91,4 +91,4 @@ each(@emoji-map, {
 
 /* rtl:end:ignore */
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/emoji.less
+++ b/src/definitions/elements/emoji.less
@@ -91,4 +91,5 @@ each(@emoji-map, {
 
 /* rtl:end:ignore */
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/flag.less
+++ b/src/definitions/elements/flag.less
@@ -83,4 +83,5 @@ each(@flags, {
 
 /* rtl:end:ignore */
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/flag.less
+++ b/src/definitions/elements/flag.less
@@ -83,4 +83,4 @@ each(@flags, {
 
 /* rtl:end:ignore */
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/header.less
+++ b/src/definitions/elements/header.less
@@ -490,4 +490,5 @@
     font-size: @mediumFontSize;
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/header.less
+++ b/src/definitions/elements/header.less
@@ -490,4 +490,4 @@
     font-size: @mediumFontSize;
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -655,4 +655,4 @@ i.icons {
     }
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -655,4 +655,5 @@ i.icons {
     }
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/image.less
+++ b/src/definitions/elements/image.less
@@ -307,4 +307,5 @@ img.ui.image {
     }
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/image.less
+++ b/src/definitions/elements/image.less
@@ -307,4 +307,4 @@ img.ui.image {
     }
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/input.less
+++ b/src/definitions/elements/input.less
@@ -791,4 +791,4 @@
     });
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/input.less
+++ b/src/definitions/elements/input.less
@@ -791,4 +791,5 @@
     });
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/label.less
+++ b/src/definitions/elements/label.less
@@ -1011,4 +1011,5 @@ a.ui.active.label:hover::before {
     });
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/label.less
+++ b/src/definitions/elements/label.less
@@ -1011,4 +1011,4 @@ a.ui.active.label:hover::before {
     });
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/list.less
+++ b/src/definitions/elements/list.less
@@ -1023,4 +1023,4 @@ ol.ui.list ol li,
     });
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/list.less
+++ b/src/definitions/elements/list.less
@@ -1023,4 +1023,5 @@ ol.ui.list ol li,
     });
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/loader.less
+++ b/src/definitions/elements/loader.less
@@ -423,4 +423,4 @@
     }
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/loader.less
+++ b/src/definitions/elements/loader.less
@@ -423,4 +423,5 @@
     }
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/placeholder.less
+++ b/src/definitions/elements/placeholder.less
@@ -248,4 +248,4 @@
     }
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/placeholder.less
+++ b/src/definitions/elements/placeholder.less
@@ -248,4 +248,5 @@
     }
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/rail.less
+++ b/src/definitions/elements/rail.less
@@ -144,4 +144,5 @@
     });
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/rail.less
+++ b/src/definitions/elements/rail.less
@@ -144,4 +144,4 @@
     });
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/reveal.less
+++ b/src/definitions/elements/reveal.less
@@ -280,4 +280,4 @@
     });
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/reveal.less
+++ b/src/definitions/elements/reveal.less
@@ -280,4 +280,5 @@
     });
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -934,4 +934,5 @@
     });
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -934,4 +934,4 @@
     });
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/step.less
+++ b/src/definitions/elements/step.less
@@ -617,4 +617,5 @@
     }
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/step.less
+++ b/src/definitions/elements/step.less
@@ -617,4 +617,4 @@
     }
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/text.less
+++ b/src/definitions/elements/text.less
@@ -71,4 +71,4 @@ span.ui.medium.text {
     });
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/text.less
+++ b/src/definitions/elements/text.less
@@ -71,4 +71,5 @@ span.ui.medium.text {
     });
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/globals/reset.less
+++ b/src/definitions/globals/reset.less
@@ -40,4 +40,5 @@ input[type="password"] {
     -moz-appearance: none; /* mobile firefox too! */
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/globals/reset.less
+++ b/src/definitions/globals/reset.less
@@ -40,4 +40,4 @@ input[type="password"] {
     -moz-appearance: none; /* mobile firefox too! */
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/globals/site.less
+++ b/src/definitions/globals/site.less
@@ -207,4 +207,4 @@ input::selection {
     color: @inputHighlightColor;
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/globals/site.less
+++ b/src/definitions/globals/site.less
@@ -207,4 +207,5 @@ input::selection {
     color: @inputHighlightColor;
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/accordion.less
+++ b/src/definitions/modules/accordion.less
@@ -364,4 +364,5 @@
     }
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/accordion.less
+++ b/src/definitions/modules/accordion.less
@@ -364,4 +364,4 @@
     }
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/calendar.less
+++ b/src/definitions/modules/calendar.less
@@ -215,4 +215,5 @@
     }
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/calendar.less
+++ b/src/definitions/modules/calendar.less
@@ -215,4 +215,4 @@
     }
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/checkbox.less
+++ b/src/definitions/modules/checkbox.less
@@ -696,4 +696,5 @@
     });
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/checkbox.less
+++ b/src/definitions/modules/checkbox.less
@@ -696,4 +696,4 @@
     });
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/dimmer.less
+++ b/src/definitions/modules/dimmer.less
@@ -390,4 +390,4 @@ body.dimmable > .dimmer {
     }
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/dimmer.less
+++ b/src/definitions/modules/dimmer.less
@@ -390,4 +390,5 @@ body.dimmable > .dimmer {
     }
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -1951,4 +1951,5 @@ select.ui.dropdown {
     }
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -1951,4 +1951,4 @@ select.ui.dropdown {
     }
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/embed.less
+++ b/src/definitions/modules/embed.less
@@ -155,4 +155,5 @@
     }
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/embed.less
+++ b/src/definitions/modules/embed.less
@@ -155,4 +155,4 @@
     }
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/flyout.less
+++ b/src/definitions/modules/flyout.less
@@ -645,4 +645,5 @@ body.pushable > .pusher {
     }
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/flyout.less
+++ b/src/definitions/modules/flyout.less
@@ -645,4 +645,4 @@ body.pushable > .pusher {
     }
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/modal.less
+++ b/src/definitions/modules/modal.less
@@ -620,4 +620,4 @@
     }
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/modal.less
+++ b/src/definitions/modules/modal.less
@@ -620,4 +620,5 @@
     }
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/nag.less
+++ b/src/definitions/modules/nag.less
@@ -207,4 +207,5 @@ a.ui.nag {
         border-radius: @borderRadius;
     }
 }
-.loadUIOverrides();
+
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/nag.less
+++ b/src/definitions/modules/nag.less
@@ -208,4 +208,5 @@ a.ui.nag {
     }
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/popup.less
+++ b/src/definitions/modules/popup.less
@@ -928,4 +928,5 @@
     });
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/popup.less
+++ b/src/definitions/modules/popup.less
@@ -928,4 +928,4 @@
     });
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/progress.less
+++ b/src/definitions/modules/progress.less
@@ -650,4 +650,4 @@
     }
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/progress.less
+++ b/src/definitions/modules/progress.less
@@ -650,4 +650,5 @@
     }
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/rating.less
+++ b/src/definitions/modules/rating.less
@@ -177,4 +177,4 @@
     });
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/rating.less
+++ b/src/definitions/modules/rating.less
@@ -177,4 +177,5 @@
     });
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/search.less
+++ b/src/definitions/modules/search.less
@@ -553,4 +553,4 @@
     }
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/search.less
+++ b/src/definitions/modules/search.less
@@ -553,4 +553,5 @@
     }
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/shape.less
+++ b/src/definitions/modules/shape.less
@@ -143,4 +143,4 @@
     display: block;
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/shape.less
+++ b/src/definitions/modules/shape.less
@@ -143,4 +143,5 @@
     display: block;
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/sidebar.less
+++ b/src/definitions/modules/sidebar.less
@@ -667,4 +667,5 @@ body.pushable > .pusher {
     }
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/sidebar.less
+++ b/src/definitions/modules/sidebar.less
@@ -667,4 +667,4 @@ body.pushable > .pusher {
     }
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/slider.less
+++ b/src/definitions/modules/slider.less
@@ -426,4 +426,4 @@
     });
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/slider.less
+++ b/src/definitions/modules/slider.less
@@ -426,4 +426,5 @@
     });
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/sticky.less
+++ b/src/definitions/modules/sticky.less
@@ -65,4 +65,4 @@
     position: sticky;
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/sticky.less
+++ b/src/definitions/modules/sticky.less
@@ -65,4 +65,5 @@
     position: sticky;
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/tab.less
+++ b/src/definitions/modules/tab.less
@@ -82,4 +82,4 @@
     }
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/tab.less
+++ b/src/definitions/modules/tab.less
@@ -82,4 +82,5 @@
     }
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/toast.less
+++ b/src/definitions/modules/toast.less
@@ -714,4 +714,4 @@
     }
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/toast.less
+++ b/src/definitions/modules/toast.less
@@ -714,4 +714,5 @@
     }
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/transition.less
+++ b/src/definitions/modules/transition.less
@@ -113,4 +113,5 @@
     }
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/transition.less
+++ b/src/definitions/modules/transition.less
@@ -113,4 +113,4 @@
     }
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/views/ad.less
+++ b/src/definitions/views/ad.less
@@ -293,4 +293,4 @@
     }
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/views/ad.less
+++ b/src/definitions/views/ad.less
@@ -293,4 +293,5 @@
     }
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/views/card.less
+++ b/src/definitions/views/card.less
@@ -1178,4 +1178,5 @@
     }
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/views/card.less
+++ b/src/definitions/views/card.less
@@ -1178,4 +1178,4 @@
     }
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/views/comment.less
+++ b/src/definitions/views/comment.less
@@ -291,4 +291,5 @@
     }
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/views/comment.less
+++ b/src/definitions/views/comment.less
@@ -291,4 +291,4 @@
     }
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/views/feed.less
+++ b/src/definitions/views/feed.less
@@ -317,4 +317,5 @@
     }
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/views/feed.less
+++ b/src/definitions/views/feed.less
@@ -317,4 +317,4 @@
     }
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/views/item.less
+++ b/src/definitions/views/item.less
@@ -598,4 +598,5 @@
     }
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/views/item.less
+++ b/src/definitions/views/item.less
@@ -598,4 +598,4 @@
     }
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/definitions/views/statistic.less
+++ b/src/definitions/views/statistic.less
@@ -414,4 +414,5 @@
     });
 }
 
+// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/views/statistic.less
+++ b/src/definitions/views/statistic.less
@@ -414,4 +414,4 @@
     });
 }
 
-.loadUIOverrides();
+@import (multiple, optional) "../../overrides.less";

--- a/src/overrides.less
+++ b/src/overrides.less
@@ -1,0 +1,7 @@
+// ------------------
+//     Overrides
+// -------------------
+
+@import (optional) "@{themesFolder}/default/@{type}s/@{element}.overrides";
+@import (optional) "@{themesFolder}/@{theme}/@{type}s/@{element}.overrides";
+@import (optional) "@{siteFolder}/@{type}s/@{element}.overrides";

--- a/src/theme.less
+++ b/src/theme.less
@@ -7,7 +7,9 @@
 ------------------- */
 
 @theme: @@element;
-
+& when (@theme = 'default') {
+    @theme = '';
+}
 /* --------------------
    Site Variables
 --------------------- */
@@ -81,9 +83,7 @@
 ------------------- */
 
 .loadUIOverrides() {
-    & when not (@theme = "default") {
-        @import (optional) "@{themesFolder}/default/@{type}s/@{element}.overrides";
-    }
+    @import (optional) "@{themesFolder}/default/@{type}s/@{element}.overrides";
     @import (optional) "@{themesFolder}/@{theme}/@{type}s/@{element}.overrides";
     @import (optional) "@{siteFolder}/@{type}s/@{element}.overrides";
 }

--- a/src/theme.less
+++ b/src/theme.less
@@ -6,7 +6,7 @@
        Theme
 ------------------- */
 
-@theme: if(@@element = 'default', '', @@element);
+@theme: if(@@element = "default", "", @@element);
 
 /* --------------------
    Site Variables

--- a/src/theme.less
+++ b/src/theme.less
@@ -6,10 +6,8 @@
        Theme
 ------------------- */
 
-@theme: @@element;
-& when (@theme = 'default') {
-    @theme = '';
-}
+@theme: if(@@element = 'default', '', @@element);
+
 /* --------------------
    Site Variables
 --------------------- */
@@ -82,8 +80,11 @@
      Overrides
 ------------------- */
 
+// Keep empty mixin in case of custom components using it so they dont break
 .loadUIOverrides() {
-    @import (optional) "@{themesFolder}/default/@{type}s/@{element}.overrides";
-    @import (optional) "@{themesFolder}/@{theme}/@{type}s/@{element}.overrides";
-    @import (optional) "@{siteFolder}/@{type}s/@{element}.overrides";
+    /* loadUIOverrides mixin is deprecated and will be removed in 2.10.0
+       Replace mixin call by
+          @import (multiple, optional) "../../overrides.less";
+       instead
+    */
 }


### PR DESCRIPTION
## Description
This PR should finally fix proper variable inheritance without scoping and without overriding/double importing the default files twice.
This is solved by simply pointing the theme value to a non existing path in case it's default, because the default path is always imported anyway.

Another workaround would have been to just replace 'default' for each component inside `theme.config` by an empty string, but as theme.config is a custom file, nobody would have updated it for the next release.
I wanted this to be backward compatible, so i replaced the variable on the fly.

However, by using any LESS function to declare a variable (i tried replace/if/when/e/%), the access breaks when trying to use such variable via `@{theme}` inside mixins (which are scoped). :(
Even trying to trick it by using `%('%s',@theme)` instead of the string path did not work and resulted into "malformed import statement instead"
That said ( and even if this could be considered a bug in LESS), to solve all those issues, i just replaced the mixin call by importing another `overrides.less` file instead, which now isn't scoped anymore, so the import using the theme-variable also works there as well

Just in case somebody has made own custom components i left the `loadUIOverrides` mixin, but replaced the content by a comment warning so it's not a breaking change and people know what to do. 

## Testcase
Try this in https://lesscss.org/less-preview (copy link does currently not work there, so paste it manually)
1. uncomment the first @import -> works (it tells you that REPLACED.less is not found, but ok)
2. comment again and uncomment the second @import inside the mixin -> breaks (you get a syntax error)
3. uncomment the line `@theme: 'bla';`
4. try 1. and 2. again -> both will work but wont help in our situation. Thats' why i completely got rid of using the mixin for the overrides import


```less
@element: 'header';
@header: 'default';

// using a conditional expression only works in same scope
@theme: if(@@element = 'default','REPLACED',@@element);

// using a static string works for both imports
//@theme: 'bla';

// this works
//@import "@{theme}";

.importer() {
  // this breaks when @theme is not a static string but a conditional expression
  //@import "@{theme}";
}

.importer();
```

## Replaces
#2714 