### PR TITLE
fix(dropdown): adjust icon on multiple non selection non search

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -887,7 +887,7 @@ select.ui.dropdown {
             margin-right: @dropdownIconMultipleRight;
         }
         &:not(.search) > .remove.icon ~ .text.default,
-            > .text.default:first-child {
+        > .text.default:first-child {
             overflow: inherit;
         }
     }

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -934,6 +934,7 @@ select.ui.dropdown {
         .ui.multiple.search.dropdown > span.sizer {
             display: none;
         }
+        .ui.multiple.search.dropdown:not(.selection) > .remove.icon + input.search,
         .ui.multiple.search.dropdown:not(.selection) > input.search:first-child {
             min-width: @multipleSearchMinWidth;
         }

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -816,7 +816,7 @@ select.ui.dropdown {
     .ui.dropdown:not(.selection) > .remove.icon ~ .dropdown.icon {
         margin-left: @clearableIconMargin;
     }
-    .ui.dropdown:not(.selection) > .remove.icon {
+    .ui.dropdown:not(.selection):not(.multiple) > .remove.icon {
         margin-top: -@clearableIconMarginTop;
     }
 }
@@ -879,13 +879,17 @@ select.ui.dropdown {
         margin: @imageLabelImageMargin;
         height: @imageLabelHeight;
     }
-
-    .ui.multiple.dropdown:not(.selection):not(.labeled) > .dropdown.icon {
-        margin-right: @dropdownIconMultipleMarginRight;
-    }
-    .ui.multiple.dropdown:not(.selection):not(.labeled):not(.search) > .text:first-child ~ .dropdown.icon {
-        margin-top: @dropdownIconMultipleMarginTop;
-        position: absolute;
+    .ui.multiple.dropdown:not(.selection):not(.labeled) {
+        & > .dropdown.icon {
+            right: @dropdownIconMultipleRight;
+        }
+        & > .remove.icon {
+            margin-right: @dropdownIconMultipleRight;
+        }
+        &:not(.search) > .remove.icon ~ .text.default,
+            > .text.default:first-child {
+            overflow: inherit;
+        }
     }
 
     & when (@variationDropdownSearch) {
@@ -926,6 +930,12 @@ select.ui.dropdown {
 
         .ui.multiple.search.dropdown.button {
             min-width: @selectionMinWidth;
+        }
+        .ui.multiple.search.dropdown > span.sizer {
+            display: none;
+        }
+        .ui.multiple.search.dropdown:not(.selection) > input.search:first-child {
+            min-width: @multipleSearchMinWidth;
         }
     }
 }

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -880,6 +880,14 @@ select.ui.dropdown {
         height: @imageLabelHeight;
     }
 
+    .ui.multiple.dropdown:not(.selection):not(.labeled) > .dropdown.icon {
+        margin-right: @dropdownIconMultipleMarginRight;
+    }
+    .ui.multiple.dropdown:not(.selection):not(.labeled):not(.search) > .text:first-child ~ .dropdown.icon {
+        margin-top: @dropdownIconMultipleMarginTop;
+        position: absolute;
+    }
+
     & when (@variationDropdownSearch) {
         /* -----------------
           Multiple Search

--- a/src/themes/default/modules/dropdown.variables
+++ b/src/themes/default/modules/dropdown.variables
@@ -21,8 +21,7 @@
 @dropdownIconSize: @relative12px;
 @dropdownIconMargin: 0 0 0 1em;
 @dropdownIconMinWidth: 1em;
-@dropdownIconMultipleMarginRight: -1em;
-@dropdownIconMultipleMarginTop: 0.75em;
+@dropdownIconMultipleRight: -1.5em;
 
 /* Current Text */
 @textTransition: none;
@@ -261,6 +260,8 @@
 @multipleSelectionChildMargin: @multipleSelectionChildVerticalMargin 0 @multipleSelectionChildVerticalMargin @multipleSelectionChildLeftMargin;
 @multipleSelectionChildLineHeight: @relative17px;
 @multipleSelectionSearchStartWidth: (@glyphWidth * 2);
+
+@multipleSearchMinWidth: 5.05em;
 
 /* Dropdown Icon */
 @multipleSelectionDropdownIconMargin: "";

--- a/src/themes/default/modules/dropdown.variables
+++ b/src/themes/default/modules/dropdown.variables
@@ -21,6 +21,8 @@
 @dropdownIconSize: @relative12px;
 @dropdownIconMargin: 0 0 0 1em;
 @dropdownIconMinWidth: 1em;
+@dropdownIconMultipleMarginRight: -1em;
+@dropdownIconMultipleMarginTop: 0.75em;
 
 /* Current Text */
 @textTransition: none;


### PR DESCRIPTION
## Description

Multiple, but non selection dropdowns had issues:
- When no values were selected, a possible long place holder was partly covered by the dropdown icon
- When no values are selected, the dropdown icon was completely misaligned
- When clearable was enabled both icons weere misaligned
- the search input was doubling its content while typing

## Testcase
Remove CSS to see issue
https://jsfiddle.net/lubber/51haf39w/6/

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/18379884/221421982-c2f574f7-fdf5-4097-b26e-f20733000fdf.png)

### After
![image](https://user-images.githubusercontent.com/18379884/221421908-7538b92a-84ae-473a-8b50-6db6b08d3b33.png)

## Closes
#817

