### PR TITLE
fix(modal): scrolling multple modals positioning

### DIFF
--- a/src/definitions/modules/modal.less
+++ b/src/definitions/modules/modal.less
@@ -437,16 +437,18 @@
         overflow: hidden;
     }
     .scrolling.dimmable > .dimmer {
-        justify-content: flex-start;
+        justify-content: center;
         position: fixed;
     }
     .scrolling.dimmable:not(body) > .dimmer {
-        justify-content: center;
         position: absolute;
     }
     .scrolling.dimmable.dimmed > .dimmer {
         overflow: auto;
         overscroll-behavior: @overscrollBehavior;
+    }
+    .scrolling.dimmable .ui.scrolling.modal {
+        top: 0;
     }
     .modals.dimmer .ui.scrolling.modal:not(.fullscreen) {
         margin: @scrollingMargin auto;

--- a/src/definitions/modules/modal.less
+++ b/src/definitions/modules/modal.less
@@ -447,11 +447,12 @@
         overflow: auto;
         overscroll-behavior: @overscrollBehavior;
     }
-    .scrolling.dimmable .ui.scrolling.modal {
+    .modals.dimmer .ui.scrolling.modal.fullscreen {
         top: 0;
     }
     .modals.dimmer .ui.scrolling.modal:not(.fullscreen) {
         margin: @scrollingMargin auto;
+        top: @scrollingTop;
     }
 
     /* Fix for Firefox, Edge, IE11 */

--- a/src/themes/default/modules/modal.variables
+++ b/src/themes/default/modules/modal.variables
@@ -133,6 +133,7 @@
 /* Scrolling Margin */
 @scrollingMargin: 2rem;
 @mobileScrollingMargin: @mobileTopAlignedMargin;
+@scrollingTop: 1em;
 
 /* Scrolling Content */
 @scrollingContentMaxHeight: calc(80vh - 10rem);


### PR DESCRIPTION
## Description
When multiple modals are used and one of them got the `scrolling` class, the other non scrolling modals are position shifted right before they get hidden/overlayed

## Testcase
Remove CSS to see issue
- Open first modal
- Open second
https://jsfiddle.net/lubber/wenjov56/


## Closes
#934 