### PR TITLE
fix(modal, flyout): ignore observed non inputs for autofocus

### DIFF
--- a/src/definitions/modules/flyout.js
+++ b/src/definitions/modules/flyout.js
@@ -525,7 +525,9 @@
                                         $removedInputs = $(collectNodes(mutation.removedNodes)).filter('a[href], [tabindex], :input');
                                     if ($addedInputs.length > 0 || $removedInputs.length > 0) {
                                         shouldRefreshInputs = true;
-                                        ignoreAutofocus = false;
+                                        if ($addedInputs.filter(':input').length > 0 || $removedInputs.filter(':input').length > 0) {
+                                            ignoreAutofocus = false;
+                                        }
                                     }
                                 }
 

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -290,7 +290,9 @@
                                         $removedInputs = $(collectNodes(mutation.removedNodes)).filter('a[href], [tabindex], :input');
                                     if ($addedInputs.length > 0 || $removedInputs.length > 0) {
                                         shouldRefreshInputs = true;
-                                        ignoreAutofocus = false;
+                                        if ($addedInputs.filter(':input').length > 0 || $removedInputs.filter(':input').length > 0) {
+                                            ignoreAutofocus = false;
+                                        }
                                     }
                                 }
 


### PR DESCRIPTION
## Description
The observer should only retrigger autofocus if an input has changed, not for any kind of tabbable element.

## Testcase
Click into the editor and press enter

### Broken
... it focuses the dropdown right after pressing enter inside the editor
https://jsfiddle.net/yk1evctn/

### Fixed
... focus stays inside the editor
https://jsfiddle.net/lubber/krghmwuv/

## Closes
#2723 
