### PR TITLE
feat(slider): restrictedLabels, min/maxRange, always ticks, tooltip

### DIFF
--- a/src/definitions/modules/popup.less
+++ b/src/definitions/modules/popup.less
@@ -117,7 +117,6 @@
     [data-tooltip]::before,
     [data-tooltip]::after {
         pointer-events: none;
-        visibility: hidden;
         opacity: 0;
         transition:
             transform @tooltipDuration @tooltipEasing,
@@ -138,9 +137,10 @@
     [data-tooltip]::after {
         transform-origin: center bottom;
     }
+    [data-tooltip][data-variation~="visible"]::before,
+    [data-tooltip][data-variation~="visible"]::after,
     [data-tooltip]:hover::before,
     [data-tooltip]:hover::after {
-        visibility: visible;
         pointer-events: auto;
         opacity: 1;
     }

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -134,24 +134,33 @@
                         if ($module.attr('tabindex') === undefined) {
                             $module.attr('tabindex', 0);
                         }
-                        var possibleTooltip = settings.showThumbTooltip
-                            ? 'data-position="' + settings.tooltipConfig.position + '" data-variation="' + settings.tooltipConfig.variation + '"'
-                            : '';
                         if ($module.find('.inner').length === 0) {
                             $module.append('<div class="inner">'
                                 + '<div class="track"></div>'
                                 + '<div class="track-fill"></div>'
-                                + '<div class="thumb" ' + possibleTooltip + '></div>'
+                                + '<div class="thumb"></div>'
                                 + '</div>');
                         }
                         precision = module.get.precision();
                         $thumb = $module.find('.thumb:not(.second)');
+                        if (settings.showThumbTooltip) {
+                            $thumb
+                                .attr('data-position', settings.tooltipConfig.position)
+                                .attr('data-variation', settings.tooltipConfig.variation)
+                            ;
+                        }
                         $currThumb = $thumb;
                         if (module.is.range()) {
                             if ($module.find('.thumb.second').length === 0) {
-                                $module.find('.inner').append('<div class="thumb second" ' + possibleTooltip + '></div>');
+                                $module.find('.inner').append('<div class="thumb second"></div>');
                             }
                             $secondThumb = $module.find('.thumb.second');
+                            if (settings.showThumbTooltip) {
+                                $secondThumb
+                                    .attr('data-position', settings.tooltipConfig.position)
+                                    .attr('data-variation', settings.tooltipConfig.variation)
+                                ;
+                            }
                         }
                         $track = $module.find('.track');
                         $trackFill = $module.find('.track-fill');

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -351,7 +351,11 @@
                         }
                         if (module.is.range() && (settings.minRange || settings.maxRange)) {
                             var currentRangeDiff = module.get.currentRangeDiff(value);
-                            if ((settings.minRange && currentRangeDiff < settings.minRange) || (settings.maxRange && currentRangeDiff > settings.maxRange)) {
+                            if ((settings.minRange && currentRangeDiff < settings.minRange)
+                                || (settings.maxRange && currentRangeDiff > settings.maxRange)
+                                || (settings.preventCrossover && value > module.thumbVal && value > module.secondThumbVal)
+                                || (settings.preventCrossover && value < module.thumbVal && value < module.secondThumbVal)
+                            ) {
                                 return;
                             }
                         }
@@ -1040,12 +1044,12 @@
                             }
                             if (!$currThumb.hasClass('second')) {
                                 if (settings.preventCrossover && module.is.range()) {
-                                    newValue = Math.min(module.secondThumbVal, newValue);
+                                    newValue = Math.min(module.secondThumbVal - (settings.minRange || 0), newValue);
                                 }
                                 module.thumbVal = newValue;
                             } else {
                                 if (settings.preventCrossover && module.is.range()) {
-                                    newValue = Math.max(module.thumbVal, newValue);
+                                    newValue = Math.max(module.thumbVal + (settings.minRange || 0), newValue);
                                 }
                                 module.secondThumbVal = newValue;
                             }

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -134,11 +134,14 @@
                         if ($module.attr('tabindex') === undefined) {
                             $module.attr('tabindex', 0);
                         }
+                        var possibleTooltip = settings.showThumbTooltip
+                            ? 'data-position="' + settings.tooltipConfig.position + '" data-variation="' + settings.tooltipConfig.variation + '"'
+                            : '';
                         if ($module.find('.inner').length === 0) {
-                            $module.append("<div class='inner'>"
-                                + "<div class='track'></div>"
-                                + "<div class='track-fill'></div>"
-                                + "<div class='thumb'></div>"
+                            $module.append('<div class="inner">'
+                                + '<div class="track"></div>'
+                                + '<div class="track-fill"></div>'
+                                + '<div class="thumb" ' + possibleTooltip + '></div>'
                                 + '</div>');
                         }
                         precision = module.get.precision();
@@ -146,7 +149,7 @@
                         $currThumb = $thumb;
                         if (module.is.range()) {
                             if ($module.find('.thumb.second').length === 0) {
-                                $module.find('.inner').append("<div class='thumb second'></div>");
+                                $module.find('.inner').append('<div class="thumb second" ' + possibleTooltip + '></div>');
                             }
                             $secondThumb = $module.find('.thumb.second');
                         }
@@ -1070,6 +1073,10 @@
                             thumbVal = module.thumbVal || module.get.min(),
                             secondThumbVal = module.secondThumbVal || module.get.min()
                         ;
+                        if (settings.showThumbTooltip) {
+                            var precision = module.get.precision();
+                            $targetThumb.attr('data-tooltip', Math.round(newValue * precision) / precision);
+                        }
                         if (module.is.range()) {
                             if (!$targetThumb.hasClass('second')) {
                                 position = newPos;
@@ -1410,6 +1417,11 @@
         },
 
         restrictedLabels: [],
+        showThumbTooltip: false,
+        tooltipConfig: {
+            position: 'top center',
+            variation: 'tiny black',
+        },
 
         labelTypes: {
             number: 'number',

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -521,7 +521,13 @@
 
                 is: {
                     range: function () {
-                        return $module.hasClass(className.range);
+                        var isRange = $module.hasClass(className.range);
+                        if (!isRange && (settings.minRange || settings.maxRange)) {
+                            $module.addClass(className.range);
+                            isRange = true;
+                        }
+
+                        return isRange;
                     },
                     hover: function () {
                         return isHover;

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -350,11 +350,13 @@
                             $currThumb = initialPosition > newPos ? $thumb : $secondThumb;
                         }
                         if (module.is.range() && (settings.minRange || settings.maxRange)) {
-                            var currentRangeDiff = module.get.currentRangeDiff(value);
+                            var currentRangeDiff = module.get.currentRangeDiff(value),
+                                isSecondThumb = $currThumb.hasClass('second')
+                            ;
                             if ((settings.minRange && currentRangeDiff < settings.minRange)
                                 || (settings.maxRange && currentRangeDiff > settings.maxRange)
-                                || (settings.preventCrossover && value > module.thumbVal && value > module.secondThumbVal)
-                                || (settings.preventCrossover && value < module.thumbVal && value < module.secondThumbVal)
+                                || (settings.preventCrossover && !isSecondThumb && value > module.secondThumbVal)
+                                || (settings.preventCrossover && isSecondThumb && value < module.thumbVal)
                             ) {
                                 return;
                             }


### PR DESCRIPTION
## Description
This PR adds new features to the slider module:

- minRange and maxRange settings to be able to restrict a range slider to a specific range by giving edge values 
  - minRange: 5  makes sure that the two thumbs always need to have a difference of 5 
  - maxRange: 10 makes sure that the two thumbs dont exceed a difference of 10
- restrictedLabels: an array of label values which restrict the displayed labels to only those which are defined
- showLabelTicks "always". This differs from "true" and comes in handy when used together with "restrictedLabels"
  - 'always' will always show the ticks for _all_ labels (even if not shown)
  - true will display the ticks only if the related label is also shown	
- showThumbTooltip option will display a tooltip containing the current value to the thumb(s)

## Testcase
https://jsfiddle.net/lubber/fzvynqom/20/

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/222982632-2851a43b-305a-4c57-aae9-6acee030d71c.png)


## Closes
#1731
#2241 
