### PR TITLE
feat(menu): simpler equal width

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -1624,9 +1624,9 @@ Floated Menu / Item
 }
 
 & when (@variationMenuEqualWidth) {
-/* -------------------
-      Evenly Sized
--------------------- */
+    /* -------------------
+          Evenly Sized
+    -------------------- */
 
     .ui[class*="equal width"].menu > .item {
         flex: 1;

--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -1623,29 +1623,36 @@ Floated Menu / Item
     }
 }
 
+& when (@variationMenuEqualWidth) {
 /* -------------------
       Evenly Sized
 -------------------- */
 
-.ui.item.menu,
-.ui.item.menu .item {
-    width: 100%;
-    padding-left: 0 !important;
-    padding-right: 0 !important;
-    margin-left: 0 !important;
-    margin-right: 0 !important;
-    text-align: center;
-    justify-content: center;
-}
-.ui.attached.item.menu:not(.tabular) {
-    margin: 0 @attachedHorizontalOffset !important;
-}
+    .ui[class*="equal width"].menu > .item {
+        flex: 1;
+    }
 
-.ui.item.menu .item:last-child::before {
-    display: none;
-}
+    .ui[class*="equal width"].menu > .item,
+    .ui.item.menu,
+    .ui.item.menu .item {
+        width: 100%;
+        padding-left: 0 !important;
+        padding-right: 0 !important;
+        margin-left: 0 !important;
+        margin-right: 0 !important;
+        text-align: center;
+        justify-content: center;
+    }
+    .ui.attached[class*="equal width"].menu:not(.tabular),
+    .ui.attached.item.menu:not(.tabular) {
+        margin: 0 @attachedHorizontalOffset !important;
+    }
 
-& when (@variationMenuEqualWidth) {
+    .ui[class*="equal width"].menu > .item:last-child::before,
+    .ui.item.menu .item:last-child::before {
+        display: none;
+    }
+
     .ui.menu.two.item .item {
         width: 50%;
     }


### PR DESCRIPTION
## Description
This PR unifies the `equal width` logic for menu as we already have in fields, grid and segment

I left the old approach ("x item menu") to avoid being a breaking change.
I will investigate if we can remove the old approach for 2.10.0 as , at the moment, i could not detect if there is a technical reason equal width menu items were done differently than in the other components

## Testcase 
https://jsfiddle.net/lubber/ydwfnur0/2/

## Closes
#2732 