### PR TITLE
feat(search): onresults callback fromcache

### DIFF
--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -561,6 +561,7 @@
                         if (cache) {
                             module.debug('Reading result from cache', searchTerm);
                             module.save.results(cache.results);
+                            settings.onResults.call(element, cache.results, true);
                             module.addResults(cache.html);
                             module.inject.id(cache.results);
                             callback();
@@ -1345,7 +1346,7 @@
         onResultsAdd: false,
 
         onSearchQuery: function (query) {},
-        onResults: function (response) {},
+        onResults: function (response, fromCache) {},
 
         onResultsOpen: function () {},
         onResultsClose: function () {},


### PR DESCRIPTION
## Description

The `onResults` callback was not firedwhen the results came from the cache.
This is now implemented. The callback will retrieve an additional 2nd parameter which will indicate if the call was initiated from remote (false) or cache (true)

## Testcase
- Watch Console
- Enter "test"
- Enter something else
- Enter "test" again

### Broken
onResult is not called when coming from cache
https://jsfiddle.net/lubber/Lphw05ek/5/

### Fixed
onResult is called from Cache aswell indicated by a second parameter
https://jsfiddle.net/lubber/Lphw05ek/7/

## Closes
#909
