### PR TITLE
feat(segment): loading segment should cover loading spinner

### DIFF
--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -545,6 +545,7 @@
         pointer-events: none;
         user-select: none;
         transition: all 0s linear;
+        min-height: @loadingMinHeight;
     }
     .ui.loading.segments::before,
     .ui.loading.segment::before {

--- a/src/themes/default/elements/segment.variables
+++ b/src/themes/default/elements/segment.variables
@@ -88,6 +88,7 @@
 /* Loading Spinner */
 @loaderSize: 3em;
 @loaderLineZIndex: 101;
+@loadingMinHeight: @loaderSize * 1.5;
 
 /*******************************
             Variations


### PR DESCRIPTION
## Description
An empty loading segment does not cover the loading spinner

> Original Fix by @brendon in https://github.com/Semantic-Org/Semantic-UI/pull/6560

## Testcase
Remove CSS to see issue
https://jsfiddle.net/lubber/uf3hgkes/

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/226191091-72ed33af-e75a-41fe-b633-64bc114feffe.png)
