### PR TITLE
feat(segment): colored inverted attached segment should not have a bl…

### DIFF
--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -615,13 +615,19 @@
         @color: @value;
         @c: @colors[@@color][color];
         & when not (@color=primary) and not (@color=secondary) {
-            .ui.@{color}.segment.segment.segment.segment.segment:not(.inverted) {
+            .ui.ui.ui.ui.ui.@{color}.segment:not(.inverted) {
                 border-top: @coloredBorderSize solid @c;
             }
             & when (@variationSegmentInverted) {
-                .ui.inverted.@{color}.segment.segment.segment.segment.segment {
+                .ui.ui.ui.ui.ui.inverted.@{color}.segment {
                     background-color: @c;
                     color: @white;
+                    & when not (@variationSegmentPiled) and ((@variationSegmentAttached) or (@variationSegmentStacked)) {
+                        border-color: c;
+                    }
+                }
+                .ui.ui.inverted.@{color}.segment:not(.piled) when (@variationSegmentPiled) and ((@variationSegmentAttached) or (@variationSegmentStacked)) {
+                    border-color: @c;
                 }
             }
         }


### PR DESCRIPTION
## Description

A colored attached segment still remains a black border, which look wrong, espcially when used in non dark backgrounds .
This PR sets the same border color to such segments so the border vanishes (border: none would change the padding, thats why setting the same color to the border just as the background was used to solve this)

> Thanks for @brendon for the original suggestion

## Testcase
https://jsfiddle.net/lubber/490atyg2/3/

### Screenshot
### Before
![image](https://user-images.githubusercontent.com/18379884/226195500-32c0d26e-1cf9-4c5a-9761-fa28dc95b2be.png)

### After
![image](https://user-images.githubusercontent.com/18379884/226195468-d02172d5-f535-4abd-99d5-23fabade260b.png)


## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/3397
