### PR TITLE
fix(formvalidation): support native validation, after submit only

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1344,16 +1344,16 @@
                             if (showErrors) {
                                 $field.closest($group).addClass(className.error);
                             }
-                        } else if (isDisabled) {
+                        } else if (showErrors) {
+                            $field.closest($group).removeClass(className.error);
+                        }
+                        if (isDisabled) {
                             module.debug('Field is disabled. Skipping', identifier);
                         } else if (field.optional && module.is.blank($field)) {
                             module.debug('Field is optional and blank. Skipping', identifier);
                         } else if (field.depends && module.is.empty($dependsField)) {
                             module.debug('Field depends on another value that is not present or empty. Skipping', $dependsField);
                         } else if (field.rules !== undefined) {
-                            if (showErrors) {
-                                $field.closest($group).removeClass(className.error);
-                            }
                             $.each(field.rules, function (index, rule) {
                                 if (module.has.field(identifier)) {
                                     var invalidFields = module.validate.rule(field, rule, true) || [];
@@ -1367,8 +1367,6 @@
                                     }
                                 }
                             });
-                        } else if (showErrors) {
-                            $field.closest($group).removeClass(className.error);
                         }
                         if (fieldValid) {
                             if (showErrors) {
@@ -1662,8 +1660,8 @@
             isExactly: '{name} must be exactly "{ruleValue}"',
             not: '{name} cannot be set to "{ruleValue}"',
             notExactly: '{name} cannot be set to exactly "{ruleValue}"',
-            contain: '{name} must contain "{ruleValue}"',
-            containExactly: '{name} must contain exactly "{ruleValue}"',
+            contains: '{name} must contain "{ruleValue}"',
+            containsExactly: '{name} must contain exactly "{ruleValue}"',
             doesntContain: '{name} cannot contain "{ruleValue}"',
             doesntContainExactly: '{name} cannot contain exactly "{ruleValue}"',
             minLength: '{name} must be at least {ruleValue} characters',

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -163,7 +163,7 @@
                         .on('click' + eventNamespace, selector.reset, module.reset)
                         .on('click' + eventNamespace, selector.clear, module.clear)
                     ;
-                    $(selector.field).on('invalid', module.event.field.invalid);
+                    $field.on('invalid' + eventNamespace, module.event.field.invalid);
                     if (settings.keyboardShortcuts) {
                         $module.on('keydown' + eventNamespace, selector.field, module.event.field.keydown);
                     }

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -130,10 +130,13 @@
                     module.bindEvents();
                 },
 
-                submit: function () {
+                submit: function (event) {
                     module.verbose('Submitting form', $module);
                     submitting = true;
                     $module.trigger('submit');
+                    if (event) {
+                        event.preventDefault();
+                    }
                 },
 
                 attachEvents: function (selector, action) {
@@ -279,7 +282,9 @@
                                 allValid = false;
                             }
                         });
-
+                        if (allValid) {
+                            allValid = $module[0].querySelectorAll(':invalid').length === 0;
+                        }
                         return allValid;
                     },
                     isDirty: function (e) {
@@ -431,9 +436,8 @@
                             if (!event.ctrlKey && key === keyCode.enter && isInput && !isInDropdown && !isCheckbox) {
                                 if (!keyHeldDown) {
                                     $field.one('keyup' + eventNamespace, module.event.field.keyup);
-                                    module.submit();
+                                    module.submit(event);
                                     module.debug('Enter pressed on input submitting form');
-                                    event.preventDefault();
                                 }
                                 keyHeldDown = true;
                             }

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -449,7 +449,7 @@
                         keyup: function () {
                             keyHeldDown = false;
                         },
-                        invalid: function(event) {
+                        invalid: function (event) {
                             event.preventDefault();
                         },
                         blur: function (event) {
@@ -542,7 +542,7 @@
 
                         return fullFields;
                     },
-                    identifier: function(validation, $el) {
+                    identifier: function (validation, $el) {
                         return validation.identifier || $el.attr('id') || $el.attr('name') || $el.data(metadata.validate);
                     },
                     prompt: function (rule, field) {
@@ -1337,7 +1337,7 @@
                             module.debug('Using field name as identifier', identifier);
                             field.identifier = identifier;
                         }
-                        if(validationMessage) {
+                        if (validationMessage) {
                             module.debug('Field is natively invalid', identifier);
                             fieldErrors.push(validationMessage);
                             fieldValid = false;

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -297,6 +297,7 @@
                                 }
                             }
                         }
+
                         return allValid;
                     },
                     isDirty: function (e) {

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -283,7 +283,19 @@
                             }
                         });
                         if (allValid) {
-                            allValid = $module[0].querySelectorAll(':invalid').length === 0;
+                            var nativeInvalid = $module[0].querySelectorAll(':invalid'),
+                                fieldErrors,
+                                identifier;
+                            for (var i = 0; i < nativeInvalid.length; i++) {
+                                if (nativeInvalid[i] && nativeInvalid[i].validationMessage) {
+                                    identifier = nativeInvalid[i].name || nativeInvalid[i].id;
+                                    fieldErrors = [nativeInvalid[i].validationMessage];
+                                    formErrors = formErrors.concat(fieldErrors);
+                                    module.add.prompt(identifier, fieldErrors, true);
+                                    settings.onInvalid.call(module.get.field(identifier, true), fieldErrors);
+                                    allValid = false;
+                                }
+                            }
                         }
                         return allValid;
                     },

--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -585,14 +585,7 @@
             box-shadow: @formStates[@@state][boxShadow];
         }
         & when (@state=error) and (@variationFormInvalid) {
-            .ui.form .field input:not(:placeholder-shown):invalid {
-                color: @c;
-                background: @bg;
-                border-color: @formStates[@@state][borderColor];
-                border-radius: @formStates[@@state][borderRadius];
-                box-shadow: @formStates[@@state][boxShadow];
-            }
-            .ui.form .field input:not(:-ms-input-placeholder):invalid when (@supportIE) {
+            .ui.form:not(.initial) .field input:invalid {
                 color: @c;
                 background: @bg;
                 border-color: @formStates[@@state][borderColor];

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -127,7 +127,7 @@
 @variationInputDisabled: true;
 @variationInputInverted: true;
 @variationInputStates: @variationAllStates;
-@variationInputInvalid: true;
+@variationInputInvalid: false;
 @variationInputTransparent: true;
 @variationInputCorner: true;
 @variationInputLoading: true;


### PR DESCRIPTION
## Description
Form validation will trigger success even if native form validations are still invalid.
This PR respects any native form validation by the browser in addition to the FUI form validation rules

Native invalid fields (like required file inputs) are now only shown as error'ed after a form submit has taken place at least once

I also fixed a possible double submit when the submit button is not a native submit input.

## Testcase
https://jsfiddle.net/lubber/7L4qhzjg/2/

## Closes
#2750 