### PR TITLE
fix(install): copy overrides.less file on install/update

### DIFF
--- a/tasks/admin/distributions/create.js
+++ b/tasks/admin/distributions/create.js
@@ -3,7 +3,7 @@
 *******************************/
 
 /*
- This will create individual distribution repositories for each SUI distribution
+ This will create individual distribution repositories for each FUI distribution
 
   * copy distribution files to release
   * update package.json file
@@ -153,6 +153,8 @@ module.exports = function (callback) {
                 tasks.push(function () {
                     let
                         definitions,
+                        overridesImport,
+                        lessImport,
                         themeImport,
                         themeConfig,
                         siteTheme,
@@ -161,7 +163,10 @@ module.exports = function (callback) {
                     definitions = gulp.src('src/definitions/**/*', { base: 'src/' })
                         .pipe(gulp.dest(outputDirectory))
                     ;
-                    themeImport = gulp.src('src/semantic.less', { base: 'src/' })
+                    overridesImport = gulp.src('src/overrides.less', { base: 'src/' })
+                        .pipe(gulp.dest(outputDirectory))
+                    ;
+                    lessImport = gulp.src('src/semantic.less', { base: 'src/' })
                         .pipe(gulp.dest(outputDirectory))
                     ;
                     themeImport = gulp.src('src/theme.less', { base: 'src/' })
@@ -177,7 +182,7 @@ module.exports = function (callback) {
                         .pipe(gulp.dest(outputDirectory))
                     ;
 
-                    return mergeStream(definitions, themeImport, themeConfig, siteTheme, themes);
+                    return mergeStream(definitions, overridesImport, lessImport, themeImport, themeConfig, siteTheme, themes);
                 });
             }
 

--- a/tasks/config/project/install.js
+++ b/tasks/config/project/install.js
@@ -240,6 +240,7 @@ module.exports = {
         config: './semantic.json.example',
         definitions: './src/definitions',
         gulpFile: './gulpfile.js',
+        overridesImport: './src/overrides.less',
         lessImport: './src/semantic.less',
         site: './src/_site',
         tasks: './tasks',
@@ -253,6 +254,7 @@ module.exports = {
     // expected final filenames
     files: {
         config: 'semantic.json',
+        overridesImport: 'src/overrides.less',
         lessImport: 'src/semantic.less',
         site: 'src/site',
         themeConfig: 'src/theme.config',
@@ -263,6 +265,7 @@ module.exports = {
     folders: {
         config: './',
         definitions: 'src/definitions/',
+        overridesImport: 'src/',
         lessImport: 'src/',
         modules: 'node_modules/',
         site: 'src/site/',

--- a/tasks/install.js
+++ b/tasks/install.js
@@ -69,9 +69,9 @@ module.exports = function (callback) {
         root: path.normalize(__dirname + '/../'),
     }; */
 
-    /* Don't do end user config if SUI is a sub-module */
+    /* Don't do end user config if FUI is a sub-module */
     if (install.isSubModule()) {
-        console.info('SUI is a sub-module, skipping end-user install');
+        console.info('FUI is a sub-module, skipping end-user install');
         callback();
 
         return;
@@ -86,7 +86,7 @@ module.exports = function (callback) {
     }
 
     /* -----------------
-        Update SUI
+        Update FUI
     ----------------- */
 
     // run update scripts if semantic.json exists
@@ -96,6 +96,7 @@ module.exports = function (callback) {
             updatePaths  = {
                 config: path.join(manager.root, files.config),
                 tasks: path.join(updateFolder, folders.tasks),
+                overridesImport: path.join(updateFolder, folders.overridesImport),
                 themeImport: path.join(updateFolder, folders.themeImport),
                 definition: path.join(currentConfig.paths.source.definitions),
                 site: path.join(currentConfig.paths.source.site),
@@ -132,7 +133,11 @@ module.exports = function (callback) {
                     .pipe(plumber())
                     .pipe(gulp.dest(updatePaths.themeImport))
                 ;
-
+                console.info('Updating overrides import file');
+                gulp.src(source.overridesImport)
+                    .pipe(plumber())
+                    .pipe(gulp.dest(updatePaths.overridesImport))
+                ;
                 console.info('Adding new site theme files...');
                 wrench.copyDirSyncRecursive(source.site, updatePaths.site, settings.wrench.merge);
 
@@ -187,7 +192,7 @@ module.exports = function (callback) {
     }
 
     /* --------------
-       Create SUI
+       Create FUI
     --------------- */
 
     gulp.task('run setup', function (callback) {
@@ -263,6 +268,7 @@ module.exports = function (callback) {
             // special install paths only for PM install
             installPaths = extend(false, {}, installPaths, {
                 definition: folders.definitions,
+                overridesImport: folders.overridesImport,
                 lessImport: folders.lessImport,
                 tasks: folders.tasks,
                 theme: folders.themes,
@@ -310,6 +316,10 @@ module.exports = function (callback) {
             gulp.src(source.themeImport)
                 .pipe(plumber())
                 .pipe(gulp.dest(installPaths.themeImport))
+            ;
+            gulp.src(source.overridesImport)
+                .pipe(plumber())
+                .pipe(gulp.dest(installPaths.overridesImport))
             ;
             gulp.src(source.lessImport)
                 .pipe(plumber())


### PR DESCRIPTION
## Description
The new file `overrides.less` was missing at install/update. Without that any install would miss the overrides files which in turn breaks components which rely on them like transition

 