### PR TITLE
feat(form): optional limit the displayed error messages per field

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1355,7 +1355,7 @@
                             module.debug('Field depends on another value that is not present or empty. Skipping', $dependsField);
                         } else if (field.rules !== undefined) {
                             $.each(field.rules, function (index, rule) {
-                                if (module.has.field(identifier)) {
+                                if (module.has.field(identifier) && (!settings.errorLimit || fieldErrors.length < settings.errorLimit)) {
                                     var invalidFields = module.validate.rule(field, rule, true) || [];
                                     if (invalidFields.length > 0) {
                                         module.debug('Field is invalid', identifier, rule.type);
@@ -1607,6 +1607,7 @@
         preventLeaving: false,
         errorFocus: true,
         dateHandling: 'date', // 'date', 'input', 'formatter'
+        errorLimit: 0,
 
         onValid: function () {},
         onInvalid: function () {},

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1331,7 +1331,8 @@
                             fieldValid  = true,
                             fieldErrors = [],
                             isDisabled = $field.filter(':not(:disabled)').length === 0,
-                            validationMessage = $field[0].validationMessage
+                            validationMessage = $field[0].validationMessage,
+                            errorLimit
                         ;
                         if (!field.identifier) {
                             module.debug('Using field name as identifier', identifier);
@@ -1354,8 +1355,9 @@
                         } else if (field.depends && module.is.empty($dependsField)) {
                             module.debug('Field depends on another value that is not present or empty. Skipping', $dependsField);
                         } else if (field.rules !== undefined) {
+                            errorLimit = field.errorLimit || settings.errorLimit;
                             $.each(field.rules, function (index, rule) {
-                                if (module.has.field(identifier) && (!settings.errorLimit || fieldErrors.length < settings.errorLimit)) {
+                                if (module.has.field(identifier) && (!errorLimit || fieldErrors.length < errorLimit)) {
                                     var invalidFields = module.validate.rule(field, rule, true) || [];
                                     if (invalidFields.length > 0) {
                                         module.debug('Field is invalid', identifier, rule.type);


### PR DESCRIPTION
## Description
Added an optional setting `errorLimit` (default 0 = unlimited).
When set to an integer value, only that given number of possible rule errors per field are displayed 

## Testcase
Submit the form

### Normal
All rule error for the single field are displaye (empty and not long enough)
https://jsfiddle.net/lubber/eqdo1huy/6/

### Improved
Only one rule error of the field is displayed 
https://jsfiddle.net/lubber/eqdo1huy/8/

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6361
