### PR TITLE
feat(search): horizontal category variant

### DIFF
--- a/src/definitions/modules/search.less
+++ b/src/definitions/modules/search.less
@@ -367,6 +367,19 @@
         transition: @categoryResultTransition;
         padding: @categoryResultPadding;
     }
+
+    & when (@variationSearchHorizontalCategory) {
+        .ui.horizontal.category.search > .results .category,
+        .ui.horizontal.category.search > .results .category > .name,
+        .ui.horizontal.category.search > .results .category > .results {
+            display: block;
+        }
+
+        .ui.horizontal.category.search > .results .category > .results {
+            width: 100%;
+            border-left: 0;
+        }
+    }
 }
 
 /*******************************

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -651,6 +651,7 @@
 @variationSearchDisabled: true;
 @variationSearchSelection: true;
 @variationSearchCategory: true;
+@variationSearchHorizontalCategory: true;
 @variationSearchLoading: true;
 @variationSearchAligned: true;
 @variationSearchFluid: true;


### PR DESCRIPTION
## Description

Added a `horizontal category search` variant, which moves the category headers to the top of each results instead of the left

## Testcase 
https://jsfiddle.net/lubber/Lv2fhp98/26/

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/232160907-3d4ac506-a198-48d3-9d9b-a12033b252c9.png)

## Closes
#1195 
https://github.com/Semantic-Org/Semantic-UI/issues/6901
