### PR TITLE
feat(item,comment): disabled variants

### DIFF
--- a/src/definitions/views/comment.less
+++ b/src/definitions/views/comment.less
@@ -290,6 +290,13 @@
         }
     }
 }
+& when (@variationCommentDisabled) {
+    .ui.disabled.comments,
+    .ui.comments .disabled.comment {
+        opacity: @disabledOpacity;
+        pointer-events: @disabledPointerEvents;
+    }
+}
 
 // stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/views/item.less
+++ b/src/definitions/views/item.less
@@ -597,6 +597,12 @@
         }
     }
 }
-
+& when (@variationItemDisabled) {
+    .ui.disabled.items,
+    .ui.items > .disabled.item {
+        opacity: @disabledOpacity;
+        pointer-events: @disabledPointerEvents;
+    }
+}
 // stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/views/item.less
+++ b/src/definitions/views/item.less
@@ -604,5 +604,6 @@
         pointer-events: @disabledPointerEvents;
     }
 }
+
 // stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -439,6 +439,7 @@
 
 /* Comment */
 @variationCommentInverted: true;
+@variationCommentDisabled: true;
 @variationCommentThreaded: true;
 @variationCommentMinimal: true;
 @variationCommentAvatar: true;
@@ -461,6 +462,7 @@
 
 /* Item */
 @variationItemInverted: true;
+@variationItemDisabled: true;
 @variationItemImage: true;
 @variationItemHeader: true;
 @variationItemDescription: true;


### PR DESCRIPTION
## Description

Added a `disabled` variant to comment and item because such elements could contain interactive elements and it's quite a common use case to have all/single comment(s)/item(s) being disabled