### PR TITLE
fix(dropdown): trigger onchange for paste values

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1097,8 +1097,8 @@
                             notFoundTokens = []
                         ;
                         tokens.forEach(function (value) {
-                            if (module.set.selected(module.escape.htmlEntities(value.trim()), null, true, true) === false) {
-                                notFoundTokens.push(value);
+                            if (module.set.selected(module.escape.htmlEntities(value.trim()), null, false, true) === false) {
+                                notFoundTokens.push(value.trim());
                             }
                         });
                         event.preventDefault();


### PR DESCRIPTION
## Description
Pasted values into multiple search dropdowns did not trigger the onchange event for selected values

## Testcase 
https://jsfiddle.net/lubber/13e0pn8q/

## Closes
#2764 