### PR TITLE
feat(checkbox): invisible variant for text only

### DIFF
--- a/src/definitions/modules/checkbox.less
+++ b/src/definitions/modules/checkbox.less
@@ -681,7 +681,7 @@
             background: @invisibleCheckboxBackground;
             border-color: @invisibleCheckboxBorderColor;
             box-shadow: @invisibleCheckboxBoxShadow;
-            color: inherit;
+            color: @invisibleCheckboxColor;
         }
         &:not(:hover):focus + label:not(.image) {
             box-shadow: @invisibleCheckboxFocusBoxShadow;

--- a/src/definitions/modules/checkbox.less
+++ b/src/definitions/modules/checkbox.less
@@ -56,9 +56,12 @@
     cursor: auto;
     position: relative;
     display: block;
-    padding-left: @labelDistance;
     outline: none;
     font-size: @labelFontSize;
+}
+
+.ui.checkbox:not(.invisible) label {
+    padding-left: @labelDistance;
 }
 
 .ui.checkbox label::before {
@@ -130,8 +133,8 @@
     background: @checkboxHoverBackground;
     border-color: @checkboxHoverBorderColor;
 }
-.ui.checkbox label:hover,
-.ui.checkbox + label:hover {
+.ui.checkbox:not(.invisible) label:hover,
+.ui.checkbox:not(.invisible) + label:hover {
     color: @labelHoverColor;
 }
 
@@ -146,7 +149,7 @@
 .ui.checkbox label:active::after {
     color: @checkboxPressedColor;
 }
-.ui.checkbox input:active ~ label {
+.ui.checkbox:not(.invisible) input:active ~ label {
     color: @labelPressedColor;
 }
 
@@ -161,7 +164,7 @@
 .ui.checkbox input:focus ~ label::after {
     color: @checkboxFocusCheckColor;
 }
-.ui.checkbox input:focus ~ label {
+.ui.checkbox:not(.invisible) input:focus ~ label {
     color: @labelFocusColor;
 }
 
@@ -649,6 +652,53 @@
         }
         .ui.ui.inverted.toggle.checkbox input:focus:checked ~ label::before {
             background-color: @toggleOnFocusLaneColor;
+        }
+    }
+}
+& when (@variationCheckboxInvisible) {
+    /* --------------
+         Invisible
+    --------------- */
+
+    .ui.invisible.checkbox {
+        display: block;
+        &
+        label::before,
+        label::after {
+            display: none;
+        }
+        & input {
+            left: -99999px;
+            position: absolute;
+        }
+        & label {
+            transition: @invisibleCheckboxLabelTransition;
+        }
+    }
+    .ui.ui.ui.ui.ui.invisible.checkbox input:not(:checked) {
+        & + label {
+            background: @invisibleCheckboxBackground;
+            border-color: @invisibleCheckboxBorderColor;
+            box-shadow: @invisibleCheckboxBoxShadow;
+            color: inherit;
+        }
+        &:not(:hover):focus + label:not(.image) {
+            box-shadow: @invisibleCheckboxFocusBoxShadow;
+        }
+        &
+        + label.image,
+        .basic& + label {
+            box-shadow: none;
+        }
+    }
+
+    .ui.invisible.checkbox input:not(:checked){
+        & + label.image {
+            opacity: @invisibleCheckboxImageOpacityUnchecked;
+            filter: @invisibleCheckboxImageFilterUnchecked;
+        }
+        &:not(:hover):focus + label.image {
+            opacity: @invisibleCheckboxImageOpacityFocus;
         }
     }
 }

--- a/src/definitions/modules/checkbox.less
+++ b/src/definitions/modules/checkbox.less
@@ -666,9 +666,8 @@
             left: -99999px;
             position: absolute;
         }
-        &
-        label::before,
-        label::after {
+        & label::before,
+        & label::after {
             display: none;
         }
         & label {

--- a/src/definitions/modules/checkbox.less
+++ b/src/definitions/modules/checkbox.less
@@ -696,12 +696,15 @@
         & + label.image {
             opacity: @invisibleCheckboxImageOpacityUnchecked;
             filter: @invisibleCheckboxImageFilterUnchecked;
-            .disabled& when (@variationCheckboxDisabled) {
-                opacity: @invisibleCheckboxImageOpacityUncheckedDisabled;
-            }
         }
         &:not(:hover):focus + label.image {
             opacity: @invisibleCheckboxImageOpacityFocus;
+        }
+        & when (@variationCheckboxDisabled) {
+            &[disabled] + label.image,
+            .disabled& + label.image {
+                opacity: @invisibleCheckboxImageOpacityUncheckedDisabled;
+            }
         }
     }
 }

--- a/src/definitions/modules/checkbox.less
+++ b/src/definitions/modules/checkbox.less
@@ -696,6 +696,9 @@
         & + label.image {
             opacity: @invisibleCheckboxImageOpacityUnchecked;
             filter: @invisibleCheckboxImageFilterUnchecked;
+            .disabled& when (@variationCheckboxDisabled) {
+                opacity: @invisibleCheckboxImageOpacityUncheckedDisabled;
+            }
         }
         &:not(:hover):focus + label.image {
             opacity: @invisibleCheckboxImageOpacityFocus;

--- a/src/definitions/modules/checkbox.less
+++ b/src/definitions/modules/checkbox.less
@@ -662,14 +662,14 @@
 
     .ui.invisible.checkbox {
         display: block;
+        & input {
+            left: -99999px;
+            position: absolute;
+        }
         &
         label::before,
         label::after {
             display: none;
-        }
-        & input {
-            left: -99999px;
-            position: absolute;
         }
         & label {
             transition: @invisibleCheckboxLabelTransition;
@@ -685,14 +685,13 @@
         &:not(:hover):focus + label:not(.image) {
             box-shadow: @invisibleCheckboxFocusBoxShadow;
         }
-        &
-        + label.image,
+        & + label.image,
         .basic& + label {
             box-shadow: none;
         }
     }
 
-    .ui.invisible.checkbox input:not(:checked){
+    .ui.invisible.checkbox input:not(:checked) {
         & + label.image {
             opacity: @invisibleCheckboxImageOpacityUnchecked;
             filter: @invisibleCheckboxImageFilterUnchecked;

--- a/src/definitions/modules/checkbox.less
+++ b/src/definitions/modules/checkbox.less
@@ -661,7 +661,9 @@
     --------------- */
 
     .ui.invisible.checkbox {
-        display: block;
+        &:not(.compact) {
+            display: block;
+        }
         & input {
             left: -99999px;
             position: absolute;

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -512,6 +512,7 @@
 @variationCheckboxDisabled: true;
 @variationCheckboxReadonly: true;
 @variationCheckboxInverted: true;
+@variationCheckboxInvisible: true;
 @variationCheckboxRadio: true;
 @variationCheckboxSlider: true;
 @variationCheckboxToggle: true;

--- a/src/themes/default/modules/checkbox.variables
+++ b/src/themes/default/modules/checkbox.variables
@@ -198,6 +198,7 @@
 @invisibleCheckboxBoxShadow: 0 0 0 @borderWidth @borderColor inset;
 @invisibleCheckboxFocusBoxShadow: 0 0 0 @borderWidth @selectedBorderColor inset;
 @invisibleCheckboxImageOpacityUnchecked: 0.5;
+@invisibleCheckboxImageOpacityUncheckedDisabled: @invisibleCheckboxImageOpacityUnchecked * @disabledCheckboxOpacity;
 @invisibleCheckboxImageOpacityFocus: 0.75;
 @invisibleCheckboxImageFilterUnchecked: grayscale(1);
 

--- a/src/themes/default/modules/checkbox.variables
+++ b/src/themes/default/modules/checkbox.variables
@@ -190,6 +190,17 @@
       Variations
 -------------------- */
 
+/* Invisible */
+@invisibleCheckboxLabelTransition: all @defaultDuration @defaultEasing;
+@invisibleCheckboxBackground: transparent;
+@invisibleCheckboxBorderColor: transparent;
+@invisibleCheckboxColor: inherit;
+@invisibleCheckboxBoxShadow: 0 0 0 @borderWidth @borderColor inset;
+@invisibleCheckboxFocusBoxShadow: 0 0 0 @borderWidth @selectedBorderColor inset;
+@invisibleCheckboxImageOpacityUnchecked: 0.5;
+@invisibleCheckboxImageOpacityFocus: 0.75;
+@invisibleCheckboxImageFilterUnchecked: grayscale(1);
+
 /* Inverted */
 @checkboxInvertedHoverBackground: @black;
 


### PR DESCRIPTION
## Description
Added an `invisible` variant to checkbox which allows to use text- or image-only check/radioboxes which are styled by using any other component for the checkbox's label tag like button, message or segment

- icons, emojis or flag only need the `image` class for the label tag. A classic "ui image" works as well
- `compact invisible` keeps the width to the content 

```html
        <div class="ui invisible radio checkbox">
          <input type="checkbox" id="id1a" name="radiogroup">
          <label for="id1a" class="ui pink button "><b>Believe me</b><br/>I am a radio  checkbox!</label>
        </div>
        <div class="ui invisible radio checkbox">
          <input type="checkbox" id="id1b" name="radiogroup">
          <label for="id1b" class="ui blue message"><b>Believe me</b><br/>I am a radio checkbox as well!</label>
        </div>

        <div class="ui invisible checkbox">
          <input type="checkbox" id="id2">
          <label for="id2" class="ui small image">
            <img src="https://fomantic-ui.com/images/avatar/large/ade.jpg">
          </label>
        </div>

        <div class="ui invisible checkbox">
          <input type="checkbox" id="id3">
          <label for="id3" class="image"><i class="ui large germany flag"></i></label>
        </div>

```

## Testcase
https://jsfiddle.net/lubber/5p3ztmyj/85/

## Screenshot
![invisiblecheckbox](https://user-images.githubusercontent.com/18379884/236027634-1831ef41-de54-4eac-8b65-9909ebcb1809.gif)

## Closes
#822
#2393 