### PR TITLE
fix(menu): dont show right wrapping border on secondary

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -1936,7 +1936,7 @@ Floated Menu / Item
         & .item:first-child::before {
             display: none;
         }
-        &:not(.tabular) .item {
+        &:not(.secondary):not(.text):not(.tabular):not(.borderless) .item {
             &:last-of-type,
             &:last-child {
                 border-right: @dividerSize solid @dividerBackground;
@@ -1944,7 +1944,7 @@ Floated Menu / Item
         }
     }
     & when (@variationMenuWrapped) {
-        .ui.wrapped.menu:not(.tabular) .item {
+        .ui.wrapped.menu:not(.secondary):not(.text):not(.tabular):not(.borderless) .item {
             &:first-child {
                 border-bottom-left-radius: 0;
             }


### PR DESCRIPTION
## Description
When using the wrapping option for some menu variants (such as secondary, text, tabular or borderless)  a very right border to the last item is not wanted .

## Closes
#2772 