### PR TITLE
fix(dropdown) Changed "slide down" transition to "slide"

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1897,7 +1897,7 @@
                     },
                     transition: function ($subMenu) {
                         return settings.transition === 'auto'
-                            ? (module.is.upward($subMenu) ? 'slide up' : 'slide down')
+                            ? (module.is.upward($subMenu) ? 'slide up' : 'slide')
                             : settings.transition;
                     },
                     userValues: function () {


### PR DESCRIPTION
<!--
 Please read our Contributing Guide and Code of Conduct before you
 submit a pull request.
  
 Contributing Guide: https://github.com/fomantic/Fomantic-UI/blob/master/CONTRIBUTING.md
 Code of Conduct: https://github.com/fomantic/Fomantic-UI/blob/master/CODE_OF_CONDUCT.md

 ----

 Please use the following pull request title format:
 "[<scope>] <summary of what you fixed/changed>"
-->

## Description
<!-- Describe what you fixed/changed in great detail (required). -->
Previously, dropdown menus would close behind other form elements if the two were vertically located next to each other. The fix changes the default transition for dropdown menus when opening or closing to be the "slide" method, instead of "slide down." This results in the dropdown menu closing on top of other form elements. Also, there was an error with dropdown menus that open upwards, as shown in the gifs below. These menus would then slide even further up to close, instead of collapsing down on the form field. The change to the "slide" transition also fixed this issue, again as shown by the gifs.

## Testcase
<!--
  If possible create an example of your change via a JSFiddle. 

  How to create an example:
   1. Open the following JSFiddle - https://jsfiddle.net/31d6y7mn
   2. Click "Fork" at the top
   3. Add the minimum required HTML, CSS and JavaScript which shows your change
   4. Click "Save" at the top
   5. Copy the URL of your fiddle and link it here
-->
https://jsfiddle.net/krpatel5657/hqe1pnu5/4/

## Screenshot (if possible)
<!--
  If possible include images or gifs of your issue.

  E.g. Incorrect component CSS should include an image of what the
  component looks like.
  
  If your looking for a tool we recommend ShareX - https://github.com/ShareX/ShareX
-->
Original issue:
![dropdown_wrong](https://user-images.githubusercontent.com/52473367/236703967-76e49f67-ef09-4725-98a0-48a3be6930f1.gif)
Fix:
![drop-down-working](https://user-images.githubusercontent.com/52473367/236703973-2f55b9e2-98a6-4255-9525-8e0779f495fc.gif)

Simultaneous fix with upwards dropdown menus:
Original error:
![drop-up-notworking](https://user-images.githubusercontent.com/52473367/236703985-67021978-a2d4-45c0-b6c4-098bb54c7d59.gif)
Fix: 
![drop-up-working](https://user-images.githubusercontent.com/52473367/236703991-4af34055-1f93-48c7-89eb-4b03df29f462.gif)


## Closes
<!--
  List all the issues this pull request closes (only if it does).
-->
#2663 