### PR TITLE
feat(colors): added class names that correspond to different shades of red, green, and blue

### DIFF
--- a/src/definitions/globals/site.less
+++ b/src/definitions/globals/site.less
@@ -108,6 +108,84 @@ p:last-child {
     margin-bottom: 0;
 }
 
+/*******************************
+        Color Classes
+*******************************/
+
+.red {
+    color: #e3342f;
+}
+
+.dark-red {
+    color: #cc1f1a;
+}
+
+.darker-red {
+    color: #621b18;
+}
+.darkest-red {
+    color: #3b0d0c;
+}
+.light-red {
+    color: #ef5753;
+}
+.lighter-red {
+    color: #f9acaa;
+}
+.lightest-red {
+    color: #fcebea;
+}
+
+.blue {
+    color: #1d4ed8;
+}
+
+.dark-blue {
+    color: #1e40af;
+}
+
+.darker-blue {
+    color: #1e3a8a;
+}
+.darkest-blue {
+    color: #172554;
+}
+
+.light-blue {
+    color: #2563eb;
+}
+.lighter-blue {
+    color: #3b82f6;
+}
+.lightest-blue {
+    color: #60a5fa;
+}
+
+.green {
+    color: #15803d;
+}
+
+.dark-green {
+    color: #166534;
+}
+
+.darker-green {
+    color: #14532d;
+}
+.darkest-green {
+    color: #052e16;
+}
+
+.light-green {
+    color: #16a34a;
+}
+.lighter-green {
+    color: #22c55e;
+}
+.lightest-green {
+    color: #4ade80;
+}
+
 /* -------------------
         Links
 -------------------- */


### PR DESCRIPTION
Many people find themselves using different tones of color for CSS styling, and it would be helpful to add class names that correspond to different shades of colors, instead of having to seek the correct Hex value.  Thus, this pr adds classes corresponding to different shades of red, green, and blue. There is the base shade, then there is dark, darker, darkest, light, lighter, lightest shades. 

An example of these changes can be found at the following [jsfiddle](https://jsfiddle.net/wpazos/9fauentq/)

![image](https://user-images.githubusercontent.com/53348298/236718296-cf45ba5b-05a8-4150-8d08-c772f75fc076.png)

This is a potential fix for issue #729.