### PR TITLE
fix(ci): upgrade unicorn to 46 to fix eslint 8.40

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
     - name: Install dependencies
-      run: yarn && yarn add -D eslint-config-airbnb-base@^15 eslint-plugin-unicorn@^45 eslint-plugin-jest@^26.9.0 @typescript-eslint/eslint-plugin @typescript-eslint/parser typescript
+      run: yarn && yarn add -D eslint-config-airbnb-base@^15 eslint-plugin-unicorn@^46 eslint-plugin-jest@^26.9.0 @typescript-eslint/eslint-plugin @typescript-eslint/parser typescript
     - name: Lint JS and LESS files
       run: npm run lint
     - name: Assert LESS files formatting using Prettier


### PR DESCRIPTION
## Description
Recent eslint 8.40 brokein ci, because of 
https://github.com/sindresorhus/eslint-plugin-unicorn/issues/2076

```
TypeError: Cannot read properties of undefined (reading 'getAllComments')
Occurred while linting /home/runner/work/Fomantic-UI/Fomantic-UI/.eslint/eqeqeq-rule.js:1
Rule: "unicorn/expiring-todo-comments"
```

## Fixes
#2779 