### PR TITLE
fix(dropdown): insert clearable at correct dom position

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -363,7 +363,7 @@
                             module.verbose('Adding clear icon');
                             $clear = $('<i />')
                                 .addClass('remove icon')
-                                .insertBefore($text)
+                                .insertAfter($icon)
                             ;
                         }
                         if (module.is.search() && !module.has.search()) {


### PR DESCRIPTION
## Description
This PR makes sure a clearable icon is always positioned at the correct DOM node in case incomplete markup exists.

## Testcase
The dropdown is instantiated twice. 
- The first time, clearable should not be set, but the search input is missing in the markup, so FUI created the search input
- The second time, the dropdown should be clearable, but this time the search input is already existing. This results into the remove icon not being a direct sibling of the dropdown icon which in turn  makes clearing selections not working anymore

## Broken
Selected items are not clearable
https://jsfiddle.net/lubber/oktecuv2/8/

## Fixed
Selected items are clearable
https://jsfiddle.net/lubber/oktecuv2/10/

## Fixes
#2791 