### PR TITLE
fix(form): add prompt while still animating

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -911,7 +911,8 @@
                             $field       = module.get.field(identifier),
                             $fieldGroup  = $field.closest($group),
                             $prompt      = $fieldGroup.children(selector.prompt),
-                            promptExists = $prompt.length > 0
+                            promptExists = $prompt.length > 0,
+                            canTransition = settings.transition && module.can.useElement('transition')
                         ;
                         module.verbose('Adding field error state', identifier);
                         if (!internal) {
@@ -920,8 +921,22 @@
                             ;
                         }
                         if (settings.inline) {
+                            if (promptExists) {
+                                if (canTransition) {
+                                    if ($prompt.transition('is animating')) {
+                                        $prompt.transition('stop all');
+                                    }
+                                } else if ($prompt.is(':animated')) {
+                                    $prompt.stop(true, true);
+                                }
+                                $prompt = $fieldGroup.children(selector.prompt);
+                                promptExists = $prompt.length > 0;
+                            }
                             if (!promptExists) {
                                 $prompt = $('<div/>').addClass(className.label);
+                                if(!canTransition) {
+                                    $prompt.css('display', 'none')
+                                }
                                 $prompt
                                     .appendTo($fieldGroup)
                                 ;
@@ -930,7 +945,7 @@
                                 .html(settings.templates.prompt(errors))
                             ;
                             if (!promptExists) {
-                                if (settings.transition && module.can.useElement('transition')) {
+                                if (canTransition) {
                                     module.verbose('Displaying error with css transition', settings.transition);
                                     $prompt.transition(settings.transition + ' in', settings.duration);
                                 } else {
@@ -939,9 +954,9 @@
                                         .fadeIn(settings.duration)
                                     ;
                                 }
-                            } else {
-                                module.verbose('Inline errors are disabled, no inline error added', identifier);
                             }
+                        } else {
+                            module.verbose('Inline errors are disabled, no inline error added', identifier);
                         }
                     },
                     errors: function (errors) {

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -934,8 +934,8 @@
                             }
                             if (!promptExists) {
                                 $prompt = $('<div/>').addClass(className.label);
-                                if(!canTransition) {
-                                    $prompt.css('display', 'none')
+                                if (!canTransition) {
+                                    $prompt.css('display', 'none');
                                 }
                                 $prompt
                                     .appendTo($fieldGroup)


### PR DESCRIPTION
## Description

If a manual `add prompt` is triggered while the form is submitting / ends validation and possibly existing prompts get faded out via transition, then the new prompt is not shown as it is still found in the dom, but not recognized that the prompt will vanish from the dom once the transition has ended.

I also fixed fadein without transition module as the fadeIn did not work at all.

## Testcase
- Click on Submit -> "some error action 45" is displayed
- Click on Submit again -> prompt vanishes although it should be displayed (again)

### Broken
https://jsfiddle.net/mL3ko1st/1/

### Fixed
https://jsfiddle.net/lubber/gvhcaryf/

## Closes
#2796 