### PR TITLE
fix(dropdown): double hide transition breaks upward out

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -579,7 +579,10 @@
                             if ($subMenu.length > 0) {
                                 module.verbose('Hiding sub-menu', $subMenu);
                                 $subMenu.each(function () {
-                                    module.animate.hide(false, $(this));
+                                    var $sub = $(this);
+                                    if (!module.is.animating($sub)) {
+                                        module.animate.hide(false, $sub);
+                                    }
                                 });
                             }
                         }


### PR DESCRIPTION
## Description
When a dropdown hides, the transition gets called twice messing up with upward menus and underlaying menu transparency.
This is because submenu hiding needs to be called separately (invented by #2331 ) , but in case a select is used the submenu is the dropdown itself, so it should not be (hide) animated again when it is already (hide) animating

## Testcase
https://jsfiddle.net/lubber/Ld624p5m/

## Closes
#2663 

## Replaces
#2777