### PR TITLE
chore(docs): remove openbase badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ The official community fork of the popular Semantic-UI framework.
 [![GitHub Actions Status](https://github.com/fomantic/Fomantic-UI/workflows/CI/badge.svg)](https://github.com/fomantic/Fomantic-UI/actions)
 [![last commit (develop)](https://img.shields.io/github/last-commit/fomantic/Fomantic-UI/develop.svg?label=last%20commit%20%28develop%29)](https://github.com/fomantic/Fomantic-UI/commits/develop)
 [![License](https://img.shields.io/github/license/fomantic/Fomantic-UI?color=%233fb911)](https://github.com/fomantic/Fomantic-UI/blob/1fd94d2479f297c906bed557f0567d1d3f0a4d2c/LICENSE.md)
-[![Rate on Openbase](https://badges.openbase.io/js/rating/fomantic-ui.svg)](https://openbase.io/js/fomantic-ui?utm_source=embedded&utm_medium=badge&utm_campaign=rate-badge)
 
 [![Discord Server](https://discordapp.com/api/guilds/453127116427493376/widget.png?style=shield)](https://discord.gg/YChxjJ3)
 [![Follow on Twitter](https://img.shields.io/twitter/follow/fomanticui?style=social)](https://twitter.com/fomanticui)


### PR DESCRIPTION
## Description

openbase has been shut down in 2023, so this badge does not work anymore

