### PR TITLE
fix(types): allow JQueryAjaxSettings objects for modules using apiSettings

### DIFF
--- a/types/fomantic-ui-api.d.ts
+++ b/types/fomantic-ui-api.d.ts
@@ -107,10 +107,10 @@ declare namespace FomanticUI {
          */
         (behavior: 'destroy'): JQuery;
 
-        <K extends keyof AccordionSettings>(behavior: 'setting', name: K, value?: undefined, ): Partial<Pick<AccordionSettings, keyof AccordionSettings>>;
-        <K extends keyof AccordionSettings>(behavior: 'setting', name: K, value: AccordionSettings[K]): JQuery;
-        (behavior: 'setting', value: Partial<Pick<AccordionSettings, keyof AccordionSettings>>): JQuery;
-        (settings?: Partial<Pick<AccordionSettings, keyof AccordionSettings>>): JQuery;
+        <K extends keyof APISettings | JQueryAjaxSettings>(behavior: 'setting', name: K, value?: undefined, ): Partial<Pick<APISettings, keyof APISettings>> | Partial<Pick<JQueryAjaxSettings, keyof JQueryAjaxSettings>>;
+        <K extends keyof APISettings>(behavior: 'setting', name: K, value: APISettings[K]): JQuery;
+        (behavior: 'setting', value: Partial<Pick<APISettings, keyof APISettings>> | Partial<Pick<JQueryAjaxSettings, keyof JQueryAjaxSettings>>): JQuery;
+        (settings?: Partial<Pick<APISettings, keyof APISettings>> | Partial<Pick<JQueryAjaxSettings, keyof JQueryAjaxSettings>>): JQuery;
     }
 
     /**

--- a/types/fomantic-ui-dropdown.d.ts
+++ b/types/fomantic-ui-dropdown.d.ts
@@ -265,7 +265,7 @@ declare namespace FomanticUI {
          * @see {@link https://fomantic-ui.com/behaviors/api.html#/settings}
          * @default false
          */
-        apiSettings: false | APISettings;
+        apiSettings: false | APISettings | JQueryAjaxSettings;
 
         /**
          * Whether dropdown should select new option when using keyboard shortcuts.

--- a/types/fomantic-ui-search.d.ts
+++ b/types/fomantic-ui-search.d.ts
@@ -124,7 +124,7 @@ declare namespace FomanticUI {
          * @see {@link https://fomantic-ui.com/behaviors/api.html#/settings}
          * @default {}
          */
-        apiSettings: APISettings;
+        apiSettings: APISettings | JQueryAjaxSettings;
 
         /**
          * Minimum characters to query for results.

--- a/types/fomantic-ui-tab.d.ts
+++ b/types/fomantic-ui-tab.d.ts
@@ -128,7 +128,7 @@ declare namespace FomanticUI {
          * @see {@link https://fomantic-ui.com/behaviors/api.html#/settings}
          * @default false
          */
-        apiSettings: false | FomanticUI.APISettings;
+        apiSettings: false | FomanticUI.APISettings | JQueryAjaxSettings;
 
         /**
          * Can be set to 'hash' or 'state'.


### PR DESCRIPTION
## Description
Following Fomantic's documentation, `apiSettings` can also accept a `JQueryAjaxSettings` object as parameter. So this PR enable correct type checking for modules that includes `apiSettings` as a parameter: `dropdown`, `search` and `tab`.

## Screenshot
Before:
![before](https://github.com/fomantic/Fomantic-UI/assets/7557689/8206663b-1b89-4c34-a0c4-9c4d152ce4d0)

After:
![after](https://github.com/fomantic/Fomantic-UI/assets/7557689/a356b0e9-8ee4-491e-aa50-6b30bd4e754d)

## Closes
#2840