### PR TITLE
fix(dropdown): remove clearable icon on disabeled or readonly

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -1186,7 +1186,7 @@ select.ui.dropdown {
     .ui.read-only.dropdown {
         > .remove.icon,
         > .label > .delete.icon {
-            display:none;
+            display: none;
         }
     }
 }

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -1181,6 +1181,16 @@ select.ui.dropdown {
     }
 }
 
+& when (@variationDropdownDisabled) or (@variationDropdownReadonly) {
+    .ui.disabled.dropdown,
+    .ui.read-only.dropdown {
+        > .remove.icon,
+        > .label > .delete.icon {
+            display:none;
+        }
+    }
+}
+
 /*******************************
            Variations
 *******************************/


### PR DESCRIPTION
## Description

A `disabled` or `read-only` dropdown used in combination with clearable or multiple labels still showed the remove/delete icon which could indicate to still being able to delete the related value

## Testcase
Remove CSS to issue
https://jsfiddle.net/lubber/18okh92g/5/

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/60163/256885933-f5d06456-c52a-4ed5-b16f-9b47d0e15ce6.png)

### After
![image](https://github.com/fomantic/Fomantic-UI/assets/18379884/3ef24d8d-a9cb-4987-93a7-4679eaeba494)

## Closes
#2862 
