### PR TITLE
feat(tab): add removable variation

### DIFF
--- a/src/definitions/modules/tab.js
+++ b/src/definitions/modules/tab.js
@@ -240,7 +240,7 @@
                             ;
                             module.removeTab(tabPath);
                             event.stopPropagation();
-                        }
+                        },
                     },
                     history: {
                         change: function (event) {
@@ -450,6 +450,7 @@
                         module.verbose('Call for tab removal', tabPath);
                         if (settings.onBeforeRemove.call(element, tabPath) === false) {
                             module.debug('onBeforeRemove returned false, cancelling tab removal', $tab);
+                            
                             return false;
                         }
                         var

--- a/src/definitions/modules/tab.js
+++ b/src/definitions/modules/tab.js
@@ -450,7 +450,7 @@
                         module.verbose('Call for tab removal', tabPath);
                         if (settings.onBeforeRemove.call(element, tabPath) === false) {
                             module.debug('onBeforeRemove returned false, cancelling tab removal', $tab);
-                            
+
                             return false;
                         }
                         var

--- a/src/definitions/modules/tab.less
+++ b/src/definitions/modules/tab.less
@@ -26,6 +26,24 @@
 }
 
 /*******************************
+              Types
+*******************************/
+
+/* --------------------
+       Closable
+--------------------- */
+
+& when (@variationTabRemove) {
+    .ui.menu .item > .remove.icon {
+        cursor: pointer;
+        font-size: @removeIconSize;
+        padding: @removeIconPadding;
+        opacity: @removeIconOpacity;
+        z-index: @removeIconZIndex;
+    }
+}
+
+/*******************************
              States
 *******************************/
 

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -714,6 +714,7 @@
 
 /* Tab */
 @variationTabLoading: true;
+@variationTabRemove: true;
 
 /* Toast */
 @variationToastInverted: true;

--- a/src/themes/default/modules/tab.variables
+++ b/src/themes/default/modules/tab.variables
@@ -9,3 +9,11 @@
 
 @loaderDistanceFromTop: 50%;
 @loaderSize: 2.5em;
+
+/* Removable */
+
+@removeIconSize: @relative12px;
+@removeIconPosition: 2em;
+@removeIconOpacity: 0.6;
+@removeIconPadding: 0 0 0 1em;
+@removeIconZIndex: 3;


### PR DESCRIPTION
## Description
This PR add the ability to remove a tab by clicking on an icon or programmaticaly. It works by adding the `removable` class to the desired tab headers or setting `removable: true` on initialization. Two new callbacks are implemented: `onRemove(tabPath)` when the tab is removed, and `onBeforeRemove(tabPath)`, which allow cancelling the removal of the table by returning `false`. When removing a tab, it will move to the closest which is not disabled.

For now i'll mark it as WIP, since there's some tests to do on nested tabs, and decide what to do if all tabs are closed.

## Screenshot
![image](https://github.com/fomantic/Fomantic-UI/assets/7557689/27a89205-f4d6-4405-b7e3-2dca966e6149)

## Closes
#2521
