### PR TITLE
fix(slider): max value had js floating point issues

### DIFF
--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -674,7 +674,8 @@
                         var
                             step = module.get.step(),
                             min = module.get.min(),
-                            quotient = step === 0 ? 0 : Math.floor((settings.max - min) / step),
+                            precision = module.get.precision(),
+                            quotient = step === 0 ? 0 : Math.floor(Math.round((settings.max - min) / step * precision) / precision),
                             remainder = step === 0 ? 0 : (settings.max - min) % step
                         ;
 
@@ -684,7 +685,9 @@
                         return settings.step;
                     },
                     numLabels: function () {
-                        var value = Math.round((module.get.max() - module.get.min()) / (module.get.step() === 0 ? 1 : module.get.step()));
+                        var step = module.get.step(),
+                            precision = module.get.precision(),
+                            value = Math.round((module.get.max() - module.get.min()) / (step === 0 ? 1 : step) * precision) / precision;
                         module.debug('Determined that there should be ' + value + ' labels');
 
                         return value;
@@ -699,7 +702,8 @@
 
                         switch (settings.labelType) {
                             case settings.labelTypes.number: {
-                                return Math.round(((value * (module.get.step() === 0 ? 1 : module.get.step())) + module.get.min()) * precision) / precision;
+                                var step = module.get.step();
+                                return Math.round(((value * (step === 0 ? 1 : step)) + module.get.min()) * precision) / precision;
                             }
                             case settings.labelTypes.letter: {
                                 return alphabet[value % 26];

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -675,7 +675,7 @@
                             step = module.get.step(),
                             min = module.get.min(),
                             precision = module.get.precision(),
-                            quotient = step === 0 ? 0 : Math.floor(Math.round((settings.max - min) / step * precision) / precision),
+                            quotient = step === 0 ? 0 : Math.floor(Math.round(((settings.max - min) / step) * precision) / precision),
                             remainder = step === 0 ? 0 : (settings.max - min) % step
                         ;
 
@@ -687,7 +687,7 @@
                     numLabels: function () {
                         var step = module.get.step(),
                             precision = module.get.precision(),
-                            value = Math.round((module.get.max() - module.get.min()) / (step === 0 ? 1 : step) * precision) / precision;
+                            value = Math.round(((module.get.max() - module.get.min()) / (step === 0 ? 1 : step)) * precision) / precision;
                         module.debug('Determined that there should be ' + value + ' labels');
 
                         return value;
@@ -703,6 +703,7 @@
                         switch (settings.labelType) {
                             case settings.labelTypes.number: {
                                 var step = module.get.step();
+
                                 return Math.round(((value * (step === 0 ? 1 : step)) + module.get.min()) * precision) / precision;
                             }
                             case settings.labelTypes.letter: {


### PR DESCRIPTION
## Description
Sometimes a calculation of max value or number of labels went into JS floating point issues why dividing

## Testcase

### Wrong Result
Max value is determined as 0.92999999 instead of 0.94
https://jsfiddle.net/4robkn7u/1/

### Fixed
Max value is 0.94 as expected
https://jsfiddle.net/lubber/qbs3cn9e/1/

## Closes
#2877