### PR TITLE
feat(site): separate variable for whole google Font url

### DIFF
--- a/src/theme.less
+++ b/src/theme.less
@@ -63,7 +63,7 @@
 
 .loadFonts() {
     & when (@importGoogleFonts) {
-        @import (css) url("@{googleProtocol}fonts.googleapis.com/css2?family=@{googleFontRequest}");
+        @import (css) url("@{googleFontUrl}");
     }
     & when (@importFonts) and not (@fontName = "") {
         each(@fonts, {

--- a/src/themes/default/globals/site.variables
+++ b/src/themes/default/globals/site.variables
@@ -124,6 +124,7 @@
 
 @googleProtocol: "https://";
 @googleFontRequest: "@{googleFontName}:@{googleFontSizes}&subset=@{googleSubset}&display=@{googleFontDisplay}";
+@googleFontUrl: "@{googleProtocol}fonts.googleapis.com/css2?family=@{googleFontRequest}";
 
 @bold: bold;
 @normal: normal;

--- a/src/themes/default/globals/site.variables
+++ b/src/themes/default/globals/site.variables
@@ -123,7 +123,8 @@
 @googleFontDisplay: "swap";
 
 @googleProtocol: "https://";
-@googleFontRequest: "@{googleFontName}:@{googleFontSizes}&subset=@{googleSubset}&display=@{googleFontDisplay}";
+@googleFonts: "@{googleFontName}:@{googleFontSizes}";
+@googleFontRequest: "@{googleFonts}&subset=@{googleSubset}&display=@{googleFontDisplay}";
 @googleFontUrl: "@{googleProtocol}fonts.googleapis.com/css2?family=@{googleFontRequest}";
 
 @bold: bold;


### PR DESCRIPTION
## Description

This PR simplifies a possible need to import multiple google fonts, so one only needs to change 1 variable `@googleFonts`
I also put the import url into a separate variable to even the whole url could be changed by only one variable

The change is completely backward compatible

## Testcase
This only variable change inside a custom theme will import 3 fonts
```less
@googleFonts: "Tangerine|Inconsolata:italic|Droid+Sans:bold";
```
and, by keeping every other variable as default, would result in
```css
@import url("https://fonts.googleapis.com/css2?family=Tangerine|Inconsolata:italic|Droid+Sans:bold&subset=latin&display=swap");
```

## Closes
#2892 