### PR TITLE
fix(formvalidation): no error for missing field on autocheck

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -619,7 +619,7 @@
                         // refresh selector cache
                         (instance || module).refresh();
                     },
-                    field: function (identifier, strict) {
+                    field: function (identifier, strict, ignoreMissing) {
                         module.verbose('Finding field with identifier', identifier);
                         identifier = module.escape.string(identifier);
                         var t;
@@ -639,7 +639,9 @@
                         if (t.length > 0) {
                             return t;
                         }
-                        module.error(error.noField.replace('{identifier}', identifier));
+                        if (!ignoreMissing) {
+                            module.error(error.noField.replace('{identifier}', identifier));
+                        }
 
                         return strict ? $() : $('<input/>');
                     },
@@ -817,10 +819,10 @@
 
                 has: {
 
-                    field: function (identifier) {
+                    field: function (identifier, ignoreMissing) {
                         module.verbose('Checking for existence of a field with identifier', identifier);
 
-                        return module.get.field(identifier, true).length > 0;
+                        return module.get.field(identifier, true, ignoreMissing).length > 0;
                     },
 
                 },
@@ -1221,7 +1223,7 @@
                         module.debug('Enabling auto check on required fields');
                         if (validation) {
                             $.each(validation, function (fieldName) {
-                                if (!module.has.field(fieldName)) {
+                                if (!module.has.field(fieldName, true)) {
                                     module.verbose('Field not found, removing from validation', fieldName);
                                     module.remove.field(fieldName);
                                 }

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1022,7 +1022,7 @@
                         }
                         if (rule === undefined) {
                             module.debug('Removed all rules');
-                            if (module.has.field(field)) {
+                            if (module.has.field(field, true)) {
                                 validation[field].rules = [];
                             } else {
                                 delete validation[field];

--- a/types/fomantic-ui-form.d.ts
+++ b/types/fomantic-ui-form.d.ts
@@ -51,7 +51,7 @@ declare namespace FomanticUI {
         /**
          * Returns element with matching name, id, or data-validate metadata to identifier.
          */
-        (behavior: 'get field', identifier: string, strict?: boolean | undefined, ignoreMissing?: boolean | undefined): string;
+        (behavior: 'get field', identifier: string, strict?: boolean, ignoreMissing?: boolean): string;
 
         /**
          * Returns value of element with id.
@@ -82,7 +82,7 @@ declare namespace FomanticUI {
         /**
          * Returns whether a field exists.
          */
-        (behavior: 'has field', identifier: string, ignoreMissing?: boolean | undefined): boolean;
+        (behavior: 'has field', identifier: string, ignoreMissing?: boolean): boolean;
 
         /**
          * Manually add errors to form, given an array errors.

--- a/types/fomantic-ui-form.d.ts
+++ b/types/fomantic-ui-form.d.ts
@@ -51,7 +51,7 @@ declare namespace FomanticUI {
         /**
          * Returns element with matching name, id, or data-validate metadata to identifier.
          */
-        (behavior: 'get field', identifier: string): string;
+        (behavior: 'get field', identifier: string, strict?: boolean | undefined, ignoreMissing?: boolean | undefined): string;
 
         /**
          * Returns value of element with id.
@@ -82,7 +82,7 @@ declare namespace FomanticUI {
         /**
          * Returns whether a field exists.
          */
-        (behavior: 'has field', identifier: string): boolean;
+        (behavior: 'has field', identifier: string, ignoreMissing?: boolean | undefined): boolean;
 
         /**
          * Manually add errors to form, given an array errors.
@@ -227,7 +227,7 @@ declare namespace FomanticUI {
         errorFocus: boolean | string;
 
         /**
-         * 
+         *
          * @default 0
          */
         errorLimit: number;
@@ -373,7 +373,7 @@ declare namespace FomanticUI {
                  */
                 leavingMessage: string;
             }
-        
+
             interface Prompts {
                 /**
                  * @default '{name} must have a value'
@@ -500,7 +500,7 @@ declare namespace FomanticUI {
                  */
                 maxCount: string;
             }
-        
+
             interface Formatters {
                 date(date: string): string;
                 datetime(date: string): string;


### PR DESCRIPTION
## Description

A followup on #2633 
As we centralised the field getter, the error message of a non existing field will occur all the time, even in situations where we definately want to remove field related validation rules if a field is non existing anymore and are aware of that.

## Testcase

### Broken
- Remove  the second field via red button
- Console shows 2 errors about the field not being existent
- submit form via blue button -> error occurs again
https://jsfiddle.net/fgw1bqr0/3/

### Fixed
All fine, no errors
https://jsfiddle.net/lubber/3725m4o1/1/

## Closes
https://github.com/fomantic/Fomantic-UI/issues/2577#issuecomment-1712101637
