### PR TITLE
fix(dropdown): create label before changing value as in 2.8.8

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -2806,8 +2806,8 @@
                                             module.save.remoteData(selectedText, selectedValue);
                                         }
                                         if (settings.useLabels) {
-                                            module.add.value(selectedValue, selectedText, $selected, preventChangeTrigger);
                                             module.add.label(selectedValue, selectedText, shouldAnimate);
+                                            module.add.value(selectedValue, selectedText, $selected, preventChangeTrigger);
                                             module.set.activeItem($selected);
                                             module.filterActive();
                                             module.select.nextAvailable($selectedItem);


### PR DESCRIPTION
## Description
This PR reverts the order change of add.value and add.label introduced in #1854
There was no reason doing so.

But this change now had an impact when trying to access the labels inside the onchange callback as the (new) labels are now not available yet when onChange is called (as it was unil 2.8.8) 


## Testcase
- Open console
- Select another language from the dropdown
### Broken
-> The new one is not logged
https://jsfiddle.net/gtoniolo/w3850tfn/1/

### Fixed
- The new one is logged
https://jsfiddle.net/lubber/5r0dv9ha/


## Closes
#2902 