### PR TITLE
feat(header): seamless attached variant

### DIFF
--- a/src/definitions/elements/header.less
+++ b/src/definitions/elements/header.less
@@ -467,6 +467,11 @@
     .ui.bottom.attached.header {
         border-radius: 0 0 @attachedBorderRadius @attachedBorderRadius;
     }
+    & when (@variationHeaderSeamless) {
+        .ui.seamless.attached.header {
+            border-bottom: none;
+        }
+    }
 
     /* Attached Sizes */
     .ui.attached.header:not(h1):not(h2):not(h3):not(h4):not(h5):not(h6) {

--- a/src/definitions/elements/header.less
+++ b/src/definitions/elements/header.less
@@ -468,7 +468,7 @@
         border-radius: 0 0 @attachedBorderRadius @attachedBorderRadius;
     }
     & when (@variationHeaderSeamless) {
-        .ui.seamless.attached.header {
+        .ui.seamless.attached:not(.bottom).header {
             border-bottom: none;
         }
     }

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -82,6 +82,7 @@
 @variationHeaderDividing: true;
 @variationHeaderBlock: true;
 @variationHeaderAttached: true;
+@variationHeaderSeamless: true;
 @variationHeaderTags: h1, h2, h3, h4, h5, h6;
 @variationHeaderSizes: @variationAllSizes;
 @variationHeaderColors: @variationAllColors;


### PR DESCRIPTION
## Description
The attached header doesn't support the seamless variant like the segment element which results in showing the border between the header and the attached element below.

This PR allows to have the attached header element with seamless variant that allows to remove the bottom border when it attaches with the another segment below.

## Testcase
**Before:** https://jsfiddle.net/jkszwbxe/

**After:** https://jsfiddle.net/ko2in/yoafg8mx/1/

## Screenshot

**Before:**
![seamless-attached-header-not-supported](https://github.com/fomantic/Fomantic-UI/assets/930315/4df47abf-7014-4d64-b032-fb24b2bd088c)

**After:**
![seamless-attached-header-supported](https://github.com/fomantic/Fomantic-UI/assets/930315/e2cf6aec-e919-4f7c-be8d-54418abd6538)

## Closes
#2874
