### PR TITLE
feat(form, input): support textarea with action button

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -441,7 +441,8 @@
         input[type="text"]:focus,
         input[type="file"]:focus,
         input[type="url"]:focus,
-        input[type="week"]:focus {
+        input[type="week"]:focus,
+        textarea:focus {
             border-top-right-radius: 0;
             border-bottom-right-radius: 0;
         }
@@ -462,7 +463,8 @@
         input[type="text"],
         input[type="file"],
         input[type="url"],
-        input[type="week"] {
+        input[type="week"],
+        textarea {
             border-bottom-left-radius: 0;
             border-top-left-radius: 0;
         }

--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -299,7 +299,7 @@
 .ui.form .fields .field .ui.input textarea,
 .ui.form .field .ui.input input,
 .ui.form .field .ui.input textarea {
-    width: auto;
+    width: 100%;
 }
 
 & when (@variationFormEqualWidth) or (@variationFormWide) {

--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -162,6 +162,11 @@
     font-family: @inputFont;
     line-height: @textAreaLineHeight;
     resize: @textAreaResize;
+    min-height: @actionTextareaMinHeight;
+}
+.ui.input > textarea {
+    flex: 1 0 auto;
+    max-width: 100%;
 }
 .ui.form textarea:not([rows]) {
     height: @textAreaHeight;
@@ -291,7 +296,9 @@
 
 /* Auto Input */
 .ui.form .fields .field .ui.input input,
-.ui.form .field .ui.input input {
+.ui.form .fields .field .ui.input textarea,
+.ui.form .field .ui.input input,
+.ui.form .field .ui.input textarea {
     width: auto;
 }
 

--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -165,7 +165,7 @@
     min-height: @actionTextareaMinHeight;
 }
 .ui.input > textarea {
-    flex: 1 0 auto;
+    flex: 1 1 auto;
     max-width: 100%;
 }
 .ui.form textarea:not([rows]) {

--- a/src/definitions/elements/input.less
+++ b/src/definitions/elements/input.less
@@ -524,7 +524,11 @@
         .ui.form .field.@{state} > .ui.action.input:not([class*="left action"]) > input + .ui.button,
         .ui.form .field.@{state} > .ui.right.labeled.input:not([class*="corner labeled"]) > input + .ui.label,
         .ui.action.input.@{state}:not([class*="left action"]) > input + .ui.button,
-        .ui.right.labeled.input.@{state}:not([class*="corner labeled"]) > input + .ui.label {
+        .ui.right.labeled.input.@{state}:not([class*="corner labeled"]) > input + .ui.label,
+        .ui.form .field.@{state} > .ui.action.input:not([class*="left action"]) > textarea + .ui.button,
+        .ui.form .field.@{state} > .ui.right.labeled.input:not([class*="corner labeled"]) > textarea + .ui.label,
+        .ui.action.input.@{state}:not([class*="left action"]) > textarea + .ui.button,
+        .ui.right.labeled.input.@{state}:not([class*="corner labeled"]) > textarea + .ui.label {
             border-right: @borderWidth solid @borderColor;
         }
         .ui.form .field.@{state} > .ui.right.labeled.input:not([class*="corner labeled"]) > .ui.label:first-child,
@@ -553,14 +557,16 @@
     }
 
     /* Input when ui Left */
-    .ui[class*="left action"].input > input {
+    .ui[class*="left action"].input > input, 
+    .ui[class*="left action"].input > textarea {
         border-top-left-radius: 0;
         border-bottom-left-radius: 0;
         border-left-color: transparent;
     }
 
     /* Input when ui Right */
-    .ui.action.input:not([class*="left action"]) > input {
+    .ui.action.input:not([class*="left action"]) > input, 
+    .ui.action.input:not([class*="left action"]) > textarea {
         border-top-right-radius: 0;
         border-bottom-right-radius: 0;
         border-right-color: transparent;
@@ -584,11 +590,13 @@
     }
 
     /* Input Focus */
-    .ui.action.input:not([class*="left action"]) > input:focus {
+    .ui.action.input:not([class*="left action"]) > input:focus,
+    .ui.action.input:not([class*="left action"]) > textarea:focus {
         border-right-color: @focusBorderColor;
     }
 
-    .ui.ui[class*="left action"].input > input:focus {
+    .ui.ui[class*="left action"].input > input:focus,
+    .ui.ui[class*="left action"].input > textarea:focus {
         border-left-color: @focusBorderColor;
     }
 }

--- a/src/definitions/elements/input.less
+++ b/src/definitions/elements/input.less
@@ -557,7 +557,7 @@
     }
 
     /* Input when ui Left */
-    .ui[class*="left action"].input > input, 
+    .ui[class*="left action"].input > input,
     .ui[class*="left action"].input > textarea {
         border-top-left-radius: 0;
         border-bottom-left-radius: 0;
@@ -565,7 +565,7 @@
     }
 
     /* Input when ui Right */
-    .ui.action.input:not([class*="left action"]) > input, 
+    .ui.action.input:not([class*="left action"]) > input,
     .ui.action.input:not([class*="left action"]) > textarea {
         border-top-right-radius: 0;
         border-bottom-right-radius: 0;

--- a/src/definitions/elements/input.less
+++ b/src/definitions/elements/input.less
@@ -35,7 +35,7 @@
 .ui.input > input {
     margin: 0;
     max-width: 100%;
-    flex: 1 0 auto;
+    flex: 1 1 auto;
     outline: none;
     -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
     text-align: @textAlign;

--- a/src/themes/default/collections/form.variables
+++ b/src/themes/default/collections/form.variables
@@ -60,7 +60,7 @@
 @textAreaBorder: @inputBorder;
 @textAreaFontSize: @inputFontSize;
 @textAreaTransition: @inputTransition;
-@actionTextareaMinHeight: (@inputVerticalPadding * 2) + @inputLineHeight;
+@actionTextareaMinHeight: (@inputVerticalPadding * 2) + @lineHeight;
 
 /* Checkbox */
 @checkboxVerticalAlign: top;

--- a/src/themes/default/collections/form.variables
+++ b/src/themes/default/collections/form.variables
@@ -60,6 +60,7 @@
 @textAreaBorder: @inputBorder;
 @textAreaFontSize: @inputFontSize;
 @textAreaTransition: @inputTransition;
+@actionTextareaMinHeight: (@inputVerticalPadding * 2) + @inputLineHeight;
 
 /* Checkbox */
 @checkboxVerticalAlign: top;


### PR DESCRIPTION
## Description
Supports textarea in the action input to display like the input field and the button stacked together.

## Testcase
**Before:** https://jsfiddle.net/vhfrb2qt/1/

**After:** https://jsfiddle.net/ko2in/5aco9q8m/

## Screenshot
### Before
![textarea-before](https://github.com/fomantic/Fomantic-UI/assets/930315/30cee39f-8207-4d51-a6e7-8db194868c06)

### After
![textarea-after](https://github.com/fomantic/Fomantic-UI/assets/930315/878c2728-e1a7-45dd-bcdb-8ab72e341f3b)


## Closes
#2814 
