### PR TITLE
fix(types): better declaration files

### DIFF
--- a/types/fomantic-ui-api.d.ts
+++ b/types/fomantic-ui-api.d.ts
@@ -143,7 +143,7 @@ declare namespace FomanticUI {
          * UI state will be applied to this element, defaults to triggering element.
          * @default false
          */
-        stateContext: false | string | JQuery;
+        stateContext: false | string | JQuery<any>;
 
         /**
          * Whether to encode parameters with 'encodeURIComponent' before adding into url string.

--- a/types/fomantic-ui-api.d.ts
+++ b/types/fomantic-ui-api.d.ts
@@ -126,6 +126,12 @@ declare namespace FomanticUI {
         on: string;
 
         /**
+         * Object containing all templates endpoints
+         * @default {}
+         */
+        api: {[key: string]: string};
+
+        /**
          * Can be set to 'local' to cache successful returned AJAX responses when using a JSON API.
          * This helps avoid server roundtrips when API endpoints will return the same results when accessed repeatedly.
          * Setting to 'false', will add cache busting parameters to the URL.
@@ -137,7 +143,7 @@ declare namespace FomanticUI {
          * UI state will be applied to this element, defaults to triggering element.
          * @default false
          */
-        stateContext: false | JQuery;
+        stateContext: false | string | JQuery;
 
         /**
          * Whether to encode parameters with 'encodeURIComponent' before adding into url string.
@@ -259,7 +265,7 @@ declare namespace FomanticUI {
          * Method for transmitting request to server.
          * @default 'get'
          */
-        method: 'get' | 'post' | 'put' | 'delete' | 'head' | 'options' | 'patch';
+        method: Uppercase<'get' | 'post' | 'put' | 'delete' | 'head' | 'options' | 'patch'> | Lowercase<'get' | 'post' | 'put' | 'delete' | 'head' | 'options' | 'patch'>;
 
         /**
          * Expected data type of response.

--- a/types/fomantic-ui-calendar.d.ts
+++ b/types/fomantic-ui-calendar.d.ts
@@ -37,7 +37,7 @@ declare namespace FomanticUI {
          * Pass false to updateInput to disable updating the input.
          * Pass false to fireChange to disable the onBeforeChange and onChange callbacks for this change
          */
-        (behavior: 'set date', date: string, updateInput: boolean, fireChange: boolean): JQuery;
+        (behavior: 'set date', date: Date | string | null, updateInput?: boolean, fireChange?: boolean): JQuery;
 
         /**
          * Get the current selection mode (year, month, day, hour, minute)
@@ -82,12 +82,12 @@ declare namespace FomanticUI {
         /**
          * Set the minimal selectable date
          */
-        (behavior: 'set minDate', date: Date | string): JQuery;
+        (behavior: 'set minDate', date: Date | string | null): JQuery;
 
         /**
          * Set the maximal selectable date
          */
-        (behavior: 'set maxDate', date: Date | string): JQuery;
+        (behavior: 'set maxDate', date: Date | string | null): JQuery;
 
         (behavior: 'destroy'): JQuery;
 
@@ -214,7 +214,7 @@ declare namespace FomanticUI {
          *
          * @default null
          */
-        initialDate: null | Date;
+        initialDate: Date | string | null;
 
         /**
          * Display mode to start in, can be 'year', 'month', 'day', 'hour', 'minute' (false = 'day').
@@ -319,11 +319,13 @@ declare namespace FomanticUI {
          *
          * @default false
          */
-        selectAdjacentDays: 5 | 10 | 15 | 20 | 30;
+        selectAdjacentDays: boolean;
 
         popupOptions: Calendar.PopupSettings;
 
         text: Calendar.TextSettings;
+
+        formatter: Calendar.FormatterSettings;
 
         // endregion
 
@@ -333,12 +335,12 @@ declare namespace FomanticUI {
          * Is called before a calendar date changes. 'return false;' will cancel the change.
          * @since 2.8.0
          */
-        onBeforeChange(this: JQuery): void;
+        onBeforeChange(this: JQuery, date?: Date, text?: string, mode?: string): void;
 
         /**
          * Is called after a calendar date has changed.
          */
-        onChange(this: JQuery): void;
+        onChange(this: JQuery, date?: Date): void;
 
         /**
          * Is called before a calendar is shown. 'return false;' will prevent the calendar to be shown.
@@ -364,7 +366,7 @@ declare namespace FomanticUI {
          * Is called when a cell of the calendar is selected providing its value and current mode.
          * 'return false;' will prevent the selection.
          */
-        onSelect(this: JQuery, date: Date, mode: string): void;
+        onSelect(this: JQuery, date?: Date, mode?: string): void;
 
         // endregion
 
@@ -436,6 +438,7 @@ declare namespace FomanticUI {
     namespace Calendar {
         type PopupSettings = Partial<Pick<Settings.Popup, keyof Settings.Popup>>;
         type TextSettings = Partial<Pick<Settings.Texts, keyof Settings.Texts>>;
+        type FormatterSettings = Partial<Pick<Settings.Formatters, keyof Settings.Formatters>>;
         type SelectorSettings = Partial<Pick<Settings.Selectors, keyof Settings.Selectors>>;
         type ClassNameSettings = Partial<Pick<Settings.ClassNames, keyof Settings.ClassNames>>;
         type RegExpSettings = Partial<Pick<Settings.RegExps, keyof Settings.RegExps>>;
@@ -472,6 +475,16 @@ declare namespace FomanticUI {
                 days: string[];
 
                 /**
+                 * @default ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+                 */
+                dayNamesShort: string[];
+
+                /**
+                 * @default ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+                 */
+                dayNames: string[];
+
+                /**
                  * @default ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
                  */
                 months: string[];
@@ -505,6 +518,78 @@ declare namespace FomanticUI {
                  * @default 'Week'
                  */
                 weekNo: string;
+            }
+
+            interface Formatters {
+                /**
+                 * 
+                 */
+                yearHeader(date: Date, settings?: CalendarSettings): string;
+
+                /**
+                 * @default 'YYYY'
+                 */
+                monthHeader: string;
+
+                /**
+                 * @default 'MMMM YYYY'
+                 */
+                dayHeader: string;
+
+                /**
+                 * @default 'MMMM D, YYYY'
+                 */
+                hourHeader: string;
+
+                /**
+                 * @default 'MMMM D, YYYY'
+                 */
+                minuteHeader: string;
+
+                /**
+                 * @default 'MMMM D, YYYY'
+                 */
+                dayColumnHeader(day: number, settings: CalendarSettings): string;
+
+                /**
+                 * @default 'MMMM D, YYYY h:mm A'
+                 */
+                datetime: string;
+
+                /**
+                 * @default 'MMMM D, YYYY'
+                 */
+                date: string;
+
+                /**
+                 * @default 'h:mm A'
+                 */
+                time: string;
+
+                /**
+                 * @default 'h:mm A'
+                 */
+                cellTime: string;
+
+                /**
+                 * @default 'MMMM YYYY'
+                 */
+                month: string;
+
+                /**
+                 * @default 'YYYY'
+                 */
+                year: string;
+                
+                /**
+                 * 
+                 */
+                today(settings: CalendarSettings): string;
+
+                /**
+                 * 
+                 */
+                cell(cell: string, date: Date, cellOptions: any): any
             }
 
             interface Selectors {

--- a/types/fomantic-ui-checkbox.d.ts
+++ b/types/fomantic-ui-checkbox.d.ts
@@ -33,6 +33,11 @@ declare namespace FomanticUI {
         (behavior: 'enable'): JQuery;
 
         /**
+         * Disable interaction with a checkbox.
+         */
+        (behavior: 'disable'): JQuery;
+
+        /**
          * Set a checkbox state to checked without callbacks.
          */
         (behavior: 'set checked'): JQuery;
@@ -81,6 +86,11 @@ declare namespace FomanticUI {
          * Returns whether element is not checked.
          */
         (behavior: 'is unchecked'): boolean;
+
+        /**
+         * Returns whether element is not determinate.
+         */
+        (behavior: 'is indeterminate'): boolean;
 
         /**
          * Returns whether element is able to be changed.
@@ -175,22 +185,22 @@ declare namespace FomanticUI {
         /**
          * Callback before a checkbox is checked. Can cancel change by returning 'false'.
          */
-        beforeChecked(this: JQuery): void | false;
+        beforeChecked(this: JQuery): void | Promise<void> | boolean;
 
         /**
          * Callback before a checkbox is set to indeterminate. Can cancel change by returning 'false'.
          */
-        beforeIndeterminate(this: JQuery): void | false;
+        beforeIndeterminate(this: JQuery): void | Promise<void> | false;
 
         /**
          * Callback before a checkbox is set to determinate. Can cancel change by returning 'false'.
          */
-        beforeDeterminate(this: JQuery): void | false;
+        beforeDeterminate(this: JQuery): void | Promise<void> | false;
 
         /**
          * Callback before a checkbox is unchecked. Can cancel change by returning 'false'.
          */
-        beforeUnchecked(this: JQuery): void | false;
+        beforeUnchecked(this: JQuery): void | Promise<void> | false;
 
         /**
          * Callback after a checkbox is enabled.

--- a/types/fomantic-ui-dropdown.d.ts
+++ b/types/fomantic-ui-dropdown.d.ts
@@ -6,7 +6,7 @@ declare namespace FomanticUI {
          * Recreates dropdown menu from passed values.
          * values should be an object with the following structure: { values: [ {value, text, name} ] }.
          */
-        (behavior: 'setup menu', values: object): void;
+        (behavior: 'setup menu', values: object): JQuery;
 
         /**
          * Changes dropdown to use new values.
@@ -17,7 +17,7 @@ declare namespace FomanticUI {
         /**
          * Refreshes all cached selectors and data
          */
-        (behavior: 'refresh'): void;
+        (behavior: 'refresh'): JQuery;
 
         /**
          * Toggles current visibility of dropdown
@@ -29,20 +29,20 @@ declare namespace FomanticUI {
          * If a function is provided to callback, it's called after the dropdown-menu is shown.
          * Set preventFocus to true if you don't want the dropdown field to focus after the menu is shown
          */
-        (behavior: 'show', callback: Function, preventFocus: boolean): void;
+        (behavior: 'show', callback?: Function, preventFocus?: boolean): void;
 
         /**
          * Hides dropdown.
          * If a function is provided to callback, it's called after the dropdown-menu is hidden.
          * Set preventBlur to true if you don't want the dropdown field to blur after the menu is hidden
          */
-        (behavior: 'hide', callback:Function, preventBlur: boolean): void;
+        (behavior: 'hide', callback?: Function, preventBlur?: boolean): void;
 
         /**
          * Clears dropdown of selection.
          * Set preventChangeTrigger to true to omit the change event (default: false).
          */
-        (behavior: 'clear', preventChangeTrigger: boolean): void;
+        (behavior: 'clear', preventChangeTrigger?: boolean): JQuery;
 
         /**
          * Hides all other dropdowns that is not current dropdown
@@ -53,7 +53,7 @@ declare namespace FomanticUI {
          * Restores dropdown text and value to its value on page load.
          * Set preventChangeTrigger to true to omit the change event (default: false).
          */
-        (behavior: 'restore defaults', preventChangeTrigger: boolean): void;
+        (behavior: 'restore defaults', preventChangeTrigger?: boolean): void;
 
         /**
          * Restores dropdown text to its value on page load
@@ -79,7 +79,7 @@ declare namespace FomanticUI {
          * Sets value as selected.
          * Set preventChangeTrigger to true to omit the change event (default: false).
          */
-        (behavior: 'set selected', value: string, preventChangeTrigger: boolean): void;
+        (behavior: 'set selected', value: string | string[], preventChangeTrigger?: boolean, keepSearchTerm?: boolean): JQuery;
 
         /**
          * Remove value from selected
@@ -87,25 +87,20 @@ declare namespace FomanticUI {
         (behavior: 'remove selected', value: string): void;
 
         /**
-         * Adds a group of values as selected
-         */
-        (behavior: 'set selected', values: string[]): void;
-
-        /**
          * Sets selected values to exactly specified values, removing current selection
          */
-        (behavior: 'set exactly', values: string[]): void;
+        (behavior: 'set exactly', values: string[]): JQuery;
 
         /**
          * Sets dropdown text to a value
          */
-        (behavior: 'text', text: string): void;
+        (behavior: 'set text', text: string): JQuery;
 
         /**
          * Sets dropdown input to value (does not update display state).
          * Set preventChangeTrigger to true to omit the change event (default: false).
          */
-        (behavior: 'set value', value: string, preventChangeTrigger: boolean): void;
+        (behavior: 'set value', value: string, preventChangeTrigger?: boolean): JQuery;
 
         /**
          * Returns current dropdown text
@@ -265,7 +260,7 @@ declare namespace FomanticUI {
          * @see {@link https://fomantic-ui.com/behaviors/api.html#/settings}
          * @default false
          */
-        apiSettings: false | APISettings | JQueryAjaxSettings;
+        apiSettings: false | Partial<Pick<APISettings, keyof APISettings>> | Partial<Pick<JQueryAjaxSettings, keyof JQueryAjaxSettings>>;
 
         /**
          * Whether dropdown should select new option when using keyboard shortcuts.
@@ -506,7 +501,7 @@ declare namespace FomanticUI {
          * Is called after a dropdown value changes.
          * Receives the name and value of selection and the active menu element.
          */
-        onChange(value: string, text: string, $choice: JQuery): void;
+        onChange(value?: string, text?: string, $choice?: JQuery): void;
 
         /**
          * Is called after a dropdown selection is added using a multiple select dropdown, only receives the added value.

--- a/types/fomantic-ui-flyout.d.ts
+++ b/types/fomantic-ui-flyout.d.ts
@@ -48,6 +48,11 @@ declare namespace FomanticUI {
          */
         (behavior: 'get settings'): FlyoutSettings;
 
+        /**
+         * Templates handling
+         */
+        (behavior: keyof Flyout.TemplatesSettings, ...args: any): Partial<Pick<FlyoutSettings, keyof FlyoutSettings>>;
+
         (behavior: 'destroy'): JQuery;
         <K extends keyof FlyoutSettings>(behavior: 'setting', name: K, value?: undefined, ): Partial<Pick<FlyoutSettings, keyof FlyoutSettings>>;
         <K extends keyof FlyoutSettings>(behavior: 'setting', name: K, value: FlyoutSettings[K]): JQuery;
@@ -145,43 +150,43 @@ declare namespace FomanticUI {
          * Content of the flyout header.
          * @default ''
          */
-        title: boolean;
+        title: string;
 
         /**
          * Content of the flyout content.
          * @default ''
          */
-        content: boolean;
+        content: string;
 
         /**
          * Can hold a string to be added to the flyout class to control its appearance.
          * @default ''
          */
-        class: boolean;
+        class: string;
 
         /**
          * Can hold a string to be added to the title class to control its appearance.
          * @default ''
          */
-        classTitle: boolean;
+        classTitle: string;
 
         /**
          * Can hold a string to be added to the content class to control its appearance.
          * @default ''
          */
-        classContent: boolean;
+        classContent: string;
 
         /**
          * Can hold a string to be added to the actions class to control its appearance.
          * @default ''
          */
-        classActions: boolean;
+        classActions: string;
 
         /**
          * Can hold a string to be added to the actions class to control its appearance.
          * @default false
          */
-        closeIcon: boolean;
+        closeIcon: boolean | string;
 
         /**
          * An array of objects. Each object defines an action with properties `text`, `class`, `icon` and `click`.
@@ -261,6 +266,8 @@ declare namespace FomanticUI {
 
         // region Config Template Settings
 
+        templates: Flyout.TemplatesSettings;
+
         // endregion
 
         // region Debug Settings
@@ -311,6 +318,7 @@ declare namespace FomanticUI {
         type ClassNameSettings = Partial<Pick<Settings.ClassNames, keyof Settings.ClassNames>>;
         type RegExpSettings = Partial<Pick<Settings.RegExps, keyof Settings.RegExps>>;
         type ErrorSettings = Partial<Pick<Settings.Errors, keyof Settings.Errors>>;
+        type TemplatesSettings = Partial<Pick<Settings.Templates, keyof Settings.Templates>> & {[key: string]: (...args: any) => Partial<Pick<FlyoutSettings, keyof FlyoutSettings>>};
 
         namespace Settings {
             interface Selectors {
@@ -519,6 +527,12 @@ declare namespace FomanticUI {
                  * @default 'There were no elements that matched the specified selector'
                  */
                 notFound: string;
+            }
+
+            interface Templates {
+                alert(): Partial<Pick<FlyoutSettings, keyof FlyoutSettings>>;
+                confirm(): Partial<Pick<FlyoutSettings, keyof FlyoutSettings>>;
+                prompt(): Partial<Pick<FlyoutSettings, keyof FlyoutSettings>>;
             }
         }
     }

--- a/types/fomantic-ui-form.d.ts
+++ b/types/fomantic-ui-form.d.ts
@@ -310,12 +310,12 @@ declare namespace FomanticUI {
         /**
          * Callback if a form is all valid.
          */
-        onSuccess(this: JQuery, event: Event, fields: object[]): void;
+        onSuccess(this: JQuery, event: Event, fields: {[key: string]: any}): void;
 
         /**
          * Callback if any form field is invalid.
          */
-        onFailure(this: JQuery, formErrors: object[], fields: object[]): void;
+        onFailure(this: JQuery, formErrors: {[key: string]: any}, fields: {[key: string]: any}): void;
 
         /**
          * Callback if form state is modified to 'dirty'.

--- a/types/fomantic-ui-form.d.ts
+++ b/types/fomantic-ui-form.d.ts
@@ -396,9 +396,9 @@ declare namespace FomanticUI {
 
     namespace Form {
         type TextSettings = Partial<Pick<Settings.Texts, keyof Settings.Texts>>;
-        type PromptSettings = Partial<Pick<Settings.Prompts, keyof Settings.Prompts>>;
+        type PromptSettings = Partial<Pick<Settings.Prompts, keyof Settings.Prompts>> & {[key: string]: string | undefined};
         type FormatterSettings = Partial<Pick<Settings.Formatters, keyof Settings.Formatters>>;
-        type RulesSettings = Partial<Pick<Settings.Rules, keyof Settings.Rules>>;
+        type RulesSettings = Partial<Pick<Settings.Rules, keyof Settings.Rules>> & {[key: string]: (value?: any, identifier?: string, module?: any) => boolean};
         type SelectorSettings = Partial<Pick<Settings.Selectors, keyof Settings.Selectors>>;
         type MetadataSettings = Partial<Pick<Settings.Metadatas, keyof Settings.Metadatas>>;
         type ClassNameSettings = Partial<Pick<Settings.ClassNames, keyof Settings.ClassNames>>;

--- a/types/fomantic-ui-modal.d.ts
+++ b/types/fomantic-ui-modal.d.ts
@@ -5,12 +5,12 @@ declare namespace FomanticUI {
         /**
          * Shows the modal.
          */
-        (behavior: 'show'): JQuery;
+        (behavior: 'show', callback?: Function): JQuery;
 
         /**
          * Hides the modal.
          */
-        (behavior: 'hide'): JQuery;
+        (behavior: 'hide', callback?: Function): JQuery;
 
         /**
          * Toggles the modal.
@@ -193,6 +193,62 @@ declare namespace FomanticUI {
          * @default 10
          */
         scrollbarWidth: number;
+
+        // dynamic content
+
+        /**
+         * Title of dynamicly created modal.
+         * @default ''
+         */
+        title: string;
+
+        /**
+         * HTML content of dynamicly created modal.
+         * @default ''
+         */
+        content: string;
+
+        /**
+         * CSS classname(s) of dynamicly created modal.
+         * @default ''
+         */
+        class: string;
+
+        /**
+         * CSS classname(s) of dynamicly created modal's title.
+         * @default ''
+         */
+        classTitle: string;
+
+        /**
+         * CSS classname(s) of dynamicly created modal's content.
+         * @default ''
+         */
+        classContent: string;
+
+        /**
+         * CSS classname(s) of dynamicly created modal's actions.
+         * @default ''
+         */
+        classActions: string;
+
+        /**
+         * Determine if a close icon shoud be displayed on dynamicly created modal.
+         * @default false
+         */
+        closeIcon: boolean;
+
+        /**
+         * 
+         * @default false
+         */
+        actions: any;
+
+        /**
+         * 
+         * @default true
+         */
+        preserveHTML: boolean;
 
         // endregion
 

--- a/types/fomantic-ui-modal.d.ts
+++ b/types/fomantic-ui-modal.d.ts
@@ -62,6 +62,11 @@ declare namespace FomanticUI {
          */
         (behavior: 'set active'): JQuery;
 
+        /**
+         * Templates handling
+         */
+        (behavior: keyof Modal.TemplatesSettings, ...args: any): Partial<Pick<ModalSettings, keyof ModalSettings>>;
+
         (behavior: 'destroy'): JQuery;
         <K extends keyof ModalSettings>(behavior: 'setting', name: K, value?: undefined, ): Partial<Pick<ModalSettings, keyof ModalSettings>>;
         <K extends keyof ModalSettings>(behavior: 'setting', name: K, value: ModalSettings[K]): JQuery;
@@ -166,13 +171,13 @@ declare namespace FomanticUI {
         /**
          * Custom settings to extend UI dimmer.
          */
-        dimmerSettings: DimmerSettings;
+        dimmerSettings: Partial<Pick<DimmerSettings, keyof DimmerSettings>>;
 
         /**
          * Custom settings to extend UI dimmer.
          * @default 'scale'
          */
-        transition: string | TransitionSettings;
+        transition: string | Partial<Pick<TransitionSettings, keyof TransitionSettings>>;
 
         /**
          * Duration of animation.
@@ -306,6 +311,8 @@ declare namespace FomanticUI {
 
         // region Config Template Settings
 
+        templates: Modal.TemplatesSettings;
+
         // endregion
 
         // region Debug Settings
@@ -355,6 +362,7 @@ declare namespace FomanticUI {
         type SelectorSettings = Partial<Pick<Settings.Selectors, keyof Settings.Selectors>>;
         type ClassNameSettings = Partial<Pick<Settings.ClassNames, keyof Settings.ClassNames>>;
         type ErrorSettings = Partial<Pick<Settings.Errors, keyof Settings.Errors>>;
+        type TemplatesSettings = Partial<Pick<Settings.Templates, keyof Settings.Templates>> & {[key: string]: (...args: any) => Partial<Pick<ModalSettings, keyof ModalSettings>>};
 
         namespace Settings {
             interface Selectors {
@@ -521,6 +529,12 @@ declare namespace FomanticUI {
                  * @default 'The element you specified could not be found'
                  */
                 notFound: string;
+            }
+
+            interface Templates {
+                alert(): Partial<Pick<ModalSettings, keyof ModalSettings>>;
+                confirm(): Partial<Pick<ModalSettings, keyof ModalSettings>>;
+                prompt(): Partial<Pick<ModalSettings, keyof ModalSettings>>;
             }
         }
     }

--- a/types/fomantic-ui-nag.d.ts
+++ b/types/fomantic-ui-nag.d.ts
@@ -26,7 +26,7 @@ declare namespace FomanticUI {
         <K extends keyof NagSettings>(behavior: 'setting', name: K, value?: undefined, ): Partial<Pick<NagSettings, keyof NagSettings>>;
         <K extends keyof NagSettings>(behavior: 'setting', name: K, value: NagSettings[K]): JQuery;
         (behavior: 'setting', value: Partial<Pick<NagSettings, keyof NagSettings>>): JQuery;
-        (settings?: NagSettings): Partial<Pick<NagSettings, keyof NagSettings>>;
+        (settings?: Partial<Pick<NagSettings, keyof NagSettings>>): JQuery;
     }
 
     /**

--- a/types/fomantic-ui-popup.d.ts
+++ b/types/fomantic-ui-popup.d.ts
@@ -84,7 +84,7 @@ declare namespace FomanticUI {
          * This is useful for including a pre-formatted popup.
          * @default false
          */
-        popup: false | string;
+        popup: false | string | JQuery;
 
         /**
          * Whether all other popups should be hidden when this popup is opened.

--- a/types/fomantic-ui-popup.d.ts
+++ b/types/fomantic-ui-popup.d.ts
@@ -266,39 +266,39 @@ declare namespace FomanticUI {
         /**
          * Callback on popup element creation, with created popup.
          */
-        onCreate(this: JQuery): void;
+        onCreate(this: JQuery, element?: JQuery<HTMLElement>): void;
 
         /**
          * Callback immediately before Popup is removed from DOM.
          */
-        onRemove(this: JQuery): void;
+        onRemove(this: JQuery, element?: JQuery<HTMLElement>): void;
 
         /**
          * Callback before popup is shown.
          * Returning 'false' from this callback will cancel the popup from showing.
          */
-        onShow(this: JQuery): boolean;
+        onShow(this: JQuery, element?: JQuery<HTMLElement>): any;
 
         /**
          * Callback after popup is shown.
          */
-        onVisible(this: JQuery): void;
+        onVisible(this: JQuery, element?: JQuery<HTMLElement>): void;
 
         /**
          * Callback before popup is hidden.
          * Returning 'false' from this callback will cancel the popup from hiding.
          */
-        onHide(this: JQuery): boolean;
+        onHide(this: JQuery, element?: JQuery<HTMLElement>): any;
 
         /**
          * Callback after popup is hidden.
          */
-        onHidden(this: JQuery): void;
+        onHidden(this: JQuery, element?: JQuery<HTMLElement>): void;
 
         /**
          * Callback after popup cannot be placed on screen.
          */
-        onUnplaceable(this: JQuery): void;
+        onUnplaceable(this: JQuery, element?: JQuery<HTMLElement>): void;
 
         // endregion
 

--- a/types/fomantic-ui-progress.d.ts
+++ b/types/fomantic-ui-progress.d.ts
@@ -209,6 +209,12 @@ declare namespace FomanticUI {
         precision: number;
 
         /**
+         * Sets current overall percent.
+         * @default false
+         */
+        percent: false | number;
+
+        /**
          * Setting a total value will make each call to increment get closer to this total (i.e. 1/20, 2/20 etc).
          * @default false
          */

--- a/types/fomantic-ui-search.d.ts
+++ b/types/fomantic-ui-search.d.ts
@@ -228,6 +228,24 @@ declare namespace FomanticUI {
          */
         ignoreDiacritics: boolean;
 
+        /**
+         * Template to use (specified in settings.templates)
+         * @default 'standard'
+         */
+        type: 'escape' | 'message' | 'category' | 'standard';
+
+        /**
+         * Field to display in standard results template
+         * @default ''
+         */
+        displayField: string;
+
+        /**
+         * Whether to add events to prompt automatically
+         * @default true
+         */
+        automatic: boolean;
+
         // endregion
 
         // region Callbacks
@@ -237,7 +255,7 @@ declare namespace FomanticUI {
          * The first parameter includes the filtered response results for that element.
          * The function should return 'false' to prevent default action (closing search results and selecting value).
          */
-        onSelect(this: JQuery, result: object, response: object): void | Promise<void> | boolean | Promise<boolean>;
+        onSelect(this: JQuery, result: object, response: object): any;
 
         /**
          * Callback after processing element template to add HTML to results.
@@ -352,24 +370,24 @@ declare namespace FomanticUI {
         namespace Settings {
             interface Templates {
                 /**
-                 * @default function(string)
+                 * @default function(string, preserveHTML)
                  */
-                escape: Function;
+                escape: (string: string, preserveHTML?: boolean) => string;
 
                 /**
-                 * @default function(message, type)
+                 * @default function(message, type, header)
                  */
-                message: Function;
+                message: (message: string, type?: string, header?: string) => string;
 
                 /**
-                 * @default function(response)
+                 * @default function(response, fields, preserveHTML)
                  */
-                category: Function;
+                category: (response: unknown, fields: {[key: string]: string}, preserveHTML?: boolean) => string;
 
                 /**
-                 * @default function(response)
+                 * @default function(response, fields, preserveHTML)
                  */
-                standard: Function;
+                standard: (response: unknown, fields: {[key: string]: string}, preserveHTML?: boolean) => string;
             }
 
             interface Selectors {

--- a/types/fomantic-ui-search.d.ts
+++ b/types/fomantic-ui-search.d.ts
@@ -10,7 +10,7 @@ declare namespace FomanticUI {
         /**
          * Displays message in search results with text, using template matching type.
          */
-        (behavior: 'display message', text: string, type: string): JQuery;
+        (behavior: 'display message', text: string, type?: string): JQuery;
 
         /**
          * Cancels current remote search query.

--- a/types/fomantic-ui-search.d.ts
+++ b/types/fomantic-ui-search.d.ts
@@ -124,7 +124,7 @@ declare namespace FomanticUI {
          * @see {@link https://fomantic-ui.com/behaviors/api.html#/settings}
          * @default {}
          */
-        apiSettings: APISettings | JQueryAjaxSettings;
+        apiSettings: Partial<Pick<APISettings, keyof APISettings>> | JQueryAjaxSettings;
 
         /**
          * Minimum characters to query for results.
@@ -237,13 +237,13 @@ declare namespace FomanticUI {
          * The first parameter includes the filtered response results for that element.
          * The function should return 'false' to prevent default action (closing search results and selecting value).
          */
-        onSelect(this: JQuery, result: object, response: object): boolean;
+        onSelect(this: JQuery, result: object, response: object): void | Promise<void> | boolean | Promise<boolean>;
 
         /**
          * Callback after processing element template to add HTML to results.
          * Function should return 'false' to prevent default actions.
          */
-        onResultsAdd(this: JQuery, html: string): boolean;
+        onResultsAdd(this: JQuery, html: string): void | boolean;
 
         /**
          * Callback on search query.

--- a/types/fomantic-ui-tab.d.ts
+++ b/types/fomantic-ui-tab.d.ts
@@ -149,7 +149,7 @@ declare namespace FomanticUI {
          * Tabs are limited to those found inside this context.
          * @default false
          */
-        context: false | string;
+        context: JQuery | string | false;
 
         /**
          * If enabled limits tabs to children of passed context.

--- a/types/fomantic-ui-tests.ts
+++ b/types/fomantic-ui-tests.ts
@@ -181,3 +181,7 @@ $.toast({
     closeEasing: 'easeOutBounce'
   }
 });
+
+$().transition("shake", "200ms");
+$().transition("horizontal flip", 500, function() { alert('done!'); });
+$().transition("fade up");

--- a/types/fomantic-ui-tests.ts
+++ b/types/fomantic-ui-tests.ts
@@ -23,3 +23,86 @@ $().tab(); // $ExpectType JQuery<HTMLElement>
 $('body').toast(); // $ExpectType JQuery<HTMLElement>
 $().transition(); // $ExpectType JQuery<HTMLElement>
 $().visibility(); // $ExpectType JQuery<HTMLElement>
+
+$().calendar({
+  today: true,
+  initialDate: null,
+  endCalendar: $()
+}); // $ExpectType JQuery<HTMLElement>
+
+$().form({
+  fields: {
+    field1: {
+      rules: [
+        {
+          type   : 'empty'
+        }
+      ]
+    },
+    field2: {
+      rules: [
+        {
+          type   : 'isExactly[dog]',
+          prompt : '{name} is set to "{value}" that is totally wrong. It should be {ruleValue}'
+        }
+      ]
+    },
+    field3: {
+      rules: [
+        {
+          type   : 'isExactly[cat]',
+          prompt : function(value) {
+            if(value == 'dog') {
+              return 'I told you to put cat, not dog!';
+            }
+            return 'That is not cat';
+          }
+        }
+      ]
+    },
+    color: {
+      identifier: 'color',
+      rules: [{
+        type: 'regExp',
+        value: /rgb\((\d{1,3}), (\d{1,3}), (\d{1,3})\)/i,
+      }]
+    },
+    yearsPracticed: {
+      identifier : 'yearsPracticed',
+      depends    : 'isDoctor',
+      rules      : [
+        {
+          type   : 'empty',
+          prompt : 'Please enter the number of years you have been a doctor'
+        }
+      ]
+    },
+    ccEmail: {
+      identifier : 'cc-email',
+      optional   : true,
+      rules: [
+        {
+          type   : 'email',
+          prompt : 'Please enter a valid second e-mail'
+        }
+      ]
+    }
+  }
+}); // $ExpectType JQuery<HTMLElement>
+
+$().form({
+  fields: {
+    gender: 'empty',
+    name: 'empty',
+    password : ['minLength[6]', 'empty']
+  }
+}); // $ExpectType JQuery<HTMLElement>
+
+//@ts-ignore
+$.fn.form.settings.rules.date = function(str_date: string) {
+  return true;
+};
+
+$().nag({
+  persist: true
+}); // $ExpectType JQuery<HTMLElement>

--- a/types/fomantic-ui-tests.ts
+++ b/types/fomantic-ui-tests.ts
@@ -24,11 +24,34 @@ $('body').toast(); // $ExpectType JQuery<HTMLElement>
 $().transition(); // $ExpectType JQuery<HTMLElement>
 $().visibility(); // $ExpectType JQuery<HTMLElement>
 
+/* Define API endpoints once globally */
+$.fn.api.settings.api = {
+  'get followers' : '/followers/{id}?results={count}',
+  'create user'   : '/create',
+  'add user'      : '/add/{id}',
+  'follow user'   : '/follow/{id}',
+  'search'        : '/search/?query={value}'
+};
+
 $().calendar({
   today: true,
   initialDate: null,
   endCalendar: $()
 }); // $ExpectType JQuery<HTMLElement>
+
+$.flyout('alert','hello'); // $ExpectType JQuery<HTMLElement>
+$.flyout('confirm','Are you sure?',function(){}); // $ExpectType JQuery<HTMLElement>
+$.flyout('prompt','Enter Code', function(){}); // $ExpectType JQuery<HTMLElement>
+
+$.fn.flyout.settings.templates.greet = function(username) {
+  return {
+    title: 'Greetings to ' + username + '!',
+    content: ''+ username.toUpperCase() + 'is the best!',
+    closeIcon: true,
+    class: 'inverted',
+    classContent: 'centered'
+  }
+}
 
 $().form({
   fields: {
@@ -98,11 +121,63 @@ $().form({
   }
 }); // $ExpectType JQuery<HTMLElement>
 
-//@ts-ignore
 $.fn.form.settings.rules.date = function(str_date: string) {
   return true;
 };
 
+$.modal('alert', {
+  title: 'Listen to me',
+  content: 'I love Fomantic-UI',
+  handler: function() {
+    $.toast({message:'Great!'});
+  }
+});
+
+$.fn.modal.settings.templates.greet = function(username: string) {
+  // do something according to modals settings and/or given parameters
+  return {
+    title: 'Greetings to ' + username + '!',
+    content: ''+ username.toUpperCase() + 'is the best!',
+    class: 'inverted',
+    classContent: 'centered',
+    dimmerSettings: {
+      variation: 'inverted'
+    }
+  }
+}
+
+$.modal('greet', 'mom');
+
 $().nag({
   persist: true
 }); // $ExpectType JQuery<HTMLElement>
+
+$().search("display message", "Hello, world !"); // $ExpectType JQuery<HTMLElement>
+
+// To change the defaults for all toast at once override the module as follows
+$.fn.toast.settings.progressUp = true;
+$.fn.toast.settings.class = 'info';
+$.fn.toast.settings.showIcon = true;
+$.fn.toast.settings.className.box = 'toast-box';  //removes shadow
+$.fn.toast.settings.className.title = 'header';   // smaller font size
+$.fn.toast.settings.className.icon = 'icon';   // top position again
+$.fn.toast.settings.transition.closeEasing = 'easeOutBounce';
+
+// Or apply the old defaults directly to the toast
+$.toast({
+  title: 'LOOK',
+  message: 'Turned back time to 2.7.0 defaults',
+  showProgress: 'bottom',
+   //make it look like 2.7.0
+  showIcon: true,
+  progressUp: true,
+  class: 'info',
+  className: {
+    box:'toast-box',
+    title:'header',
+    icon: 'icon'
+  },
+  transition: {
+    closeEasing: 'easeOutBounce'
+  }
+});

--- a/types/fomantic-ui-toast.d.ts
+++ b/types/fomantic-ui-toast.d.ts
@@ -13,6 +13,11 @@ declare namespace FomanticUI {
         (behavior: 'animate continue'): JQuery;
 
         /**
+         * Show the toast
+         */
+        (behavior: 'show'): JQuery;
+
+        /**
          * Closes the toast
          */
         (behavior: 'close'): JQuery;
@@ -273,7 +278,7 @@ declare namespace FomanticUI {
         /**
          * An array of objects. Each object defines an action with 'properties' 'text', 'class', 'icon' and 'click'.
          */
-        actions: Toast.ActionsSettings;
+        actions: Toast.ActionsSettings[];
 
         // endregion
 

--- a/types/fomantic-ui-transition.d.ts
+++ b/types/fomantic-ui-transition.d.ts
@@ -112,6 +112,52 @@ declare namespace FomanticUI {
          */
         (behavior: 'is supported'): boolean;
 
+        (behavior: 'scale'): JQuery;
+
+        (behavior: 'zoom'): JQuery;
+
+        (behavior: 'fade'): JQuery;
+        (behavior: 'fade up'): JQuery;
+        (behavior: 'fade down'): JQuery;
+        (behavior: 'fade left'): JQuery;
+        (behavior: 'fade right'): JQuery;
+
+        (behavior: 'horizontal flip'): JQuery;
+        (behavior: 'vertical flip'): JQuery;
+
+        (behavior: 'drop'): JQuery;
+
+        (behavior: 'fly up'): JQuery;
+        (behavior: 'fly down'): JQuery;
+        (behavior: 'fly left'): JQuery;
+        (behavior: 'fly right'): JQuery;
+
+        (behavior: 'swing up'): JQuery;
+        (behavior: 'swing down'): JQuery;
+        (behavior: 'swing left'): JQuery;
+        (behavior: 'swing right'): JQuery;
+
+        (behavior: 'browse'): JQuery;
+        (behavior: 'browse up'): JQuery;
+        (behavior: 'browse down'): JQuery;
+        (behavior: 'browse left'): JQuery;
+        (behavior: 'browse right'): JQuery;
+
+        (behavior: 'slide up'): JQuery;
+        (behavior: 'slide down'): JQuery;
+        (behavior: 'slide left'): JQuery;
+        (behavior: 'slide right'): JQuery;
+
+        // Static animations
+        (behavior: 'pulsating'): JQuery;
+        (behavior: 'jiggle'): JQuery;
+        (behavior: 'flash'): JQuery;
+        (behavior: 'shake'): JQuery;
+        (behavior: 'pulse'): JQuery;
+        (behavior: 'tada'): JQuery;
+        (behavior: 'bounce'): JQuery;
+        (behavior: 'glow'): JQuery;
+
         /**
          * Destroys instance and removes all events.
          */

--- a/types/fomantic-ui-transition.d.ts
+++ b/types/fomantic-ui-transition.d.ts
@@ -112,51 +112,33 @@ declare namespace FomanticUI {
          */
         (behavior: 'is supported'): boolean;
 
-        (behavior: 'scale'): JQuery;
+        (behavior: 'scale', duration?: any, onComplete?: () => any): JQuery;
 
-        (behavior: 'zoom'): JQuery;
+        (behavior: 'zoom', duration?: any, onComplete?: () => any): JQuery;
 
-        (behavior: 'fade'): JQuery;
-        (behavior: 'fade up'): JQuery;
-        (behavior: 'fade down'): JQuery;
-        (behavior: 'fade left'): JQuery;
-        (behavior: 'fade right'): JQuery;
+        (behavior: 'fade' | 'fade up' | 'fade down' | 'fade left' | 'fade right', duration?: any, onComplete?: () => any): JQuery;
 
-        (behavior: 'horizontal flip'): JQuery;
-        (behavior: 'vertical flip'): JQuery;
+        (behavior: 'horizontal flip' | 'vertical flip', duration?: any, onComplete?: () => any): JQuery;
 
-        (behavior: 'drop'): JQuery;
+        (behavior: 'drop', duration?: any, onComplete?: () => any): JQuery;
 
-        (behavior: 'fly up'): JQuery;
-        (behavior: 'fly down'): JQuery;
-        (behavior: 'fly left'): JQuery;
-        (behavior: 'fly right'): JQuery;
+        (behavior: 'fly up' | 'fly down' | 'fly left' | 'fly right', duration?: any, onComplete?: () => any): JQuery;
 
-        (behavior: 'swing up'): JQuery;
-        (behavior: 'swing down'): JQuery;
-        (behavior: 'swing left'): JQuery;
-        (behavior: 'swing right'): JQuery;
+        (behavior: 'swing up' | 'swing down' | 'swing left' | 'swing right', duration?: any, onComplete?: () => any): JQuery;
 
-        (behavior: 'browse'): JQuery;
-        (behavior: 'browse up'): JQuery;
-        (behavior: 'browse down'): JQuery;
-        (behavior: 'browse left'): JQuery;
-        (behavior: 'browse right'): JQuery;
+        (behavior: 'browse' | 'browse up' | 'browse down' | 'browse left' | 'browse right', duration?: any, onComplete?: () => any): JQuery;
 
-        (behavior: 'slide up'): JQuery;
-        (behavior: 'slide down'): JQuery;
-        (behavior: 'slide left'): JQuery;
-        (behavior: 'slide right'): JQuery;
+        (behavior: 'slide up' | 'slide down' | 'slide left' | 'slide right', duration?: any, onComplete?: () => any): JQuery;
 
         // Static animations
-        (behavior: 'pulsating'): JQuery;
-        (behavior: 'jiggle'): JQuery;
-        (behavior: 'flash'): JQuery;
-        (behavior: 'shake'): JQuery;
-        (behavior: 'pulse'): JQuery;
-        (behavior: 'tada'): JQuery;
-        (behavior: 'bounce'): JQuery;
-        (behavior: 'glow'): JQuery;
+        (behavior: 'pulsating', duration?: any, onComplete?: () => any): JQuery;
+        (behavior: 'jiggle', duration?: any, onComplete?: () => any): JQuery;
+        (behavior: 'flash', duration?: any, onComplete?: () => any): JQuery;
+        (behavior: 'shake', duration?: any, onComplete?: () => any): JQuery;
+        (behavior: 'pulse', duration?: any, onComplete?: () => any): JQuery;
+        (behavior: 'tada', duration?: any, onComplete?: () => any): JQuery;
+        (behavior: 'bounce', duration?: any, onComplete?: () => any): JQuery;
+        (behavior: 'glow', duration?: any, onComplete?: () => any): JQuery;
 
         /**
          * Destroys instance and removes all events.

--- a/types/fomantic-ui-visibility.d.ts
+++ b/types/fomantic-ui-visibility.d.ts
@@ -46,8 +46,8 @@ declare namespace FomanticUI {
         (behavior: 'destroy'): JQuery;
         <K extends keyof VisibilitySettings>(behavior: 'setting', name: K, value?: undefined, ): Partial<Pick<VisibilitySettings, keyof VisibilitySettings>>;
         <K extends keyof VisibilitySettings>(behavior: 'setting', name: K, value: VisibilitySettings[K]): JQuery;
-        (behavior: 'setting', value: VisibilitySettings): JQuery;
-        (settings?: VisibilitySettings): JQuery;
+        (behavior: 'setting', value: Partial<Pick<VisibilitySettings, keyof VisibilitySettings>>): JQuery;
+        (settings?: Partial<Pick<VisibilitySettings, keyof VisibilitySettings>>): JQuery;
     }
 
     /**


### PR DESCRIPTION
## Description
This is the first round of fixes/improvements for type declarations of Fomantic. Some properties and methods were missing, some were too restrictive.

I've enabled strict type checking on my work project (~500k lines of code and use almost every module of Fomantic). Before the fix I had around 2500 errors during transpilation, 0 after.

I just cannot fix one error, that I circumvent by adding the `//@ts-expect-error` on the line before:
For a `Form`, creating a new rule will raise an error in VSCode (that can be safely bypassed).

![image](https://github.com/fomantic/Fomantic-UI/assets/7557689/a23079d6-b411-4f42-973e-4d27abee3869)

`$.fn.form.settings.rules` is typed and Intellisense is working, but adding a new rule to it will trigger an error. Anyway, this is not a blocking issue for merging, since this PR will make a lot more good than bad :)

## Closes
#2906
