### PR TITLE
fix(grid): fix stackable inverted grid divider for mobile screen

### DIFF
--- a/src/definitions/collections/grid.less
+++ b/src/definitions/collections/grid.less
@@ -1723,10 +1723,10 @@
             border-top: none !important;
         }
         & when (@variationGridInverted) {
-            .ui.inverted.stackable.celled.grid > .column:not(.row),
-            .ui.inverted.stackable.divided.grid > .column:not(.row),
-            .ui.inverted.stackable.celled.grid > .row > .column,
-            .ui.inverted.stackable.divided.grid > .row > .column {
+            .ui.ui.inverted.stackable.celled.grid > .column:not(.row),
+            .ui.ui.inverted.stackable.divided.grid > .column:not(.row),
+            .ui.ui.inverted.stackable.celled.grid > .row > .column,
+            .ui.ui.inverted.stackable.divided.grid > .row > .column {
                 border-top: @stackableInvertedMobileBorder;
             }
         }


### PR DESCRIPTION
## Description

The stackable inverted grid item is not showing the divider in mobile screen due to the override by specificity of non-inverted grid.

## Testcase

#### Before:
- Open fiddle https://jsfiddle.net/ko2in/tqw0anjv/
- Resize the panel to become narrow as mobile screen size

#### After:
- Open fiddle https://jsfiddle.net/ko2in/tqw0anjv/4/
- Resize the panel to become narrow as mobile screen size

## Screenshot
#### Before:

![inverted-grid-divider-no-border](https://github.com/fomantic/Fomantic-UI/assets/930315/a7d79733-2d3c-46ed-ad16-f4480b7fe1c7)

#### After:

![inverted-grid-divider](https://github.com/fomantic/Fomantic-UI/assets/930315/a5642776-bf25-4a83-8317-0291cc87d096)


## Closes
#2922
