### PR TITLE
Jaimin

### DIFF
--- a/dist/components/grid.css
+++ b/dist/components/grid.css
@@ -8,36 +8,35 @@
  *
  */
 
-
 /*******************************
             Standard
 *******************************/
 
 .ui.grid {
-  display: flex;
-  flex-flow: row wrap;
-  align-items: stretch;
-  padding: 0;
+    display: flex;
+    flex-flow: row wrap;
+    align-items: stretch;
+    padding: 0;
 }
 
 /* ----------------------
       Remove Gutters
 ----------------------- */
 .ui.grid {
-  margin: -1rem -1rem;
+    margin: -1rem -1rem;
 }
 .ui.relaxed.grid {
-  margin-left: -1.5rem;
-  margin-right: -1.5rem;
+    margin-left: -1.5rem;
+    margin-right: -1.5rem;
 }
 .ui[class*="very relaxed"].grid {
-  margin-left: -2.5rem;
-  margin-right: -2.5rem;
+    margin-left: -2.5rem;
+    margin-right: -2.5rem;
 }
 
 /* Preserve Rows Spacing on Consecutive Grids */
 .ui.grid + .grid {
-  margin-top: 1rem;
+    margin-top: 1rem;
 }
 
 /* -------------------
@@ -47,31 +46,31 @@
 /* Standard 16 column */
 .ui.grid > .column:not(.row),
 .ui.grid > .row > .column {
-  position: relative;
-  display: inline-block;
-  width: 6.25%;
-  padding-left: 1rem;
-  padding-right: 1rem;
-  vertical-align: top;
+    position: relative;
+    display: inline-block;
+    width: 6.25%;
+    padding-left: 1rem;
+    padding-right: 1rem;
+    vertical-align: top;
 }
 .ui.grid > * {
-  padding-left: 1rem;
-  padding-right: 1rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
 }
 
 /* -------------------
         Rows
 -------------------- */
 .ui.grid > .row {
-  position: relative;
-  display: flex;
-  flex-flow: row wrap;
-  justify-content: inherit;
-  align-items: stretch;
-  width: 100% !important;
-  padding: 0;
-  padding-top: 1rem;
-  padding-bottom: 1rem;
+    position: relative;
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: inherit;
+    align-items: stretch;
+    width: 100% !important;
+    padding: 0;
+    padding-top: 1rem;
+    padding-bottom: 1rem;
 }
 
 /* -------------------
@@ -80,12 +79,12 @@
 
 /* Vertical padding when no rows */
 .ui.grid > .column:not(.row) {
-  padding-top: 1rem;
-  padding-bottom: 1rem;
+    padding-top: 1rem;
+    padding-bottom: 1rem;
 }
 .ui.grid > .row > .column {
-  margin-top: 0;
-  margin-bottom: 0;
+    margin-top: 0;
+    margin-bottom: 0;
 }
 
 /* -------------------
@@ -93,7 +92,7 @@
 -------------------- */
 .ui.grid > .row > img,
 .ui.grid > .row > .column > img {
-  max-width: 100%;
+    max-width: 100%;
 }
 
 /* -------------------
@@ -102,86 +101,84 @@
 
 /* Collapse Margin on Consecutive Grid */
 .ui.grid > .ui.grid:first-child {
-  margin-top: 0;
+    margin-top: 0;
 }
 .ui.grid > .ui.grid:last-child {
-  margin-bottom: 0;
+    margin-bottom: 0;
 }
 
 /* Segment inside Aligned Grid */
 .ui.grid .aligned.row > .column > .segment:not(.compact):not(.attached),
 .ui.aligned.grid .column > .segment:not(.compact):not(.attached) {
-  width: 100%;
+    width: 100%;
 }
 
 /* Align Dividers with Gutter */
 .ui.grid .row + .ui.divider {
-  flex-grow: 1;
-  margin: 1rem 1rem;
+    flex-grow: 1;
+    margin: 1rem 1rem;
 }
 .ui.grid .column + .ui.vertical.divider {
-  height: calc(50% - 1rem);
+    height: calc(50% - 1rem);
 }
 
 /* Remove Border on Last Horizontal Segment */
 .ui.grid > .row > .column:last-child > .horizontal.segment,
 .ui.grid > .column:last-child > .horizontal.segment {
-  box-shadow: none;
+    box-shadow: none;
 }
-
 
 /*******************************
            Variations
 *******************************/
 
-
 /* -----------------------
            Page Grid
     ------------------------- */
 @media only screen and (max-width: 767.98px) {
-  .ui.page.grid {
-    width: auto;
-    padding-left: 0;
-    padding-right: 0;
-    margin-left: 0;
-    margin-right: 0;
-  }
+    .ui.page.grid {
+        width: auto;
+        padding-left: 0;
+        padding-right: 0;
+        margin-left: 0;
+        margin-right: 0;
+    }
 }
 @media only screen and (min-width: 768px) and (max-width: 991.98px) {
-  .ui.page.grid {
-    width: auto;
-    margin-left: 0;
-    margin-right: 0;
-    padding-left: 2em;
-    padding-right: 2em;
-  }
+    .ui.page.grid {
+        width: auto;
+        margin-left: 0;
+        margin-right: 0;
+        padding-left: 2em;
+        padding-right: 2em;
+    }
 }
 @media only screen and (min-width: 992px) and (max-width: 1199.98px) {
-  .ui.page.grid {
-    width: auto;
-    margin-left: 0;
-    margin-right: 0;
-    padding-left: 3%;
-    padding-right: 3%;
-  }
+    .ui.page.grid {
+        width: auto;
+        margin-left: 0;
+        margin-right: 0;
+        padding-left: 3%;
+        padding-right: 3%;
+    }
 }
 @media only screen and (min-width: 1200px) and (max-width: 1919.98px) {
-  .ui.page.grid {
-    width: auto;
-    margin-left: 0;
-    margin-right: 0;
-    padding-left: 15%;
-    padding-right: 15%;
-  }
+    .ui.page.grid {
+        width: auto;
+        margin-left: 0;
+        margin-right: 0;
+        padding-left: 15%;
+        padding-right: 15%;
+    }
 }
 @media only screen and (min-width: 1920px) {
-  .ui.page.grid {
-    width: auto;
-    margin-left: 0;
-    margin-right: 0;
-    padding-left: 23%;
-    padding-right: 23%;
-  }
+    .ui.page.grid {
+        width: auto;
+        margin-left: 0;
+        margin-right: 0;
+        padding-left: 23%;
+        padding-right: 23%;
+    }
 }
 
 /* -------------------
@@ -191,128 +188,128 @@
 /* Assume full width with one column */
 .ui.grid > .column:only-child,
 .ui.grid > .row > .column:only-child {
-  width: 100%;
+    width: 100%;
 }
 
 /* Grid Based */
 .ui[class*="one column"].grid > .row > .column,
 .ui[class*="one column"].grid > .column:not(.row) {
-  width: 100%;
+    width: 100%;
 }
 .ui[class*="two column"].grid > .row > .column,
 .ui[class*="two column"].grid > .column:not(.row) {
-  width: 50%;
+    width: 50%;
 }
 .ui[class*="three column"].grid > .row > .column,
 .ui[class*="three column"].grid > .column:not(.row) {
-  width: 33.33333333%;
+    width: 33.33333333%;
 }
 .ui[class*="four column"].grid > .row > .column,
 .ui[class*="four column"].grid > .column:not(.row) {
-  width: 25%;
+    width: 25%;
 }
 .ui[class*="five column"].grid > .row > .column,
 .ui[class*="five column"].grid > .column:not(.row) {
-  width: 20%;
+    width: 20%;
 }
 .ui[class*="six column"].grid > .row > .column,
 .ui[class*="six column"].grid > .column:not(.row) {
-  width: 16.66666667%;
+    width: 16.66666667%;
 }
 .ui[class*="seven column"].grid > .row > .column,
 .ui[class*="seven column"].grid > .column:not(.row) {
-  width: 14.28571429%;
+    width: 14.28571429%;
 }
 .ui[class*="eight column"].grid > .row > .column,
 .ui[class*="eight column"].grid > .column:not(.row) {
-  width: 12.5%;
+    width: 12.5%;
 }
 .ui[class*="nine column"].grid > .row > .column,
 .ui[class*="nine column"].grid > .column:not(.row) {
-  width: 11.11111111%;
+    width: 11.11111111%;
 }
 .ui[class*="ten column"].grid > .row > .column,
 .ui[class*="ten column"].grid > .column:not(.row) {
-  width: 10%;
+    width: 10%;
 }
 .ui[class*="eleven column"].grid > .row > .column,
 .ui[class*="eleven column"].grid > .column:not(.row) {
-  width: 9.09090909%;
+    width: 9.09090909%;
 }
 .ui[class*="twelve column"].grid > .row > .column,
 .ui[class*="twelve column"].grid > .column:not(.row) {
-  width: 8.33333333%;
+    width: 8.33333333%;
 }
 .ui[class*="thirteen column"].grid > .row > .column,
 .ui[class*="thirteen column"].grid > .column:not(.row) {
-  width: 7.69230769%;
+    width: 7.69230769%;
 }
 .ui[class*="fourteen column"].grid > .row > .column,
 .ui[class*="fourteen column"].grid > .column:not(.row) {
-  width: 7.14285714%;
+    width: 7.14285714%;
 }
 .ui[class*="fifteen column"].grid > .row > .column,
 .ui[class*="fifteen column"].grid > .column:not(.row) {
-  width: 6.66666667%;
+    width: 6.66666667%;
 }
 .ui[class*="sixteen column"].grid > .row > .column,
 .ui[class*="sixteen column"].grid > .column:not(.row) {
-  width: 6.25%;
+    width: 6.25%;
 }
 
 /* Row Based Overrides */
 .ui.grid > [class*="one column"].row > .column {
-  width: 100% !important;
+    width: 100% !important;
 }
 .ui.grid > [class*="two column"].row > .column {
-  width: 50% !important;
+    width: 50% !important;
 }
 .ui.grid > [class*="three column"].row > .column {
-  width: 33.33333333% !important;
+    width: 33.33333333% !important;
 }
 .ui.grid > [class*="four column"].row > .column {
-  width: 25% !important;
+    width: 25% !important;
 }
 .ui.grid > [class*="five column"].row > .column {
-  width: 20% !important;
+    width: 20% !important;
 }
 .ui.grid > [class*="six column"].row > .column {
-  width: 16.66666667% !important;
+    width: 16.66666667% !important;
 }
 .ui.grid > [class*="seven column"].row > .column {
-  width: 14.28571429% !important;
+    width: 14.28571429% !important;
 }
 .ui.grid > [class*="eight column"].row > .column {
-  width: 12.5% !important;
+    width: 12.5% !important;
 }
 .ui.grid > [class*="nine column"].row > .column {
-  width: 11.11111111% !important;
+    width: 11.11111111% !important;
 }
 .ui.grid > [class*="ten column"].row > .column {
-  width: 10% !important;
+    width: 10% !important;
 }
 .ui.grid > [class*="eleven column"].row > .column {
-  width: 9.09090909% !important;
+    width: 9.09090909% !important;
 }
 .ui.grid > [class*="twelve column"].row > .column {
-  width: 8.33333333% !important;
+    width: 8.33333333% !important;
 }
 .ui.grid > [class*="thirteen column"].row > .column {
-  width: 7.69230769% !important;
+    width: 7.69230769% !important;
 }
 .ui.grid > [class*="fourteen column"].row > .column {
-  width: 7.14285714% !important;
+    width: 7.14285714% !important;
 }
 .ui.grid > [class*="fifteen column"].row > .column {
-  width: 6.66666667% !important;
+    width: 6.66666667% !important;
 }
 .ui.grid > [class*="sixteen column"].row > .column {
-  width: 6.25% !important;
+    width: 6.25% !important;
 }
 
 /* Celled Page */
 .ui.celled.page.grid {
-  box-shadow: none;
+    box-shadow: none;
 }
 
 /* -------------------
@@ -324,97 +321,97 @@
 .ui.grid > .column.row > [class*="one wide"].column,
 .ui.grid > [class*="one wide"].column,
 .ui.column.grid > [class*="one wide"].column {
-  width: 6.25% !important;
+    width: 6.25% !important;
 }
 .ui.grid > .row > [class*="two wide"].column,
 .ui.grid > .column.row > [class*="two wide"].column,
 .ui.grid > [class*="two wide"].column,
 .ui.column.grid > [class*="two wide"].column {
-  width: 12.5% !important;
+    width: 12.5% !important;
 }
 .ui.grid > .row > [class*="three wide"].column,
 .ui.grid > .column.row > [class*="three wide"].column,
 .ui.grid > [class*="three wide"].column,
 .ui.column.grid > [class*="three wide"].column {
-  width: 18.75% !important;
+    width: 18.75% !important;
 }
 .ui.grid > .row > [class*="four wide"].column,
 .ui.grid > .column.row > [class*="four wide"].column,
 .ui.grid > [class*="four wide"].column,
 .ui.column.grid > [class*="four wide"].column {
-  width: 25% !important;
+    width: 25% !important;
 }
 .ui.grid > .row > [class*="five wide"].column,
 .ui.grid > .column.row > [class*="five wide"].column,
 .ui.grid > [class*="five wide"].column,
 .ui.column.grid > [class*="five wide"].column {
-  width: 31.25% !important;
+    width: 31.25% !important;
 }
 .ui.grid > .row > [class*="six wide"].column,
 .ui.grid > .column.row > [class*="six wide"].column,
 .ui.grid > [class*="six wide"].column,
 .ui.column.grid > [class*="six wide"].column {
-  width: 37.5% !important;
+    width: 37.5% !important;
 }
 .ui.grid > .row > [class*="seven wide"].column,
 .ui.grid > .column.row > [class*="seven wide"].column,
 .ui.grid > [class*="seven wide"].column,
 .ui.column.grid > [class*="seven wide"].column {
-  width: 43.75% !important;
+    width: 43.75% !important;
 }
 .ui.grid > .row > [class*="eight wide"].column,
 .ui.grid > .column.row > [class*="eight wide"].column,
 .ui.grid > [class*="eight wide"].column,
 .ui.column.grid > [class*="eight wide"].column {
-  width: 50% !important;
+    width: 50% !important;
 }
 .ui.grid > .row > [class*="nine wide"].column,
 .ui.grid > .column.row > [class*="nine wide"].column,
 .ui.grid > [class*="nine wide"].column,
 .ui.column.grid > [class*="nine wide"].column {
-  width: 56.25% !important;
+    width: 56.25% !important;
 }
 .ui.grid > .row > [class*="ten wide"].column,
 .ui.grid > .column.row > [class*="ten wide"].column,
 .ui.grid > [class*="ten wide"].column,
 .ui.column.grid > [class*="ten wide"].column {
-  width: 62.5% !important;
+    width: 62.5% !important;
 }
 .ui.grid > .row > [class*="eleven wide"].column,
 .ui.grid > .column.row > [class*="eleven wide"].column,
 .ui.grid > [class*="eleven wide"].column,
 .ui.column.grid > [class*="eleven wide"].column {
-  width: 68.75% !important;
+    width: 68.75% !important;
 }
 .ui.grid > .row > [class*="twelve wide"].column,
 .ui.grid > .column.row > [class*="twelve wide"].column,
 .ui.grid > [class*="twelve wide"].column,
 .ui.column.grid > [class*="twelve wide"].column {
-  width: 75% !important;
+    width: 75% !important;
 }
 .ui.grid > .row > [class*="thirteen wide"].column,
 .ui.grid > .column.row > [class*="thirteen wide"].column,
 .ui.grid > [class*="thirteen wide"].column,
 .ui.column.grid > [class*="thirteen wide"].column {
-  width: 81.25% !important;
+    width: 81.25% !important;
 }
 .ui.grid > .row > [class*="fourteen wide"].column,
 .ui.grid > .column.row > [class*="fourteen wide"].column,
 .ui.grid > [class*="fourteen wide"].column,
 .ui.column.grid > [class*="fourteen wide"].column {
-  width: 87.5% !important;
+    width: 87.5% !important;
 }
 .ui.grid > .row > [class*="fifteen wide"].column,
 .ui.grid > .column.row > [class*="fifteen wide"].column,
 .ui.grid > [class*="fifteen wide"].column,
 .ui.column.grid > [class*="fifteen wide"].column {
-  width: 93.75% !important;
+    width: 93.75% !important;
 }
 .ui.grid > .row > [class*="sixteen wide"].column,
 .ui.grid > .column.row > [class*="sixteen wide"].column,
 .ui.grid > [class*="sixteen wide"].column,
 .ui.column.grid > [class*="sixteen wide"].column {
-  width: 100% !important;
+    width: 100% !important;
 }
 
 /* ----------------------
@@ -423,502 +420,502 @@
 
 /* Mobile Sizing Combinations */
 @media only screen and (min-width: 320px) and (max-width: 767.98px) {
-  .ui.grid > .row > [class*="one wide mobile"].column,
-  .ui.grid > .column.row > [class*="one wide mobile"].column,
-  .ui.grid > [class*="one wide mobile"].column,
-  .ui.column.grid > [class*="one wide mobile"].column {
-    width: 6.25% !important;
-  }
-  .ui.grid > .row > [class*="two wide mobile"].column,
-  .ui.grid > .column.row > [class*="two wide mobile"].column,
-  .ui.grid > [class*="two wide mobile"].column,
-  .ui.column.grid > [class*="two wide mobile"].column {
-    width: 12.5% !important;
-  }
-  .ui.grid > .row > [class*="three wide mobile"].column,
-  .ui.grid > .column.row > [class*="three wide mobile"].column,
-  .ui.grid > [class*="three wide mobile"].column,
-  .ui.column.grid > [class*="three wide mobile"].column {
-    width: 18.75% !important;
-  }
-  .ui.grid > .row > [class*="four wide mobile"].column,
-  .ui.grid > .column.row > [class*="four wide mobile"].column,
-  .ui.grid > [class*="four wide mobile"].column,
-  .ui.column.grid > [class*="four wide mobile"].column {
-    width: 25% !important;
-  }
-  .ui.grid > .row > [class*="five wide mobile"].column,
-  .ui.grid > .column.row > [class*="five wide mobile"].column,
-  .ui.grid > [class*="five wide mobile"].column,
-  .ui.column.grid > [class*="five wide mobile"].column {
-    width: 31.25% !important;
-  }
-  .ui.grid > .row > [class*="six wide mobile"].column,
-  .ui.grid > .column.row > [class*="six wide mobile"].column,
-  .ui.grid > [class*="six wide mobile"].column,
-  .ui.column.grid > [class*="six wide mobile"].column {
-    width: 37.5% !important;
-  }
-  .ui.grid > .row > [class*="seven wide mobile"].column,
-  .ui.grid > .column.row > [class*="seven wide mobile"].column,
-  .ui.grid > [class*="seven wide mobile"].column,
-  .ui.column.grid > [class*="seven wide mobile"].column {
-    width: 43.75% !important;
-  }
-  .ui.grid > .row > [class*="eight wide mobile"].column,
-  .ui.grid > .column.row > [class*="eight wide mobile"].column,
-  .ui.grid > [class*="eight wide mobile"].column,
-  .ui.column.grid > [class*="eight wide mobile"].column {
-    width: 50% !important;
-  }
-  .ui.grid > .row > [class*="nine wide mobile"].column,
-  .ui.grid > .column.row > [class*="nine wide mobile"].column,
-  .ui.grid > [class*="nine wide mobile"].column,
-  .ui.column.grid > [class*="nine wide mobile"].column {
-    width: 56.25% !important;
-  }
-  .ui.grid > .row > [class*="ten wide mobile"].column,
-  .ui.grid > .column.row > [class*="ten wide mobile"].column,
-  .ui.grid > [class*="ten wide mobile"].column,
-  .ui.column.grid > [class*="ten wide mobile"].column {
-    width: 62.5% !important;
-  }
-  .ui.grid > .row > [class*="eleven wide mobile"].column,
-  .ui.grid > .column.row > [class*="eleven wide mobile"].column,
-  .ui.grid > [class*="eleven wide mobile"].column,
-  .ui.column.grid > [class*="eleven wide mobile"].column {
-    width: 68.75% !important;
-  }
-  .ui.grid > .row > [class*="twelve wide mobile"].column,
-  .ui.grid > .column.row > [class*="twelve wide mobile"].column,
-  .ui.grid > [class*="twelve wide mobile"].column,
-  .ui.column.grid > [class*="twelve wide mobile"].column {
-    width: 75% !important;
-  }
-  .ui.grid > .row > [class*="thirteen wide mobile"].column,
-  .ui.grid > .column.row > [class*="thirteen wide mobile"].column,
-  .ui.grid > [class*="thirteen wide mobile"].column,
-  .ui.column.grid > [class*="thirteen wide mobile"].column {
-    width: 81.25% !important;
-  }
-  .ui.grid > .row > [class*="fourteen wide mobile"].column,
-  .ui.grid > .column.row > [class*="fourteen wide mobile"].column,
-  .ui.grid > [class*="fourteen wide mobile"].column,
-  .ui.column.grid > [class*="fourteen wide mobile"].column {
-    width: 87.5% !important;
-  }
-  .ui.grid > .row > [class*="fifteen wide mobile"].column,
-  .ui.grid > .column.row > [class*="fifteen wide mobile"].column,
-  .ui.grid > [class*="fifteen wide mobile"].column,
-  .ui.column.grid > [class*="fifteen wide mobile"].column {
-    width: 93.75% !important;
-  }
-  .ui.grid > .row > [class*="sixteen wide mobile"].column,
-  .ui.grid > .column.row > [class*="sixteen wide mobile"].column,
-  .ui.grid > [class*="sixteen wide mobile"].column,
-  .ui.column.grid > [class*="sixteen wide mobile"].column {
-    width: 100% !important;
-  }
+    .ui.grid > .row > [class*="one wide mobile"].column,
+    .ui.grid > .column.row > [class*="one wide mobile"].column,
+    .ui.grid > [class*="one wide mobile"].column,
+    .ui.column.grid > [class*="one wide mobile"].column {
+        width: 6.25% !important;
+    }
+    .ui.grid > .row > [class*="two wide mobile"].column,
+    .ui.grid > .column.row > [class*="two wide mobile"].column,
+    .ui.grid > [class*="two wide mobile"].column,
+    .ui.column.grid > [class*="two wide mobile"].column {
+        width: 12.5% !important;
+    }
+    .ui.grid > .row > [class*="three wide mobile"].column,
+    .ui.grid > .column.row > [class*="three wide mobile"].column,
+    .ui.grid > [class*="three wide mobile"].column,
+    .ui.column.grid > [class*="three wide mobile"].column {
+        width: 18.75% !important;
+    }
+    .ui.grid > .row > [class*="four wide mobile"].column,
+    .ui.grid > .column.row > [class*="four wide mobile"].column,
+    .ui.grid > [class*="four wide mobile"].column,
+    .ui.column.grid > [class*="four wide mobile"].column {
+        width: 25% !important;
+    }
+    .ui.grid > .row > [class*="five wide mobile"].column,
+    .ui.grid > .column.row > [class*="five wide mobile"].column,
+    .ui.grid > [class*="five wide mobile"].column,
+    .ui.column.grid > [class*="five wide mobile"].column {
+        width: 31.25% !important;
+    }
+    .ui.grid > .row > [class*="six wide mobile"].column,
+    .ui.grid > .column.row > [class*="six wide mobile"].column,
+    .ui.grid > [class*="six wide mobile"].column,
+    .ui.column.grid > [class*="six wide mobile"].column {
+        width: 37.5% !important;
+    }
+    .ui.grid > .row > [class*="seven wide mobile"].column,
+    .ui.grid > .column.row > [class*="seven wide mobile"].column,
+    .ui.grid > [class*="seven wide mobile"].column,
+    .ui.column.grid > [class*="seven wide mobile"].column {
+        width: 43.75% !important;
+    }
+    .ui.grid > .row > [class*="eight wide mobile"].column,
+    .ui.grid > .column.row > [class*="eight wide mobile"].column,
+    .ui.grid > [class*="eight wide mobile"].column,
+    .ui.column.grid > [class*="eight wide mobile"].column {
+        width: 50% !important;
+    }
+    .ui.grid > .row > [class*="nine wide mobile"].column,
+    .ui.grid > .column.row > [class*="nine wide mobile"].column,
+    .ui.grid > [class*="nine wide mobile"].column,
+    .ui.column.grid > [class*="nine wide mobile"].column {
+        width: 56.25% !important;
+    }
+    .ui.grid > .row > [class*="ten wide mobile"].column,
+    .ui.grid > .column.row > [class*="ten wide mobile"].column,
+    .ui.grid > [class*="ten wide mobile"].column,
+    .ui.column.grid > [class*="ten wide mobile"].column {
+        width: 62.5% !important;
+    }
+    .ui.grid > .row > [class*="eleven wide mobile"].column,
+    .ui.grid > .column.row > [class*="eleven wide mobile"].column,
+    .ui.grid > [class*="eleven wide mobile"].column,
+    .ui.column.grid > [class*="eleven wide mobile"].column {
+        width: 68.75% !important;
+    }
+    .ui.grid > .row > [class*="twelve wide mobile"].column,
+    .ui.grid > .column.row > [class*="twelve wide mobile"].column,
+    .ui.grid > [class*="twelve wide mobile"].column,
+    .ui.column.grid > [class*="twelve wide mobile"].column {
+        width: 75% !important;
+    }
+    .ui.grid > .row > [class*="thirteen wide mobile"].column,
+    .ui.grid > .column.row > [class*="thirteen wide mobile"].column,
+    .ui.grid > [class*="thirteen wide mobile"].column,
+    .ui.column.grid > [class*="thirteen wide mobile"].column {
+        width: 81.25% !important;
+    }
+    .ui.grid > .row > [class*="fourteen wide mobile"].column,
+    .ui.grid > .column.row > [class*="fourteen wide mobile"].column,
+    .ui.grid > [class*="fourteen wide mobile"].column,
+    .ui.column.grid > [class*="fourteen wide mobile"].column {
+        width: 87.5% !important;
+    }
+    .ui.grid > .row > [class*="fifteen wide mobile"].column,
+    .ui.grid > .column.row > [class*="fifteen wide mobile"].column,
+    .ui.grid > [class*="fifteen wide mobile"].column,
+    .ui.column.grid > [class*="fifteen wide mobile"].column {
+        width: 93.75% !important;
+    }
+    .ui.grid > .row > [class*="sixteen wide mobile"].column,
+    .ui.grid > .column.row > [class*="sixteen wide mobile"].column,
+    .ui.grid > [class*="sixteen wide mobile"].column,
+    .ui.column.grid > [class*="sixteen wide mobile"].column {
+        width: 100% !important;
+    }
 }
 
 /* Tablet Sizing Combinations */
 @media only screen and (min-width: 768px) and (max-width: 991.98px) {
-  .ui.grid > .row > [class*="one wide tablet"].column,
-  .ui.grid > .column.row > [class*="one wide tablet"].column,
-  .ui.grid > [class*="one wide tablet"].column,
-  .ui.column.grid > [class*="one wide tablet"].column {
-    width: 6.25% !important;
-  }
-  .ui.grid > .row > [class*="two wide tablet"].column,
-  .ui.grid > .column.row > [class*="two wide tablet"].column,
-  .ui.grid > [class*="two wide tablet"].column,
-  .ui.column.grid > [class*="two wide tablet"].column {
-    width: 12.5% !important;
-  }
-  .ui.grid > .row > [class*="three wide tablet"].column,
-  .ui.grid > .column.row > [class*="three wide tablet"].column,
-  .ui.grid > [class*="three wide tablet"].column,
-  .ui.column.grid > [class*="three wide tablet"].column {
-    width: 18.75% !important;
-  }
-  .ui.grid > .row > [class*="four wide tablet"].column,
-  .ui.grid > .column.row > [class*="four wide tablet"].column,
-  .ui.grid > [class*="four wide tablet"].column,
-  .ui.column.grid > [class*="four wide tablet"].column {
-    width: 25% !important;
-  }
-  .ui.grid > .row > [class*="five wide tablet"].column,
-  .ui.grid > .column.row > [class*="five wide tablet"].column,
-  .ui.grid > [class*="five wide tablet"].column,
-  .ui.column.grid > [class*="five wide tablet"].column {
-    width: 31.25% !important;
-  }
-  .ui.grid > .row > [class*="six wide tablet"].column,
-  .ui.grid > .column.row > [class*="six wide tablet"].column,
-  .ui.grid > [class*="six wide tablet"].column,
-  .ui.column.grid > [class*="six wide tablet"].column {
-    width: 37.5% !important;
-  }
-  .ui.grid > .row > [class*="seven wide tablet"].column,
-  .ui.grid > .column.row > [class*="seven wide tablet"].column,
-  .ui.grid > [class*="seven wide tablet"].column,
-  .ui.column.grid > [class*="seven wide tablet"].column {
-    width: 43.75% !important;
-  }
-  .ui.grid > .row > [class*="eight wide tablet"].column,
-  .ui.grid > .column.row > [class*="eight wide tablet"].column,
-  .ui.grid > [class*="eight wide tablet"].column,
-  .ui.column.grid > [class*="eight wide tablet"].column {
-    width: 50% !important;
-  }
-  .ui.grid > .row > [class*="nine wide tablet"].column,
-  .ui.grid > .column.row > [class*="nine wide tablet"].column,
-  .ui.grid > [class*="nine wide tablet"].column,
-  .ui.column.grid > [class*="nine wide tablet"].column {
-    width: 56.25% !important;
-  }
-  .ui.grid > .row > [class*="ten wide tablet"].column,
-  .ui.grid > .column.row > [class*="ten wide tablet"].column,
-  .ui.grid > [class*="ten wide tablet"].column,
-  .ui.column.grid > [class*="ten wide tablet"].column {
-    width: 62.5% !important;
-  }
-  .ui.grid > .row > [class*="eleven wide tablet"].column,
-  .ui.grid > .column.row > [class*="eleven wide tablet"].column,
-  .ui.grid > [class*="eleven wide tablet"].column,
-  .ui.column.grid > [class*="eleven wide tablet"].column {
-    width: 68.75% !important;
-  }
-  .ui.grid > .row > [class*="twelve wide tablet"].column,
-  .ui.grid > .column.row > [class*="twelve wide tablet"].column,
-  .ui.grid > [class*="twelve wide tablet"].column,
-  .ui.column.grid > [class*="twelve wide tablet"].column {
-    width: 75% !important;
-  }
-  .ui.grid > .row > [class*="thirteen wide tablet"].column,
-  .ui.grid > .column.row > [class*="thirteen wide tablet"].column,
-  .ui.grid > [class*="thirteen wide tablet"].column,
-  .ui.column.grid > [class*="thirteen wide tablet"].column {
-    width: 81.25% !important;
-  }
-  .ui.grid > .row > [class*="fourteen wide tablet"].column,
-  .ui.grid > .column.row > [class*="fourteen wide tablet"].column,
-  .ui.grid > [class*="fourteen wide tablet"].column,
-  .ui.column.grid > [class*="fourteen wide tablet"].column {
-    width: 87.5% !important;
-  }
-  .ui.grid > .row > [class*="fifteen wide tablet"].column,
-  .ui.grid > .column.row > [class*="fifteen wide tablet"].column,
-  .ui.grid > [class*="fifteen wide tablet"].column,
-  .ui.column.grid > [class*="fifteen wide tablet"].column {
-    width: 93.75% !important;
-  }
-  .ui.grid > .row > [class*="sixteen wide tablet"].column,
-  .ui.grid > .column.row > [class*="sixteen wide tablet"].column,
-  .ui.grid > [class*="sixteen wide tablet"].column,
-  .ui.column.grid > [class*="sixteen wide tablet"].column {
-    width: 100% !important;
-  }
+    .ui.grid > .row > [class*="one wide tablet"].column,
+    .ui.grid > .column.row > [class*="one wide tablet"].column,
+    .ui.grid > [class*="one wide tablet"].column,
+    .ui.column.grid > [class*="one wide tablet"].column {
+        width: 6.25% !important;
+    }
+    .ui.grid > .row > [class*="two wide tablet"].column,
+    .ui.grid > .column.row > [class*="two wide tablet"].column,
+    .ui.grid > [class*="two wide tablet"].column,
+    .ui.column.grid > [class*="two wide tablet"].column {
+        width: 12.5% !important;
+    }
+    .ui.grid > .row > [class*="three wide tablet"].column,
+    .ui.grid > .column.row > [class*="three wide tablet"].column,
+    .ui.grid > [class*="three wide tablet"].column,
+    .ui.column.grid > [class*="three wide tablet"].column {
+        width: 18.75% !important;
+    }
+    .ui.grid > .row > [class*="four wide tablet"].column,
+    .ui.grid > .column.row > [class*="four wide tablet"].column,
+    .ui.grid > [class*="four wide tablet"].column,
+    .ui.column.grid > [class*="four wide tablet"].column {
+        width: 25% !important;
+    }
+    .ui.grid > .row > [class*="five wide tablet"].column,
+    .ui.grid > .column.row > [class*="five wide tablet"].column,
+    .ui.grid > [class*="five wide tablet"].column,
+    .ui.column.grid > [class*="five wide tablet"].column {
+        width: 31.25% !important;
+    }
+    .ui.grid > .row > [class*="six wide tablet"].column,
+    .ui.grid > .column.row > [class*="six wide tablet"].column,
+    .ui.grid > [class*="six wide tablet"].column,
+    .ui.column.grid > [class*="six wide tablet"].column {
+        width: 37.5% !important;
+    }
+    .ui.grid > .row > [class*="seven wide tablet"].column,
+    .ui.grid > .column.row > [class*="seven wide tablet"].column,
+    .ui.grid > [class*="seven wide tablet"].column,
+    .ui.column.grid > [class*="seven wide tablet"].column {
+        width: 43.75% !important;
+    }
+    .ui.grid > .row > [class*="eight wide tablet"].column,
+    .ui.grid > .column.row > [class*="eight wide tablet"].column,
+    .ui.grid > [class*="eight wide tablet"].column,
+    .ui.column.grid > [class*="eight wide tablet"].column {
+        width: 50% !important;
+    }
+    .ui.grid > .row > [class*="nine wide tablet"].column,
+    .ui.grid > .column.row > [class*="nine wide tablet"].column,
+    .ui.grid > [class*="nine wide tablet"].column,
+    .ui.column.grid > [class*="nine wide tablet"].column {
+        width: 56.25% !important;
+    }
+    .ui.grid > .row > [class*="ten wide tablet"].column,
+    .ui.grid > .column.row > [class*="ten wide tablet"].column,
+    .ui.grid > [class*="ten wide tablet"].column,
+    .ui.column.grid > [class*="ten wide tablet"].column {
+        width: 62.5% !important;
+    }
+    .ui.grid > .row > [class*="eleven wide tablet"].column,
+    .ui.grid > .column.row > [class*="eleven wide tablet"].column,
+    .ui.grid > [class*="eleven wide tablet"].column,
+    .ui.column.grid > [class*="eleven wide tablet"].column {
+        width: 68.75% !important;
+    }
+    .ui.grid > .row > [class*="twelve wide tablet"].column,
+    .ui.grid > .column.row > [class*="twelve wide tablet"].column,
+    .ui.grid > [class*="twelve wide tablet"].column,
+    .ui.column.grid > [class*="twelve wide tablet"].column {
+        width: 75% !important;
+    }
+    .ui.grid > .row > [class*="thirteen wide tablet"].column,
+    .ui.grid > .column.row > [class*="thirteen wide tablet"].column,
+    .ui.grid > [class*="thirteen wide tablet"].column,
+    .ui.column.grid > [class*="thirteen wide tablet"].column {
+        width: 81.25% !important;
+    }
+    .ui.grid > .row > [class*="fourteen wide tablet"].column,
+    .ui.grid > .column.row > [class*="fourteen wide tablet"].column,
+    .ui.grid > [class*="fourteen wide tablet"].column,
+    .ui.column.grid > [class*="fourteen wide tablet"].column {
+        width: 87.5% !important;
+    }
+    .ui.grid > .row > [class*="fifteen wide tablet"].column,
+    .ui.grid > .column.row > [class*="fifteen wide tablet"].column,
+    .ui.grid > [class*="fifteen wide tablet"].column,
+    .ui.column.grid > [class*="fifteen wide tablet"].column {
+        width: 93.75% !important;
+    }
+    .ui.grid > .row > [class*="sixteen wide tablet"].column,
+    .ui.grid > .column.row > [class*="sixteen wide tablet"].column,
+    .ui.grid > [class*="sixteen wide tablet"].column,
+    .ui.column.grid > [class*="sixteen wide tablet"].column {
+        width: 100% !important;
+    }
 }
 
 /* Computer/Desktop Sizing Combinations */
 @media only screen and (min-width: 992px) {
-  .ui.grid > .row > [class*="one wide computer"].column,
-  .ui.grid > .column.row > [class*="one wide computer"].column,
-  .ui.grid > [class*="one wide computer"].column,
-  .ui.column.grid > [class*="one wide computer"].column {
-    width: 6.25% !important;
-  }
-  .ui.grid > .row > [class*="two wide computer"].column,
-  .ui.grid > .column.row > [class*="two wide computer"].column,
-  .ui.grid > [class*="two wide computer"].column,
-  .ui.column.grid > [class*="two wide computer"].column {
-    width: 12.5% !important;
-  }
-  .ui.grid > .row > [class*="three wide computer"].column,
-  .ui.grid > .column.row > [class*="three wide computer"].column,
-  .ui.grid > [class*="three wide computer"].column,
-  .ui.column.grid > [class*="three wide computer"].column {
-    width: 18.75% !important;
-  }
-  .ui.grid > .row > [class*="four wide computer"].column,
-  .ui.grid > .column.row > [class*="four wide computer"].column,
-  .ui.grid > [class*="four wide computer"].column,
-  .ui.column.grid > [class*="four wide computer"].column {
-    width: 25% !important;
-  }
-  .ui.grid > .row > [class*="five wide computer"].column,
-  .ui.grid > .column.row > [class*="five wide computer"].column,
-  .ui.grid > [class*="five wide computer"].column,
-  .ui.column.grid > [class*="five wide computer"].column {
-    width: 31.25% !important;
-  }
-  .ui.grid > .row > [class*="six wide computer"].column,
-  .ui.grid > .column.row > [class*="six wide computer"].column,
-  .ui.grid > [class*="six wide computer"].column,
-  .ui.column.grid > [class*="six wide computer"].column {
-    width: 37.5% !important;
-  }
-  .ui.grid > .row > [class*="seven wide computer"].column,
-  .ui.grid > .column.row > [class*="seven wide computer"].column,
-  .ui.grid > [class*="seven wide computer"].column,
-  .ui.column.grid > [class*="seven wide computer"].column {
-    width: 43.75% !important;
-  }
-  .ui.grid > .row > [class*="eight wide computer"].column,
-  .ui.grid > .column.row > [class*="eight wide computer"].column,
-  .ui.grid > [class*="eight wide computer"].column,
-  .ui.column.grid > [class*="eight wide computer"].column {
-    width: 50% !important;
-  }
-  .ui.grid > .row > [class*="nine wide computer"].column,
-  .ui.grid > .column.row > [class*="nine wide computer"].column,
-  .ui.grid > [class*="nine wide computer"].column,
-  .ui.column.grid > [class*="nine wide computer"].column {
-    width: 56.25% !important;
-  }
-  .ui.grid > .row > [class*="ten wide computer"].column,
-  .ui.grid > .column.row > [class*="ten wide computer"].column,
-  .ui.grid > [class*="ten wide computer"].column,
-  .ui.column.grid > [class*="ten wide computer"].column {
-    width: 62.5% !important;
-  }
-  .ui.grid > .row > [class*="eleven wide computer"].column,
-  .ui.grid > .column.row > [class*="eleven wide computer"].column,
-  .ui.grid > [class*="eleven wide computer"].column,
-  .ui.column.grid > [class*="eleven wide computer"].column {
-    width: 68.75% !important;
-  }
-  .ui.grid > .row > [class*="twelve wide computer"].column,
-  .ui.grid > .column.row > [class*="twelve wide computer"].column,
-  .ui.grid > [class*="twelve wide computer"].column,
-  .ui.column.grid > [class*="twelve wide computer"].column {
-    width: 75% !important;
-  }
-  .ui.grid > .row > [class*="thirteen wide computer"].column,
-  .ui.grid > .column.row > [class*="thirteen wide computer"].column,
-  .ui.grid > [class*="thirteen wide computer"].column,
-  .ui.column.grid > [class*="thirteen wide computer"].column {
-    width: 81.25% !important;
-  }
-  .ui.grid > .row > [class*="fourteen wide computer"].column,
-  .ui.grid > .column.row > [class*="fourteen wide computer"].column,
-  .ui.grid > [class*="fourteen wide computer"].column,
-  .ui.column.grid > [class*="fourteen wide computer"].column {
-    width: 87.5% !important;
-  }
-  .ui.grid > .row > [class*="fifteen wide computer"].column,
-  .ui.grid > .column.row > [class*="fifteen wide computer"].column,
-  .ui.grid > [class*="fifteen wide computer"].column,
-  .ui.column.grid > [class*="fifteen wide computer"].column {
-    width: 93.75% !important;
-  }
-  .ui.grid > .row > [class*="sixteen wide computer"].column,
-  .ui.grid > .column.row > [class*="sixteen wide computer"].column,
-  .ui.grid > [class*="sixteen wide computer"].column,
-  .ui.column.grid > [class*="sixteen wide computer"].column {
-    width: 100% !important;
-  }
+    .ui.grid > .row > [class*="one wide computer"].column,
+    .ui.grid > .column.row > [class*="one wide computer"].column,
+    .ui.grid > [class*="one wide computer"].column,
+    .ui.column.grid > [class*="one wide computer"].column {
+        width: 6.25% !important;
+    }
+    .ui.grid > .row > [class*="two wide computer"].column,
+    .ui.grid > .column.row > [class*="two wide computer"].column,
+    .ui.grid > [class*="two wide computer"].column,
+    .ui.column.grid > [class*="two wide computer"].column {
+        width: 12.5% !important;
+    }
+    .ui.grid > .row > [class*="three wide computer"].column,
+    .ui.grid > .column.row > [class*="three wide computer"].column,
+    .ui.grid > [class*="three wide computer"].column,
+    .ui.column.grid > [class*="three wide computer"].column {
+        width: 18.75% !important;
+    }
+    .ui.grid > .row > [class*="four wide computer"].column,
+    .ui.grid > .column.row > [class*="four wide computer"].column,
+    .ui.grid > [class*="four wide computer"].column,
+    .ui.column.grid > [class*="four wide computer"].column {
+        width: 25% !important;
+    }
+    .ui.grid > .row > [class*="five wide computer"].column,
+    .ui.grid > .column.row > [class*="five wide computer"].column,
+    .ui.grid > [class*="five wide computer"].column,
+    .ui.column.grid > [class*="five wide computer"].column {
+        width: 31.25% !important;
+    }
+    .ui.grid > .row > [class*="six wide computer"].column,
+    .ui.grid > .column.row > [class*="six wide computer"].column,
+    .ui.grid > [class*="six wide computer"].column,
+    .ui.column.grid > [class*="six wide computer"].column {
+        width: 37.5% !important;
+    }
+    .ui.grid > .row > [class*="seven wide computer"].column,
+    .ui.grid > .column.row > [class*="seven wide computer"].column,
+    .ui.grid > [class*="seven wide computer"].column,
+    .ui.column.grid > [class*="seven wide computer"].column {
+        width: 43.75% !important;
+    }
+    .ui.grid > .row > [class*="eight wide computer"].column,
+    .ui.grid > .column.row > [class*="eight wide computer"].column,
+    .ui.grid > [class*="eight wide computer"].column,
+    .ui.column.grid > [class*="eight wide computer"].column {
+        width: 50% !important;
+    }
+    .ui.grid > .row > [class*="nine wide computer"].column,
+    .ui.grid > .column.row > [class*="nine wide computer"].column,
+    .ui.grid > [class*="nine wide computer"].column,
+    .ui.column.grid > [class*="nine wide computer"].column {
+        width: 56.25% !important;
+    }
+    .ui.grid > .row > [class*="ten wide computer"].column,
+    .ui.grid > .column.row > [class*="ten wide computer"].column,
+    .ui.grid > [class*="ten wide computer"].column,
+    .ui.column.grid > [class*="ten wide computer"].column {
+        width: 62.5% !important;
+    }
+    .ui.grid > .row > [class*="eleven wide computer"].column,
+    .ui.grid > .column.row > [class*="eleven wide computer"].column,
+    .ui.grid > [class*="eleven wide computer"].column,
+    .ui.column.grid > [class*="eleven wide computer"].column {
+        width: 68.75% !important;
+    }
+    .ui.grid > .row > [class*="twelve wide computer"].column,
+    .ui.grid > .column.row > [class*="twelve wide computer"].column,
+    .ui.grid > [class*="twelve wide computer"].column,
+    .ui.column.grid > [class*="twelve wide computer"].column {
+        width: 75% !important;
+    }
+    .ui.grid > .row > [class*="thirteen wide computer"].column,
+    .ui.grid > .column.row > [class*="thirteen wide computer"].column,
+    .ui.grid > [class*="thirteen wide computer"].column,
+    .ui.column.grid > [class*="thirteen wide computer"].column {
+        width: 81.25% !important;
+    }
+    .ui.grid > .row > [class*="fourteen wide computer"].column,
+    .ui.grid > .column.row > [class*="fourteen wide computer"].column,
+    .ui.grid > [class*="fourteen wide computer"].column,
+    .ui.column.grid > [class*="fourteen wide computer"].column {
+        width: 87.5% !important;
+    }
+    .ui.grid > .row > [class*="fifteen wide computer"].column,
+    .ui.grid > .column.row > [class*="fifteen wide computer"].column,
+    .ui.grid > [class*="fifteen wide computer"].column,
+    .ui.column.grid > [class*="fifteen wide computer"].column {
+        width: 93.75% !important;
+    }
+    .ui.grid > .row > [class*="sixteen wide computer"].column,
+    .ui.grid > .column.row > [class*="sixteen wide computer"].column,
+    .ui.grid > [class*="sixteen wide computer"].column,
+    .ui.column.grid > [class*="sixteen wide computer"].column {
+        width: 100% !important;
+    }
 }
 
 /* Large Monitor Sizing Combinations */
 @media only screen and (min-width: 1200px) and (max-width: 1919.98px) {
-  .ui.grid > .row > [class*="one wide large screen"].column,
-  .ui.grid > .column.row > [class*="one wide large screen"].column,
-  .ui.grid > [class*="one wide large screen"].column,
-  .ui.column.grid > [class*="one wide large screen"].column {
-    width: 6.25% !important;
-  }
-  .ui.grid > .row > [class*="two wide large screen"].column,
-  .ui.grid > .column.row > [class*="two wide large screen"].column,
-  .ui.grid > [class*="two wide large screen"].column,
-  .ui.column.grid > [class*="two wide large screen"].column {
-    width: 12.5% !important;
-  }
-  .ui.grid > .row > [class*="three wide large screen"].column,
-  .ui.grid > .column.row > [class*="three wide large screen"].column,
-  .ui.grid > [class*="three wide large screen"].column,
-  .ui.column.grid > [class*="three wide large screen"].column {
-    width: 18.75% !important;
-  }
-  .ui.grid > .row > [class*="four wide large screen"].column,
-  .ui.grid > .column.row > [class*="four wide large screen"].column,
-  .ui.grid > [class*="four wide large screen"].column,
-  .ui.column.grid > [class*="four wide large screen"].column {
-    width: 25% !important;
-  }
-  .ui.grid > .row > [class*="five wide large screen"].column,
-  .ui.grid > .column.row > [class*="five wide large screen"].column,
-  .ui.grid > [class*="five wide large screen"].column,
-  .ui.column.grid > [class*="five wide large screen"].column {
-    width: 31.25% !important;
-  }
-  .ui.grid > .row > [class*="six wide large screen"].column,
-  .ui.grid > .column.row > [class*="six wide large screen"].column,
-  .ui.grid > [class*="six wide large screen"].column,
-  .ui.column.grid > [class*="six wide large screen"].column {
-    width: 37.5% !important;
-  }
-  .ui.grid > .row > [class*="seven wide large screen"].column,
-  .ui.grid > .column.row > [class*="seven wide large screen"].column,
-  .ui.grid > [class*="seven wide large screen"].column,
-  .ui.column.grid > [class*="seven wide large screen"].column {
-    width: 43.75% !important;
-  }
-  .ui.grid > .row > [class*="eight wide large screen"].column,
-  .ui.grid > .column.row > [class*="eight wide large screen"].column,
-  .ui.grid > [class*="eight wide large screen"].column,
-  .ui.column.grid > [class*="eight wide large screen"].column {
-    width: 50% !important;
-  }
-  .ui.grid > .row > [class*="nine wide large screen"].column,
-  .ui.grid > .column.row > [class*="nine wide large screen"].column,
-  .ui.grid > [class*="nine wide large screen"].column,
-  .ui.column.grid > [class*="nine wide large screen"].column {
-    width: 56.25% !important;
-  }
-  .ui.grid > .row > [class*="ten wide large screen"].column,
-  .ui.grid > .column.row > [class*="ten wide large screen"].column,
-  .ui.grid > [class*="ten wide large screen"].column,
-  .ui.column.grid > [class*="ten wide large screen"].column {
-    width: 62.5% !important;
-  }
-  .ui.grid > .row > [class*="eleven wide large screen"].column,
-  .ui.grid > .column.row > [class*="eleven wide large screen"].column,
-  .ui.grid > [class*="eleven wide large screen"].column,
-  .ui.column.grid > [class*="eleven wide large screen"].column {
-    width: 68.75% !important;
-  }
-  .ui.grid > .row > [class*="twelve wide large screen"].column,
-  .ui.grid > .column.row > [class*="twelve wide large screen"].column,
-  .ui.grid > [class*="twelve wide large screen"].column,
-  .ui.column.grid > [class*="twelve wide large screen"].column {
-    width: 75% !important;
-  }
-  .ui.grid > .row > [class*="thirteen wide large screen"].column,
-  .ui.grid > .column.row > [class*="thirteen wide large screen"].column,
-  .ui.grid > [class*="thirteen wide large screen"].column,
-  .ui.column.grid > [class*="thirteen wide large screen"].column {
-    width: 81.25% !important;
-  }
-  .ui.grid > .row > [class*="fourteen wide large screen"].column,
-  .ui.grid > .column.row > [class*="fourteen wide large screen"].column,
-  .ui.grid > [class*="fourteen wide large screen"].column,
-  .ui.column.grid > [class*="fourteen wide large screen"].column {
-    width: 87.5% !important;
-  }
-  .ui.grid > .row > [class*="fifteen wide large screen"].column,
-  .ui.grid > .column.row > [class*="fifteen wide large screen"].column,
-  .ui.grid > [class*="fifteen wide large screen"].column,
-  .ui.column.grid > [class*="fifteen wide large screen"].column {
-    width: 93.75% !important;
-  }
-  .ui.grid > .row > [class*="sixteen wide large screen"].column,
-  .ui.grid > .column.row > [class*="sixteen wide large screen"].column,
-  .ui.grid > [class*="sixteen wide large screen"].column,
-  .ui.column.grid > [class*="sixteen wide large screen"].column {
-    width: 100% !important;
-  }
+    .ui.grid > .row > [class*="one wide large screen"].column,
+    .ui.grid > .column.row > [class*="one wide large screen"].column,
+    .ui.grid > [class*="one wide large screen"].column,
+    .ui.column.grid > [class*="one wide large screen"].column {
+        width: 6.25% !important;
+    }
+    .ui.grid > .row > [class*="two wide large screen"].column,
+    .ui.grid > .column.row > [class*="two wide large screen"].column,
+    .ui.grid > [class*="two wide large screen"].column,
+    .ui.column.grid > [class*="two wide large screen"].column {
+        width: 12.5% !important;
+    }
+    .ui.grid > .row > [class*="three wide large screen"].column,
+    .ui.grid > .column.row > [class*="three wide large screen"].column,
+    .ui.grid > [class*="three wide large screen"].column,
+    .ui.column.grid > [class*="three wide large screen"].column {
+        width: 18.75% !important;
+    }
+    .ui.grid > .row > [class*="four wide large screen"].column,
+    .ui.grid > .column.row > [class*="four wide large screen"].column,
+    .ui.grid > [class*="four wide large screen"].column,
+    .ui.column.grid > [class*="four wide large screen"].column {
+        width: 25% !important;
+    }
+    .ui.grid > .row > [class*="five wide large screen"].column,
+    .ui.grid > .column.row > [class*="five wide large screen"].column,
+    .ui.grid > [class*="five wide large screen"].column,
+    .ui.column.grid > [class*="five wide large screen"].column {
+        width: 31.25% !important;
+    }
+    .ui.grid > .row > [class*="six wide large screen"].column,
+    .ui.grid > .column.row > [class*="six wide large screen"].column,
+    .ui.grid > [class*="six wide large screen"].column,
+    .ui.column.grid > [class*="six wide large screen"].column {
+        width: 37.5% !important;
+    }
+    .ui.grid > .row > [class*="seven wide large screen"].column,
+    .ui.grid > .column.row > [class*="seven wide large screen"].column,
+    .ui.grid > [class*="seven wide large screen"].column,
+    .ui.column.grid > [class*="seven wide large screen"].column {
+        width: 43.75% !important;
+    }
+    .ui.grid > .row > [class*="eight wide large screen"].column,
+    .ui.grid > .column.row > [class*="eight wide large screen"].column,
+    .ui.grid > [class*="eight wide large screen"].column,
+    .ui.column.grid > [class*="eight wide large screen"].column {
+        width: 50% !important;
+    }
+    .ui.grid > .row > [class*="nine wide large screen"].column,
+    .ui.grid > .column.row > [class*="nine wide large screen"].column,
+    .ui.grid > [class*="nine wide large screen"].column,
+    .ui.column.grid > [class*="nine wide large screen"].column {
+        width: 56.25% !important;
+    }
+    .ui.grid > .row > [class*="ten wide large screen"].column,
+    .ui.grid > .column.row > [class*="ten wide large screen"].column,
+    .ui.grid > [class*="ten wide large screen"].column,
+    .ui.column.grid > [class*="ten wide large screen"].column {
+        width: 62.5% !important;
+    }
+    .ui.grid > .row > [class*="eleven wide large screen"].column,
+    .ui.grid > .column.row > [class*="eleven wide large screen"].column,
+    .ui.grid > [class*="eleven wide large screen"].column,
+    .ui.column.grid > [class*="eleven wide large screen"].column {
+        width: 68.75% !important;
+    }
+    .ui.grid > .row > [class*="twelve wide large screen"].column,
+    .ui.grid > .column.row > [class*="twelve wide large screen"].column,
+    .ui.grid > [class*="twelve wide large screen"].column,
+    .ui.column.grid > [class*="twelve wide large screen"].column {
+        width: 75% !important;
+    }
+    .ui.grid > .row > [class*="thirteen wide large screen"].column,
+    .ui.grid > .column.row > [class*="thirteen wide large screen"].column,
+    .ui.grid > [class*="thirteen wide large screen"].column,
+    .ui.column.grid > [class*="thirteen wide large screen"].column {
+        width: 81.25% !important;
+    }
+    .ui.grid > .row > [class*="fourteen wide large screen"].column,
+    .ui.grid > .column.row > [class*="fourteen wide large screen"].column,
+    .ui.grid > [class*="fourteen wide large screen"].column,
+    .ui.column.grid > [class*="fourteen wide large screen"].column {
+        width: 87.5% !important;
+    }
+    .ui.grid > .row > [class*="fifteen wide large screen"].column,
+    .ui.grid > .column.row > [class*="fifteen wide large screen"].column,
+    .ui.grid > [class*="fifteen wide large screen"].column,
+    .ui.column.grid > [class*="fifteen wide large screen"].column {
+        width: 93.75% !important;
+    }
+    .ui.grid > .row > [class*="sixteen wide large screen"].column,
+    .ui.grid > .column.row > [class*="sixteen wide large screen"].column,
+    .ui.grid > [class*="sixteen wide large screen"].column,
+    .ui.column.grid > [class*="sixteen wide large screen"].column {
+        width: 100% !important;
+    }
 }
 
 /* Widescreen Sizing Combinations */
 @media only screen and (min-width: 1920px) {
-  .ui.grid > .row > [class*="one wide widescreen"].column,
-  .ui.grid > .column.row > [class*="one wide widescreen"].column,
-  .ui.grid > [class*="one wide widescreen"].column,
-  .ui.column.grid > [class*="one wide widescreen"].column {
-    width: 6.25% !important;
-  }
-  .ui.grid > .row > [class*="two wide widescreen"].column,
-  .ui.grid > .column.row > [class*="two wide widescreen"].column,
-  .ui.grid > [class*="two wide widescreen"].column,
-  .ui.column.grid > [class*="two wide widescreen"].column {
-    width: 12.5% !important;
-  }
-  .ui.grid > .row > [class*="three wide widescreen"].column,
-  .ui.grid > .column.row > [class*="three wide widescreen"].column,
-  .ui.grid > [class*="three wide widescreen"].column,
-  .ui.column.grid > [class*="three wide widescreen"].column {
-    width: 18.75% !important;
-  }
-  .ui.grid > .row > [class*="four wide widescreen"].column,
-  .ui.grid > .column.row > [class*="four wide widescreen"].column,
-  .ui.grid > [class*="four wide widescreen"].column,
-  .ui.column.grid > [class*="four wide widescreen"].column {
-    width: 25% !important;
-  }
-  .ui.grid > .row > [class*="five wide widescreen"].column,
-  .ui.grid > .column.row > [class*="five wide widescreen"].column,
-  .ui.grid > [class*="five wide widescreen"].column,
-  .ui.column.grid > [class*="five wide widescreen"].column {
-    width: 31.25% !important;
-  }
-  .ui.grid > .row > [class*="six wide widescreen"].column,
-  .ui.grid > .column.row > [class*="six wide widescreen"].column,
-  .ui.grid > [class*="six wide widescreen"].column,
-  .ui.column.grid > [class*="six wide widescreen"].column {
-    width: 37.5% !important;
-  }
-  .ui.grid > .row > [class*="seven wide widescreen"].column,
-  .ui.grid > .column.row > [class*="seven wide widescreen"].column,
-  .ui.grid > [class*="seven wide widescreen"].column,
-  .ui.column.grid > [class*="seven wide widescreen"].column {
-    width: 43.75% !important;
-  }
-  .ui.grid > .row > [class*="eight wide widescreen"].column,
-  .ui.grid > .column.row > [class*="eight wide widescreen"].column,
-  .ui.grid > [class*="eight wide widescreen"].column,
-  .ui.column.grid > [class*="eight wide widescreen"].column {
-    width: 50% !important;
-  }
-  .ui.grid > .row > [class*="nine wide widescreen"].column,
-  .ui.grid > .column.row > [class*="nine wide widescreen"].column,
-  .ui.grid > [class*="nine wide widescreen"].column,
-  .ui.column.grid > [class*="nine wide widescreen"].column {
-    width: 56.25% !important;
-  }
-  .ui.grid > .row > [class*="ten wide widescreen"].column,
-  .ui.grid > .column.row > [class*="ten wide widescreen"].column,
-  .ui.grid > [class*="ten wide widescreen"].column,
-  .ui.column.grid > [class*="ten wide widescreen"].column {
-    width: 62.5% !important;
-  }
-  .ui.grid > .row > [class*="eleven wide widescreen"].column,
-  .ui.grid > .column.row > [class*="eleven wide widescreen"].column,
-  .ui.grid > [class*="eleven wide widescreen"].column,
-  .ui.column.grid > [class*="eleven wide widescreen"].column {
-    width: 68.75% !important;
-  }
-  .ui.grid > .row > [class*="twelve wide widescreen"].column,
-  .ui.grid > .column.row > [class*="twelve wide widescreen"].column,
-  .ui.grid > [class*="twelve wide widescreen"].column,
-  .ui.column.grid > [class*="twelve wide widescreen"].column {
-    width: 75% !important;
-  }
-  .ui.grid > .row > [class*="thirteen wide widescreen"].column,
-  .ui.grid > .column.row > [class*="thirteen wide widescreen"].column,
-  .ui.grid > [class*="thirteen wide widescreen"].column,
-  .ui.column.grid > [class*="thirteen wide widescreen"].column {
-    width: 81.25% !important;
-  }
-  .ui.grid > .row > [class*="fourteen wide widescreen"].column,
-  .ui.grid > .column.row > [class*="fourteen wide widescreen"].column,
-  .ui.grid > [class*="fourteen wide widescreen"].column,
-  .ui.column.grid > [class*="fourteen wide widescreen"].column {
-    width: 87.5% !important;
-  }
-  .ui.grid > .row > [class*="fifteen wide widescreen"].column,
-  .ui.grid > .column.row > [class*="fifteen wide widescreen"].column,
-  .ui.grid > [class*="fifteen wide widescreen"].column,
-  .ui.column.grid > [class*="fifteen wide widescreen"].column {
-    width: 93.75% !important;
-  }
-  .ui.grid > .row > [class*="sixteen wide widescreen"].column,
-  .ui.grid > .column.row > [class*="sixteen wide widescreen"].column,
-  .ui.grid > [class*="sixteen wide widescreen"].column,
-  .ui.column.grid > [class*="sixteen wide widescreen"].column {
-    width: 100% !important;
-  }
+    .ui.grid > .row > [class*="one wide widescreen"].column,
+    .ui.grid > .column.row > [class*="one wide widescreen"].column,
+    .ui.grid > [class*="one wide widescreen"].column,
+    .ui.column.grid > [class*="one wide widescreen"].column {
+        width: 6.25% !important;
+    }
+    .ui.grid > .row > [class*="two wide widescreen"].column,
+    .ui.grid > .column.row > [class*="two wide widescreen"].column,
+    .ui.grid > [class*="two wide widescreen"].column,
+    .ui.column.grid > [class*="two wide widescreen"].column {
+        width: 12.5% !important;
+    }
+    .ui.grid > .row > [class*="three wide widescreen"].column,
+    .ui.grid > .column.row > [class*="three wide widescreen"].column,
+    .ui.grid > [class*="three wide widescreen"].column,
+    .ui.column.grid > [class*="three wide widescreen"].column {
+        width: 18.75% !important;
+    }
+    .ui.grid > .row > [class*="four wide widescreen"].column,
+    .ui.grid > .column.row > [class*="four wide widescreen"].column,
+    .ui.grid > [class*="four wide widescreen"].column,
+    .ui.column.grid > [class*="four wide widescreen"].column {
+        width: 25% !important;
+    }
+    .ui.grid > .row > [class*="five wide widescreen"].column,
+    .ui.grid > .column.row > [class*="five wide widescreen"].column,
+    .ui.grid > [class*="five wide widescreen"].column,
+    .ui.column.grid > [class*="five wide widescreen"].column {
+        width: 31.25% !important;
+    }
+    .ui.grid > .row > [class*="six wide widescreen"].column,
+    .ui.grid > .column.row > [class*="six wide widescreen"].column,
+    .ui.grid > [class*="six wide widescreen"].column,
+    .ui.column.grid > [class*="six wide widescreen"].column {
+        width: 37.5% !important;
+    }
+    .ui.grid > .row > [class*="seven wide widescreen"].column,
+    .ui.grid > .column.row > [class*="seven wide widescreen"].column,
+    .ui.grid > [class*="seven wide widescreen"].column,
+    .ui.column.grid > [class*="seven wide widescreen"].column {
+        width: 43.75% !important;
+    }
+    .ui.grid > .row > [class*="eight wide widescreen"].column,
+    .ui.grid > .column.row > [class*="eight wide widescreen"].column,
+    .ui.grid > [class*="eight wide widescreen"].column,
+    .ui.column.grid > [class*="eight wide widescreen"].column {
+        width: 50% !important;
+    }
+    .ui.grid > .row > [class*="nine wide widescreen"].column,
+    .ui.grid > .column.row > [class*="nine wide widescreen"].column,
+    .ui.grid > [class*="nine wide widescreen"].column,
+    .ui.column.grid > [class*="nine wide widescreen"].column {
+        width: 56.25% !important;
+    }
+    .ui.grid > .row > [class*="ten wide widescreen"].column,
+    .ui.grid > .column.row > [class*="ten wide widescreen"].column,
+    .ui.grid > [class*="ten wide widescreen"].column,
+    .ui.column.grid > [class*="ten wide widescreen"].column {
+        width: 62.5% !important;
+    }
+    .ui.grid > .row > [class*="eleven wide widescreen"].column,
+    .ui.grid > .column.row > [class*="eleven wide widescreen"].column,
+    .ui.grid > [class*="eleven wide widescreen"].column,
+    .ui.column.grid > [class*="eleven wide widescreen"].column {
+        width: 68.75% !important;
+    }
+    .ui.grid > .row > [class*="twelve wide widescreen"].column,
+    .ui.grid > .column.row > [class*="twelve wide widescreen"].column,
+    .ui.grid > [class*="twelve wide widescreen"].column,
+    .ui.column.grid > [class*="twelve wide widescreen"].column {
+        width: 75% !important;
+    }
+    .ui.grid > .row > [class*="thirteen wide widescreen"].column,
+    .ui.grid > .column.row > [class*="thirteen wide widescreen"].column,
+    .ui.grid > [class*="thirteen wide widescreen"].column,
+    .ui.column.grid > [class*="thirteen wide widescreen"].column {
+        width: 81.25% !important;
+    }
+    .ui.grid > .row > [class*="fourteen wide widescreen"].column,
+    .ui.grid > .column.row > [class*="fourteen wide widescreen"].column,
+    .ui.grid > [class*="fourteen wide widescreen"].column,
+    .ui.column.grid > [class*="fourteen wide widescreen"].column {
+        width: 87.5% !important;
+    }
+    .ui.grid > .row > [class*="fifteen wide widescreen"].column,
+    .ui.grid > .column.row > [class*="fifteen wide widescreen"].column,
+    .ui.grid > [class*="fifteen wide widescreen"].column,
+    .ui.column.grid > [class*="fifteen wide widescreen"].column {
+        width: 93.75% !important;
+    }
+    .ui.grid > .row > [class*="sixteen wide widescreen"].column,
+    .ui.grid > .column.row > [class*="sixteen wide widescreen"].column,
+    .ui.grid > [class*="sixteen wide widescreen"].column,
+    .ui.column.grid > [class*="sixteen wide widescreen"].column {
+        width: 100% !important;
+    }
 }
 
 /* ----------------------
@@ -927,19 +924,19 @@
 .ui.centered.grid,
 .ui.centered.grid > .row,
 .ui.grid > .centered.row {
-  text-align: center;
-  justify-content: center;
+    text-align: center;
+    justify-content: center;
 }
 .ui.centered.grid > .column:not(.aligned):not(.justified):not(.row),
 .ui.centered.grid > .row > .column:not(.aligned):not(.justified),
 .ui.grid .centered.row > .column:not(.aligned):not(.justified) {
-  text-align: left;
+    text-align: left;
 }
 .ui.grid > .centered.column,
 .ui.grid > .row > .centered.column {
-  display: block;
-  margin-left: auto;
-  margin-right: auto;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 /* ----------------------
@@ -948,51 +945,51 @@
 .ui.relaxed.grid > .column:not(.row),
 .ui.relaxed.grid > .row > .column,
 .ui.grid > .relaxed.row > .column {
-  padding-left: 1.5rem;
-  padding-right: 1.5rem;
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
 }
 .ui[class*="very relaxed"].grid > .column:not(.row),
 .ui[class*="very relaxed"].grid > .row > .column,
 .ui.grid > [class*="very relaxed"].row > .column {
-  padding-left: 2.5rem;
-  padding-right: 2.5rem;
+    padding-left: 2.5rem;
+    padding-right: 2.5rem;
 }
 
 /* Coupling with UI Divider */
 .ui.relaxed.grid .row + .ui.divider,
 .ui.grid .relaxed.row + .ui.divider {
-  margin-left: 1.5rem;
-  margin-right: 1.5rem;
+    margin-left: 1.5rem;
+    margin-right: 1.5rem;
 }
 .ui[class*="very relaxed"].grid .row + .ui.divider,
 .ui.grid [class*="very relaxed"].row + .ui.divider {
-  margin-left: 2.5rem;
-  margin-right: 2.5rem;
+    margin-left: 2.5rem;
+    margin-right: 2.5rem;
 }
 
 /* ----------------------
             Padded
     ----------------------- */
 .ui.padded.grid:not(.vertically):not(.horizontally) {
-  margin: 0;
+    margin: 0;
 }
 [class*="horizontally padded"].ui.grid {
-  margin-left: 0;
-  margin-right: 0;
+    margin-left: 0;
+    margin-right: 0;
 }
 [class*="vertically padded"].ui.grid {
-  margin-top: 0;
-  margin-bottom: 0;
+    margin-top: 0;
+    margin-bottom: 0;
 }
 
 /* ----------------------
            "Floated"
     ----------------------- */
 .ui.grid [class*="left floated"].column {
-  margin-right: auto;
+    margin-right: auto;
 }
 .ui.grid [class*="right floated"].column {
-  margin-left: auto;
+    margin-left: auto;
 }
 
 /* ----------------------
@@ -1000,137 +997,143 @@
     ----------------------- */
 .ui.divided.grid:not([class*="vertically divided"]) > .column:not(.row),
 .ui.divided.grid:not([class*="vertically divided"]) > .row > .column {
-  box-shadow: -1px 0 0 0 rgba(34, 36, 38, 0.15);
+    box-shadow: -1px 0 0 0 rgba(34, 36, 38, 0.15);
 }
 
 /* Swap from padding to margin on columns to have dividers align */
 .ui[class*="vertically divided"].grid > .column:not(.row),
 .ui[class*="vertically divided"].grid > .row > .column {
-  margin-top: 1rem;
-  margin-bottom: 1rem;
-  padding-top: 0;
-  padding-bottom: 0;
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+    padding-top: 0;
+    padding-bottom: 0;
 }
 .ui[class*="vertically divided"].grid > .row {
-  margin-top: 0;
-  margin-bottom: 0;
+    margin-top: 0;
+    margin-bottom: 0;
 }
 
 /* No divider on first column on row */
 .ui.divided.grid:not([class*="vertically divided"]) > .column:first-child,
-.ui.divided.grid:not([class*="vertically divided"]) > .row > .column:first-child {
-  box-shadow: none;
+.ui.divided.grid:not([class*="vertically divided"])
+    > .row
+    > .column:first-child {
+    box-shadow: none;
 }
 
 /* No space on top of first row */
 .ui[class*="vertically divided"].grid > .row:first-child > .column {
-  margin-top: 0;
+    margin-top: 0;
 }
 
 /* Divided Row */
 .ui.grid > .divided.row > .column {
-  box-shadow: -1px 0 0 0 rgba(34, 36, 38, 0.15);
+    box-shadow: -1px 0 0 0 rgba(34, 36, 38, 0.15);
 }
 .ui.grid > .divided.row > .column:first-child {
-  box-shadow: none;
+    box-shadow: none;
 }
 
 /* Vertically Divided */
 .ui[class*="vertically divided"].grid > .row {
-  position: relative;
+    position: relative;
 }
 .ui[class*="vertically divided"].grid > .row::before {
-  position: absolute;
-  content: "";
-  top: 0;
-  left: 0;
-  width: calc(100% - 2rem);
-  height: 1px;
-  margin: 0 1rem;
-  box-shadow: 0 -1px 0 0 rgba(34, 36, 38, 0.15);
+    position: absolute;
+    content: "";
+    top: 0;
+    left: 0;
+    width: calc(100% - 2rem);
+    height: 1px;
+    margin: 0 1rem;
+    box-shadow: 0 -1px 0 0 rgba(34, 36, 38, 0.15);
 }
 
 /* Padded Horizontally Divided */
 [class*="horizontally padded"].ui.divided.grid,
 .ui.padded.divided.grid:not(.vertically):not(.horizontally) {
-  width: 100%;
+    width: 100%;
 }
 
 /* First Row Vertically Divided */
 .ui[class*="vertically divided"].grid > .row:first-child::before {
-  box-shadow: none;
+    box-shadow: none;
 }
 
 /* Inverted Divided */
-.ui.inverted.divided.grid:not([class*="vertically divided"]) > .column:not(.row),
+.ui.inverted.divided.grid:not([class*="vertically divided"])
+    > .column:not(.row),
 .ui.inverted.divided.grid:not([class*="vertically divided"]) > .row > .column {
-  box-shadow: -1px 0 0 0 rgba(255, 255, 255, 0.1);
+    box-shadow: -1px 0 0 0 rgba(255, 255, 255, 0.1);
 }
-.ui.inverted.divided.grid:not([class*="vertically divided"]) > .column:not(.row):first-child,
-.ui.inverted.divided.grid:not([class*="vertically divided"]) > .row > .column:first-child {
-  box-shadow: none;
+.ui.inverted.divided.grid:not([class*="vertically divided"])
+    > .column:not(.row):first-child,
+.ui.inverted.divided.grid:not([class*="vertically divided"])
+    > .row
+    > .column:first-child {
+    box-shadow: none;
 }
 .ui.inverted[class*="vertically divided"].grid > .row::before {
-  box-shadow: 0 -1px 0 0 rgba(255, 255, 255, 0.1);
+    box-shadow: 0 -1px 0 0 rgba(255, 255, 255, 0.1);
 }
 
 /* Relaxed */
 .ui.relaxed[class*="vertically divided"].grid > .row::before {
-  margin-left: 1.5rem;
-  margin-right: 1.5rem;
-  width: calc(100% - 3rem);
+    margin-left: 1.5rem;
+    margin-right: 1.5rem;
+    width: calc(100% - 3rem);
 }
 .ui[class*="very relaxed"][class*="vertically divided"].grid > .row::before {
-  margin-left: 2.5rem;
-  margin-right: 2.5rem;
-  width: calc(100% - 5rem);
+    margin-left: 2.5rem;
+    margin-right: 2.5rem;
+    width: calc(100% - 5rem);
 }
 
 /* ----------------------
              Celled
     ----------------------- */
 .ui.celled.grid {
-  width: 100%;
-  margin: 1em 0;
-  box-shadow: 0 0 0 1px #d4d4d5;
+    width: 100%;
+    margin: 1em 0;
+    box-shadow: 0 0 0 1px #d4d4d5;
 }
 .ui.celled.grid > .row {
-  width: 100% !important;
-  margin: 0;
-  padding: 0;
-  box-shadow: 0 -1px 0 0 #d4d4d5;
+    width: 100% !important;
+    margin: 0;
+    padding: 0;
+    box-shadow: 0 -1px 0 0 #d4d4d5;
 }
 .ui.celled.grid > .column:not(.row),
 .ui.celled.grid > .row > .column {
-  box-shadow: -1px 0 0 0 #d4d4d5;
+    box-shadow: -1px 0 0 0 #d4d4d5;
 }
 .ui.celled.grid > .column:first-child,
 .ui.celled.grid > .row > .column:first-child {
-  box-shadow: none;
+    box-shadow: none;
 }
 .ui.celled.grid > .column:not(.row),
 .ui.celled.grid > .row > .column {
-  padding: 1em;
+    padding: 1em;
 }
 .ui.relaxed.celled.grid > .column:not(.row),
 .ui.relaxed.celled.grid > .row > .column {
-  padding: 1.5em;
+    padding: 1.5em;
 }
 .ui[class*="very relaxed"].celled.grid > .column:not(.row),
 .ui[class*="very relaxed"].celled.grid > .row > .column {
-  padding: 2em;
+    padding: 2em;
 }
 
 /* Internally Celled */
 .ui[class*="internally celled"].grid {
-  box-shadow: none;
-  margin: 0;
+    box-shadow: none;
+    margin: 0;
 }
 .ui[class*="internally celled"].grid > .row:first-child {
-  box-shadow: none;
+    box-shadow: none;
 }
 .ui[class*="internally celled"].grid > .row > .column:first-child {
-  box-shadow: none;
+    box-shadow: none;
 }
 
 /* ----------------------
@@ -1143,9 +1146,9 @@
 .ui.grid > [class*="top aligned"].row > .column,
 .ui.grid > [class*="top aligned"].column:not(.row),
 .ui.grid > .row > [class*="top aligned"].column {
-  flex-direction: column;
-  vertical-align: top;
-  align-self: flex-start !important;
+    flex-direction: column;
+    vertical-align: top;
+    align-self: flex-start !important;
 }
 
 /* Middle Aligned */
@@ -1154,9 +1157,9 @@
 .ui.grid > [class*="middle aligned"].row > .column,
 .ui.grid > [class*="middle aligned"].column:not(.row),
 .ui.grid > .row > [class*="middle aligned"].column {
-  flex-direction: column;
-  vertical-align: middle;
-  align-self: center !important;
+    flex-direction: column;
+    vertical-align: middle;
+    align-self: center !important;
 }
 
 /* Bottom Aligned */
@@ -1165,9 +1168,9 @@
 .ui.grid > [class*="bottom aligned"].row > .column,
 .ui.grid > [class*="bottom aligned"].column:not(.row),
 .ui.grid > .row > [class*="bottom aligned"].column {
-  flex-direction: column;
-  vertical-align: bottom;
-  align-self: flex-end !important;
+    flex-direction: column;
+    vertical-align: bottom;
+    align-self: flex-end !important;
 }
 
 /* Stretched */
@@ -1176,16 +1179,16 @@
 .ui.grid > .stretched.row > .column,
 .ui.grid > .stretched.column:not(.row),
 .ui.grid > .row > .stretched.column {
-  display: inline-flex !important;
-  align-self: stretch;
-  flex-direction: column;
+    display: inline-flex !important;
+    align-self: stretch;
+    flex-direction: column;
 }
 .ui.stretched.grid > .row > .column > *,
 .ui.stretched.grid > .column > *,
 .ui.grid > .stretched.row > .column > *,
 .ui.grid > .stretched.column:not(.row) > *,
 .ui.grid > .row > .stretched.column > * {
-  flex-grow: 1;
+    flex-grow: 1;
 }
 
 /* ----------------------
@@ -1198,8 +1201,8 @@
 .ui.grid > [class*="left aligned"].row > .column,
 .ui.ui.grid > [class*="left aligned"].column,
 .ui.ui.grid > .row > [class*="left aligned"].column {
-  text-align: left;
-  align-self: inherit;
+    text-align: left;
+    align-self: inherit;
 }
 
 /* Center Aligned */
@@ -1208,11 +1211,11 @@
 .ui.grid > [class*="center aligned"].row > .column,
 .ui.ui.grid > [class*="center aligned"].column,
 .ui.ui.grid > .row > [class*="center aligned"].column {
-  text-align: center;
-  align-self: inherit;
+    text-align: center;
+    align-self: inherit;
 }
 .ui[class*="center aligned"].grid {
-  justify-content: center;
+    justify-content: center;
 }
 
 /* Right Aligned */
@@ -1221,8 +1224,8 @@
 .ui.grid > [class*="right aligned"].row > .column,
 .ui.ui.grid > [class*="right aligned"].column,
 .ui.ui.grid > .row > [class*="right aligned"].column {
-  text-align: right;
-  align-self: inherit;
+    text-align: right;
+    align-self: inherit;
 }
 
 /* Justified */
@@ -1231,10 +1234,10 @@
 .ui.grid > .justified.row > .column,
 .ui.ui.grid > .justified.column,
 .ui.ui.grid > .row > .justified.column {
-  text-align: justify;
-  -webkit-hyphens: auto;
-      -ms-hyphens: auto;
-          hyphens: auto;
+    text-align: justify;
+    -webkit-hyphens: auto;
+    -ms-hyphens: auto;
+    hyphens: auto;
 }
 
 /* ----------------------
@@ -1243,92 +1246,92 @@
 .ui.grid > .primary.row,
 .ui.grid > .primary.column,
 .ui.grid > .row > .primary.column {
-  background-color: #2185d0;
-  color: #fff;
+    background-color: #2185d0;
+    color: #fff;
 }
 .ui.grid > .secondary.row,
 .ui.grid > .secondary.column,
 .ui.grid > .row > .secondary.column {
-  background-color: #1b1c1d;
-  color: #fff;
+    background-color: #1b1c1d;
+    color: #fff;
 }
 .ui.grid > .red.row,
 .ui.grid > .red.column,
 .ui.grid > .row > .red.column {
-  background-color: #db2828;
-  color: #fff;
+    background-color: #db2828;
+    color: #fff;
 }
 .ui.grid > .orange.row,
 .ui.grid > .orange.column,
 .ui.grid > .row > .orange.column {
-  background-color: #f2711c;
-  color: #fff;
+    background-color: #f2711c;
+    color: #fff;
 }
 .ui.grid > .yellow.row,
 .ui.grid > .yellow.column,
 .ui.grid > .row > .yellow.column {
-  background-color: #fbbd08;
-  color: #fff;
+    background-color: #fbbd08;
+    color: #fff;
 }
 .ui.grid > .olive.row,
 .ui.grid > .olive.column,
 .ui.grid > .row > .olive.column {
-  background-color: #b5cc18;
-  color: #fff;
+    background-color: #b5cc18;
+    color: #fff;
 }
 .ui.grid > .green.row,
 .ui.grid > .green.column,
 .ui.grid > .row > .green.column {
-  background-color: #21ba45;
-  color: #fff;
+    background-color: #21ba45;
+    color: #fff;
 }
 .ui.grid > .teal.row,
 .ui.grid > .teal.column,
 .ui.grid > .row > .teal.column {
-  background-color: #00b5ad;
-  color: #fff;
+    background-color: #00b5ad;
+    color: #fff;
 }
 .ui.grid > .blue.row,
 .ui.grid > .blue.column,
 .ui.grid > .row > .blue.column {
-  background-color: #2185d0;
-  color: #fff;
+    background-color: #2185d0;
+    color: #fff;
 }
 .ui.grid > .violet.row,
 .ui.grid > .violet.column,
 .ui.grid > .row > .violet.column {
-  background-color: #6435c9;
-  color: #fff;
+    background-color: #6435c9;
+    color: #fff;
 }
 .ui.grid > .purple.row,
 .ui.grid > .purple.column,
 .ui.grid > .row > .purple.column {
-  background-color: #a333c8;
-  color: #fff;
+    background-color: #a333c8;
+    color: #fff;
 }
 .ui.grid > .pink.row,
 .ui.grid > .pink.column,
 .ui.grid > .row > .pink.column {
-  background-color: #e03997;
-  color: #fff;
+    background-color: #e03997;
+    color: #fff;
 }
 .ui.grid > .brown.row,
 .ui.grid > .brown.column,
 .ui.grid > .row > .brown.column {
-  background-color: #a5673f;
-  color: #fff;
+    background-color: #a5673f;
+    color: #fff;
 }
 .ui.grid > .grey.row,
 .ui.grid > .grey.column,
 .ui.grid > .row > .grey.column {
-  background-color: #767676;
-  color: #fff;
+    background-color: #767676;
+    color: #fff;
 }
 .ui.grid > .black.row,
 .ui.grid > .black.column,
 .ui.grid > .row > .black.column {
-  background-color: #1b1c1d;
-  color: #fff;
+    background-color: #1b1c1d;
+    color: #fff;
 }
 
 /* ----------------------
@@ -1337,13 +1340,13 @@
 .ui[class*="equal width"].grid > .column:not(.row),
 .ui[class*="equal width"].grid > .row > .column,
 .ui.grid > [class*="equal width"].row > .column {
-  display: inline-block;
-  flex-grow: 1;
+    display: inline-block;
+    flex-grow: 1;
 }
 .ui[class*="equal width"].grid > .wide.column,
 .ui[class*="equal width"].grid > .row > .wide.column,
 .ui.grid > [class*="equal width"].row > .wide.column {
-  flex-grow: 0;
+    flex-grow: 0;
 }
 
 /* ----------------------
@@ -1352,117 +1355,165 @@
 
 /* Mobile */
 @media only screen and (max-width: 767.98px) {
-  .ui[class*="mobile reversed"].grid,
-  .ui[class*="mobile reversed"].grid > .row,
-  .ui.grid > [class*="mobile reversed"].row {
-    flex-direction: row-reverse;
-  }
-  .ui[class*="mobile vertically reversed"].grid,
-  .ui.stackable[class*="mobile reversed"] {
-    flex-direction: column-reverse;
-  }
-  
-/* Divided Reversed */
-  .ui[class*="mobile reversed"].divided.grid:not([class*="vertically divided"]) > .column:first-child,
-  .ui[class*="mobile reversed"].divided.grid:not([class*="vertically divided"]) > .row > .column:first-child {
-    box-shadow: -1px 0 0 0 rgba(34, 36, 38, 0.15);
-  }
-  .ui[class*="mobile reversed"].divided.grid:not([class*="vertically divided"]) > .column:last-child,
-  .ui[class*="mobile reversed"].divided.grid:not([class*="vertically divided"]) > .row > .column:last-child {
-    box-shadow: none;
-  }
-  
-/* Vertically Divided Reversed */
-  .ui.grid[class*="vertically divided"][class*="mobile vertically reversed"] > .row:first-child::before {
-    box-shadow: 0 -1px 0 0 rgba(34, 36, 38, 0.15);
-  }
-  .ui.grid[class*="vertically divided"][class*="mobile vertically reversed"] > .row:last-child::before {
-    box-shadow: none;
-  }
-  
-/* Celled Reversed */
-  .ui[class*="mobile reversed"].celled.grid > .row > .column:first-child {
-    box-shadow: -1px 0 0 0 #d4d4d5;
-  }
-  .ui[class*="mobile reversed"].celled.grid > .row > .column:last-child {
-    box-shadow: none;
-  }
+    .ui[class*="mobile reversed"].grid,
+    .ui[class*="mobile reversed"].grid > .row,
+    .ui.grid > [class*="mobile reversed"].row {
+        flex-direction: row-reverse;
+    }
+    .ui[class*="mobile vertically reversed"].grid,
+    .ui.stackable[class*="mobile reversed"] {
+        flex-direction: column-reverse;
+    }
+
+    /* Divided Reversed */
+    .ui[class*="mobile reversed"].divided.grid:not(
+            [class*="vertically divided"]
+        )
+        > .column:first-child,
+    .ui[class*="mobile reversed"].divided.grid:not(
+            [class*="vertically divided"]
+        )
+        > .row
+        > .column:first-child {
+        box-shadow: -1px 0 0 0 rgba(34, 36, 38, 0.15);
+    }
+    .ui[class*="mobile reversed"].divided.grid:not(
+            [class*="vertically divided"]
+        )
+        > .column:last-child,
+    .ui[class*="mobile reversed"].divided.grid:not(
+            [class*="vertically divided"]
+        )
+        > .row
+        > .column:last-child {
+        box-shadow: none;
+    }
+
+    /* Vertically Divided Reversed */
+    .ui.grid[class*="vertically divided"][class*="mobile vertically reversed"]
+        > .row:first-child::before {
+        box-shadow: 0 -1px 0 0 rgba(34, 36, 38, 0.15);
+    }
+    .ui.grid[class*="vertically divided"][class*="mobile vertically reversed"]
+        > .row:last-child::before {
+        box-shadow: none;
+    }
+
+    /* Celled Reversed */
+    .ui[class*="mobile reversed"].celled.grid > .row > .column:first-child {
+        box-shadow: -1px 0 0 0 #d4d4d5;
+    }
+    .ui[class*="mobile reversed"].celled.grid > .row > .column:last-child {
+        box-shadow: none;
+    }
 }
 
 /* Tablet */
 @media only screen and (min-width: 768px) and (max-width: 991.98px) {
-  .ui[class*="tablet reversed"].grid,
-  .ui[class*="tablet reversed"].grid > .row,
-  .ui.grid > [class*="tablet reversed"].row {
-    flex-direction: row-reverse;
-  }
-  .ui[class*="tablet vertically reversed"].grid {
-    flex-direction: column-reverse;
-  }
-  
-/* Divided Reversed */
-  .ui[class*="tablet reversed"].divided.grid:not([class*="vertically divided"]) > .column:first-child,
-  .ui[class*="tablet reversed"].divided.grid:not([class*="vertically divided"]) > .row > .column:first-child {
-    box-shadow: -1px 0 0 0 rgba(34, 36, 38, 0.15);
-  }
-  .ui[class*="tablet reversed"].divided.grid:not([class*="vertically divided"]) > .column:last-child,
-  .ui[class*="tablet reversed"].divided.grid:not([class*="vertically divided"]) > .row > .column:last-child {
-    box-shadow: none;
-  }
-  
-/* Vertically Divided Reversed */
-  .ui.grid[class*="vertically divided"][class*="tablet vertically reversed"] > .row:first-child::before {
-    box-shadow: 0 -1px 0 0 rgba(34, 36, 38, 0.15);
-  }
-  .ui.grid[class*="vertically divided"][class*="tablet vertically reversed"] > .row:last-child::before {
-    box-shadow: none;
-  }
-  
-/* Celled Reversed */
-  .ui[class*="tablet reversed"].celled.grid > .row > .column:first-child {
-    box-shadow: -1px 0 0 0 #d4d4d5;
-  }
-  .ui[class*="tablet reversed"].celled.grid > .row > .column:last-child {
-    box-shadow: none;
-  }
+    .ui[class*="tablet reversed"].grid,
+    .ui[class*="tablet reversed"].grid > .row,
+    .ui.grid > [class*="tablet reversed"].row {
+        flex-direction: row-reverse;
+    }
+    .ui[class*="tablet vertically reversed"].grid {
+        flex-direction: column-reverse;
+    }
+
+    /* Divided Reversed */
+    .ui[class*="tablet reversed"].divided.grid:not(
+            [class*="vertically divided"]
+        )
+        > .column:first-child,
+    .ui[class*="tablet reversed"].divided.grid:not(
+            [class*="vertically divided"]
+        )
+        > .row
+        > .column:first-child {
+        box-shadow: -1px 0 0 0 rgba(34, 36, 38, 0.15);
+    }
+    .ui[class*="tablet reversed"].divided.grid:not(
+            [class*="vertically divided"]
+        )
+        > .column:last-child,
+    .ui[class*="tablet reversed"].divided.grid:not(
+            [class*="vertically divided"]
+        )
+        > .row
+        > .column:last-child {
+        box-shadow: none;
+    }
+
+    /* Vertically Divided Reversed */
+    .ui.grid[class*="vertically divided"][class*="tablet vertically reversed"]
+        > .row:first-child::before {
+        box-shadow: 0 -1px 0 0 rgba(34, 36, 38, 0.15);
+    }
+    .ui.grid[class*="vertically divided"][class*="tablet vertically reversed"]
+        > .row:last-child::before {
+        box-shadow: none;
+    }
+
+    /* Celled Reversed */
+    .ui[class*="tablet reversed"].celled.grid > .row > .column:first-child {
+        box-shadow: -1px 0 0 0 #d4d4d5;
+    }
+    .ui[class*="tablet reversed"].celled.grid > .row > .column:last-child {
+        box-shadow: none;
+    }
 }
 
 /* Computer */
 @media only screen and (min-width: 992px) {
-  .ui[class*="computer reversed"].grid,
-  .ui[class*="computer reversed"].grid > .row,
-  .ui.grid > [class*="computer reversed"].row {
-    flex-direction: row-reverse;
-  }
-  .ui[class*="computer vertically reversed"].grid {
-    flex-direction: column-reverse;
-  }
-  
-/* Divided Reversed */
-  .ui[class*="computer reversed"].divided.grid:not([class*="vertically divided"]) > .column:first-child,
-  .ui[class*="computer reversed"].divided.grid:not([class*="vertically divided"]) > .row > .column:first-child {
-    box-shadow: -1px 0 0 0 rgba(34, 36, 38, 0.15);
-  }
-  .ui[class*="computer reversed"].divided.grid:not([class*="vertically divided"]) > .column:last-child,
-  .ui[class*="computer reversed"].divided.grid:not([class*="vertically divided"]) > .row > .column:last-child {
-    box-shadow: none;
-  }
-  
-/* Vertically Divided Reversed */
-  .ui.grid[class*="vertically divided"][class*="computer vertically reversed"] > .row:first-child::before {
-    box-shadow: 0 -1px 0 0 rgba(34, 36, 38, 0.15);
-  }
-  .ui.grid[class*="vertically divided"][class*="computer vertically reversed"] > .row:last-child::before {
-    box-shadow: none;
-  }
-  
-/* Celled Reversed */
-  .ui[class*="computer reversed"].celled.grid > .row > .column:first-child {
-    box-shadow: -1px 0 0 0 #d4d4d5;
-  }
-  .ui[class*="computer reversed"].celled.grid > .row > .column:last-child {
-    box-shadow: none;
-  }
+    .ui[class*="computer reversed"].grid,
+    .ui[class*="computer reversed"].grid > .row,
+    .ui.grid > [class*="computer reversed"].row {
+        flex-direction: row-reverse;
+    }
+    .ui[class*="computer vertically reversed"].grid {
+        flex-direction: column-reverse;
+    }
+
+    /* Divided Reversed */
+    .ui[class*="computer reversed"].divided.grid:not(
+            [class*="vertically divided"]
+        )
+        > .column:first-child,
+    .ui[class*="computer reversed"].divided.grid:not(
+            [class*="vertically divided"]
+        )
+        > .row
+        > .column:first-child {
+        box-shadow: -1px 0 0 0 rgba(34, 36, 38, 0.15);
+    }
+    .ui[class*="computer reversed"].divided.grid:not(
+            [class*="vertically divided"]
+        )
+        > .column:last-child,
+    .ui[class*="computer reversed"].divided.grid:not(
+            [class*="vertically divided"]
+        )
+        > .row
+        > .column:last-child {
+        box-shadow: none;
+    }
+
+    /* Vertically Divided Reversed */
+    .ui.grid[class*="vertically divided"][class*="computer vertically reversed"]
+        > .row:first-child::before {
+        box-shadow: 0 -1px 0 0 rgba(34, 36, 38, 0.15);
+    }
+    .ui.grid[class*="vertically divided"][class*="computer vertically reversed"]
+        > .row:last-child::before {
+        box-shadow: none;
+    }
+
+    /* Celled Reversed */
+    .ui[class*="computer reversed"].celled.grid > .row > .column:first-child {
+        box-shadow: -1px 0 0 0 #d4d4d5;
+    }
+    .ui[class*="computer reversed"].celled.grid > .row > .column:last-child {
+        box-shadow: none;
+    }
 }
 
 /* -------------------
@@ -1471,264 +1522,305 @@
 
 /* Tablet Only */
 @media only screen and (min-width: 768px) and (max-width: 991.98px) {
-  .ui.doubling.grid {
-    width: auto;
-  }
-  .ui.grid > .doubling.row,
-  .ui.doubling.grid > .row {
-    margin: 0 !important;
-    padding: 0 !important;
-  }
-  .ui.grid > .doubling.row > .column,
-  .ui.doubling.grid > .row > .column {
-    padding-top: 1rem !important;
-    padding-bottom: 1rem !important;
-    box-shadow: none !important;
-    margin: 0;
-  }
-  .ui.grid:not(.stretched) > .doubling.row:not(.stretched) > .column:not(.stretched),
-  .ui.doubling.grid:not(.stretched) > .row:not(.stretched) > .column:not(.stretched) {
-    display: inline-block !important;
-  }
-  .ui[class*="two column"].doubling.grid > .row > .column,
-  .ui[class*="two column"].doubling.grid > .column:not(.row),
-  .ui.ui.grid > [class*="two column"].doubling.row > .column {
-    width: 100% !important;
-  }
-  .ui[class*="three column"].doubling.grid > .row > .column,
-  .ui[class*="three column"].doubling.grid > .column:not(.row),
-  .ui.ui.grid > [class*="three column"].doubling.row > .column {
-    width: 50% !important;
-  }
-  .ui[class*="four column"].doubling.grid > .row > .column,
-  .ui[class*="four column"].doubling.grid > .column:not(.row),
-  .ui.ui.grid > [class*="four column"].doubling.row > .column {
-    width: 50% !important;
-  }
-  .ui[class*="five column"].doubling.grid > .row > .column,
-  .ui[class*="five column"].doubling.grid > .column:not(.row),
-  .ui.ui.grid > [class*="five column"].doubling.row > .column {
-    width: 33.33333333% !important;
-  }
-  .ui[class*="six column"].doubling.grid > .row > .column,
-  .ui[class*="six column"].doubling.grid > .column:not(.row),
-  .ui.ui.grid > [class*="six column"].doubling.row > .column {
-    width: 33.33333333% !important;
-  }
-  .ui[class*="seven column"].doubling.grid > .row > .column,
-  .ui[class*="seven column"].doubling.grid > .column:not(.row),
-  .ui.ui.grid > [class*="seven column"].doubling.row > .column {
-    width: 33.33333333% !important;
-  }
-  .ui[class*="eight column"].doubling.grid > .row > .column,
-  .ui[class*="eight column"].doubling.grid > .column:not(.row),
-  .ui.ui.grid > [class*="eight column"].doubling.row > .column {
-    width: 25% !important;
-  }
-  .ui[class*="nine column"].doubling.grid > .row > .column,
-  .ui[class*="nine column"].doubling.grid > .column:not(.row),
-  .ui.ui.grid > [class*="nine column"].doubling.row > .column {
-    width: 25% !important;
-  }
-  .ui[class*="ten column"].doubling.grid > .row > .column,
-  .ui[class*="ten column"].doubling.grid > .column:not(.row),
-  .ui.ui.grid > [class*="ten column"].doubling.row > .column {
-    width: 20% !important;
-  }
-  .ui[class*="eleven column"].doubling.grid > .row > .column,
-  .ui[class*="eleven column"].doubling.grid > .column:not(.row),
-  .ui.ui.grid > [class*="eleven column"].doubling.row > .column {
-    width: 20% !important;
-  }
-  .ui[class*="twelve column"].doubling.grid > .row > .column,
-  .ui[class*="twelve column"].doubling.grid > .column:not(.row),
-  .ui.ui.grid > [class*="twelve column"].doubling.row > .column {
-    width: 16.66666667% !important;
-  }
-  .ui[class*="thirteen column"].doubling.grid > .row > .column,
-  .ui[class*="thirteen column"].doubling.grid > .column:not(.row),
-  .ui.ui.grid > [class*="thirteen column"].doubling.row > .column {
-    width: 16.66666667% !important;
-  }
-  .ui[class*="fourteen column"].doubling.grid > .row > .column,
-  .ui[class*="fourteen column"].doubling.grid > .column:not(.row),
-  .ui.ui.grid > [class*="fourteen column"].doubling.row > .column {
-    width: 14.28571429% !important;
-  }
-  .ui[class*="fifteen column"].doubling.grid > .row > .column,
-  .ui[class*="fifteen column"].doubling.grid > .column:not(.row),
-  .ui.ui.grid > [class*="fifteen column"].doubling.row > .column {
-    width: 14.28571429% !important;
-  }
-  .ui[class*="sixteen column"].doubling.grid > .row > .column,
-  .ui[class*="sixteen column"].doubling.grid > .column:not(.row),
-  .ui.ui.grid > [class*="sixteen column"].doubling.row > .column {
-    width: 12.5% !important;
-  }
+    .ui.doubling.grid {
+        width: auto;
+    }
+    .ui.grid > .doubling.row,
+    .ui.doubling.grid > .row {
+        margin: 0 !important;
+        padding: 0 !important;
+    }
+    .ui.grid > .doubling.row > .column,
+    .ui.doubling.grid > .row > .column {
+        padding-top: 1rem !important;
+        padding-bottom: 1rem !important;
+        box-shadow: none !important;
+        margin: 0;
+    }
+    .ui.grid:not(.stretched)
+        > .doubling.row:not(.stretched)
+        > .column:not(.stretched),
+    .ui.doubling.grid:not(.stretched)
+        > .row:not(.stretched)
+        > .column:not(.stretched) {
+        display: inline-block !important;
+    }
+    .ui[class*="two column"].doubling.grid > .row > .column,
+    .ui[class*="two column"].doubling.grid > .column:not(.row),
+    .ui.ui.grid > [class*="two column"].doubling.row > .column {
+        width: 100% !important;
+    }
+    .ui[class*="three column"].doubling.grid > .row > .column,
+    .ui[class*="three column"].doubling.grid > .column:not(.row),
+    .ui.ui.grid > [class*="three column"].doubling.row > .column {
+        width: 50% !important;
+    }
+    .ui[class*="four column"].doubling.grid > .row > .column,
+    .ui[class*="four column"].doubling.grid > .column:not(.row),
+    .ui.ui.grid > [class*="four column"].doubling.row > .column {
+        width: 50% !important;
+    }
+    .ui[class*="five column"].doubling.grid > .row > .column,
+    .ui[class*="five column"].doubling.grid > .column:not(.row),
+    .ui.ui.grid > [class*="five column"].doubling.row > .column {
+        width: 33.33333333% !important;
+    }
+    .ui[class*="six column"].doubling.grid > .row > .column,
+    .ui[class*="six column"].doubling.grid > .column:not(.row),
+    .ui.ui.grid > [class*="six column"].doubling.row > .column {
+        width: 33.33333333% !important;
+    }
+    .ui[class*="seven column"].doubling.grid > .row > .column,
+    .ui[class*="seven column"].doubling.grid > .column:not(.row),
+    .ui.ui.grid > [class*="seven column"].doubling.row > .column {
+        width: 33.33333333% !important;
+    }
+    .ui[class*="eight column"].doubling.grid > .row > .column,
+    .ui[class*="eight column"].doubling.grid > .column:not(.row),
+    .ui.ui.grid > [class*="eight column"].doubling.row > .column {
+        width: 25% !important;
+    }
+    .ui[class*="nine column"].doubling.grid > .row > .column,
+    .ui[class*="nine column"].doubling.grid > .column:not(.row),
+    .ui.ui.grid > [class*="nine column"].doubling.row > .column {
+        width: 25% !important;
+    }
+    .ui[class*="ten column"].doubling.grid > .row > .column,
+    .ui[class*="ten column"].doubling.grid > .column:not(.row),
+    .ui.ui.grid > [class*="ten column"].doubling.row > .column {
+        width: 20% !important;
+    }
+    .ui[class*="eleven column"].doubling.grid > .row > .column,
+    .ui[class*="eleven column"].doubling.grid > .column:not(.row),
+    .ui.ui.grid > [class*="eleven column"].doubling.row > .column {
+        width: 20% !important;
+    }
+    .ui[class*="twelve column"].doubling.grid > .row > .column,
+    .ui[class*="twelve column"].doubling.grid > .column:not(.row),
+    .ui.ui.grid > [class*="twelve column"].doubling.row > .column {
+        width: 16.66666667% !important;
+    }
+    .ui[class*="thirteen column"].doubling.grid > .row > .column,
+    .ui[class*="thirteen column"].doubling.grid > .column:not(.row),
+    .ui.ui.grid > [class*="thirteen column"].doubling.row > .column {
+        width: 16.66666667% !important;
+    }
+    .ui[class*="fourteen column"].doubling.grid > .row > .column,
+    .ui[class*="fourteen column"].doubling.grid > .column:not(.row),
+    .ui.ui.grid > [class*="fourteen column"].doubling.row > .column {
+        width: 14.28571429% !important;
+    }
+    .ui[class*="fifteen column"].doubling.grid > .row > .column,
+    .ui[class*="fifteen column"].doubling.grid > .column:not(.row),
+    .ui.ui.grid > [class*="fifteen column"].doubling.row > .column {
+        width: 14.28571429% !important;
+    }
+    .ui[class*="sixteen column"].doubling.grid > .row > .column,
+    .ui[class*="sixteen column"].doubling.grid > .column:not(.row),
+    .ui.ui.grid > [class*="sixteen column"].doubling.row > .column {
+        width: 12.5% !important;
+    }
 }
 
 /* Mobile Only */
 @media only screen and (max-width: 767.98px) {
-  .ui.grid > .doubling.row,
-  .ui.doubling.grid > .row {
-    margin: 0 !important;
-    padding: 0 !important;
-  }
-  .ui.grid > .doubling.row > .column,
-  .ui.doubling.grid > .row > .column {
-    padding-top: 1rem !important;
-    padding-bottom: 1rem !important;
-    margin: 0 !important;
-    box-shadow: none !important;
-  }
-  .ui[class*="two column"].doubling:not(.stackable).grid > .row > .column,
-  .ui[class*="two column"].doubling:not(.stackable).grid > .column:not(.row),
-  .ui.ui.grid > [class*="two column"].doubling:not(.stackable).row > .column {
-    width: 100% !important;
-  }
-  .ui[class*="three column"].doubling:not(.stackable).grid > .row > .column,
-  .ui[class*="three column"].doubling:not(.stackable).grid > .column:not(.row),
-  .ui.ui.grid > [class*="three column"].doubling:not(.stackable).row > .column {
-    width: 50% !important;
-  }
-  .ui[class*="four column"].doubling:not(.stackable).grid > .row > .column,
-  .ui[class*="four column"].doubling:not(.stackable).grid > .column:not(.row),
-  .ui.ui.grid > [class*="four column"].doubling:not(.stackable).row > .column {
-    width: 50% !important;
-  }
-  .ui[class*="five column"].doubling:not(.stackable).grid > .row > .column,
-  .ui[class*="five column"].doubling:not(.stackable).grid > .column:not(.row),
-  .ui.ui.grid > [class*="five column"].doubling:not(.stackable).row > .column {
-    width: 50% !important;
-  }
-  .ui[class*="six column"].doubling:not(.stackable).grid > .row > .column,
-  .ui[class*="six column"].doubling:not(.stackable).grid > .column:not(.row),
-  .ui.ui.grid > [class*="six column"].doubling:not(.stackable).row > .column {
-    width: 50% !important;
-  }
-  .ui[class*="seven column"].doubling:not(.stackable).grid > .row > .column,
-  .ui[class*="seven column"].doubling:not(.stackable).grid > .column:not(.row),
-  .ui.ui.grid > [class*="seven column"].doubling:not(.stackable).row > .column {
-    width: 50% !important;
-  }
-  .ui[class*="eight column"].doubling:not(.stackable).grid > .row > .column,
-  .ui[class*="eight column"].doubling:not(.stackable).grid > .column:not(.row),
-  .ui.ui.grid > [class*="eight column"].doubling:not(.stackable).row > .column {
-    width: 50% !important;
-  }
-  .ui[class*="nine column"].doubling:not(.stackable).grid > .row > .column,
-  .ui[class*="nine column"].doubling:not(.stackable).grid > .column:not(.row),
-  .ui.ui.grid > [class*="nine column"].doubling:not(.stackable).row > .column {
-    width: 33.33333333% !important;
-  }
-  .ui[class*="ten column"].doubling:not(.stackable).grid > .row > .column,
-  .ui[class*="ten column"].doubling:not(.stackable).grid > .column:not(.row),
-  .ui.ui.grid > [class*="ten column"].doubling:not(.stackable).row > .column {
-    width: 33.33333333% !important;
-  }
-  .ui[class*="eleven column"].doubling:not(.stackable).grid > .row > .column,
-  .ui[class*="eleven column"].doubling:not(.stackable).grid > .column:not(.row),
-  .ui.ui.grid > [class*="eleven column"].doubling:not(.stackable).row > .column {
-    width: 33.33333333% !important;
-  }
-  .ui[class*="twelve column"].doubling:not(.stackable).grid > .row > .column,
-  .ui[class*="twelve column"].doubling:not(.stackable).grid > .column:not(.row),
-  .ui.ui.grid > [class*="twelve column"].doubling:not(.stackable).row > .column {
-    width: 33.33333333% !important;
-  }
-  .ui[class*="thirteen column"].doubling:not(.stackable).grid > .row > .column,
-  .ui[class*="thirteen column"].doubling:not(.stackable).grid > .column:not(.row),
-  .ui.ui.grid > [class*="thirteen column"].doubling:not(.stackable).row > .column {
-    width: 33.33333333% !important;
-  }
-  .ui[class*="fourteen column"].doubling:not(.stackable).grid > .row > .column,
-  .ui[class*="fourteen column"].doubling:not(.stackable).grid > .column:not(.row),
-  .ui.ui.grid > [class*="fourteen column"].doubling:not(.stackable).row > .column {
-    width: 25% !important;
-  }
-  .ui[class*="fifteen column"].doubling:not(.stackable).grid > .row > .column,
-  .ui[class*="fifteen column"].doubling:not(.stackable).grid > .column:not(.row),
-  .ui.ui.grid > [class*="fifteen column"].doubling:not(.stackable).row > .column {
-    width: 25% !important;
-  }
-  .ui[class*="sixteen column"].doubling:not(.stackable).grid > .row > .column,
-  .ui[class*="sixteen column"].doubling:not(.stackable).grid > .column:not(.row),
-  .ui.ui.grid > [class*="sixteen column"].doubling:not(.stackable).row > .column {
-    width: 25% !important;
-  }
+    .ui.grid > .doubling.row,
+    .ui.doubling.grid > .row {
+        margin: 0 !important;
+        padding: 0 !important;
+    }
+    .ui.grid > .doubling.row > .column,
+    .ui.doubling.grid > .row > .column {
+        padding-top: 1rem !important;
+        padding-bottom: 1rem !important;
+        margin: 0 !important;
+        box-shadow: none !important;
+    }
+    .ui[class*="two column"].doubling:not(.stackable).grid > .row > .column,
+    .ui[class*="two column"].doubling:not(.stackable).grid > .column:not(.row),
+    .ui.ui.grid > [class*="two column"].doubling:not(.stackable).row > .column {
+        width: 100% !important;
+    }
+    .ui[class*="three column"].doubling:not(.stackable).grid > .row > .column,
+    .ui[class*="three column"].doubling:not(.stackable).grid
+        > .column:not(.row),
+    .ui.ui.grid
+        > [class*="three column"].doubling:not(.stackable).row
+        > .column {
+        width: 50% !important;
+    }
+    .ui[class*="four column"].doubling:not(.stackable).grid > .row > .column,
+    .ui[class*="four column"].doubling:not(.stackable).grid > .column:not(.row),
+    .ui.ui.grid
+        > [class*="four column"].doubling:not(.stackable).row
+        > .column {
+        width: 50% !important;
+    }
+    .ui[class*="five column"].doubling:not(.stackable).grid > .row > .column,
+    .ui[class*="five column"].doubling:not(.stackable).grid > .column:not(.row),
+    .ui.ui.grid
+        > [class*="five column"].doubling:not(.stackable).row
+        > .column {
+        width: 50% !important;
+    }
+    .ui[class*="six column"].doubling:not(.stackable).grid > .row > .column,
+    .ui[class*="six column"].doubling:not(.stackable).grid > .column:not(.row),
+    .ui.ui.grid > [class*="six column"].doubling:not(.stackable).row > .column {
+        width: 50% !important;
+    }
+    .ui[class*="seven column"].doubling:not(.stackable).grid > .row > .column,
+    .ui[class*="seven column"].doubling:not(.stackable).grid
+        > .column:not(.row),
+    .ui.ui.grid
+        > [class*="seven column"].doubling:not(.stackable).row
+        > .column {
+        width: 50% !important;
+    }
+    .ui[class*="eight column"].doubling:not(.stackable).grid > .row > .column,
+    .ui[class*="eight column"].doubling:not(.stackable).grid
+        > .column:not(.row),
+    .ui.ui.grid
+        > [class*="eight column"].doubling:not(.stackable).row
+        > .column {
+        width: 50% !important;
+    }
+    .ui[class*="nine column"].doubling:not(.stackable).grid > .row > .column,
+    .ui[class*="nine column"].doubling:not(.stackable).grid > .column:not(.row),
+    .ui.ui.grid
+        > [class*="nine column"].doubling:not(.stackable).row
+        > .column {
+        width: 33.33333333% !important;
+    }
+    .ui[class*="ten column"].doubling:not(.stackable).grid > .row > .column,
+    .ui[class*="ten column"].doubling:not(.stackable).grid > .column:not(.row),
+    .ui.ui.grid > [class*="ten column"].doubling:not(.stackable).row > .column {
+        width: 33.33333333% !important;
+    }
+    .ui[class*="eleven column"].doubling:not(.stackable).grid > .row > .column,
+    .ui[class*="eleven column"].doubling:not(.stackable).grid
+        > .column:not(.row),
+    .ui.ui.grid
+        > [class*="eleven column"].doubling:not(.stackable).row
+        > .column {
+        width: 33.33333333% !important;
+    }
+    .ui[class*="twelve column"].doubling:not(.stackable).grid > .row > .column,
+    .ui[class*="twelve column"].doubling:not(.stackable).grid
+        > .column:not(.row),
+    .ui.ui.grid
+        > [class*="twelve column"].doubling:not(.stackable).row
+        > .column {
+        width: 33.33333333% !important;
+    }
+    .ui[class*="thirteen column"].doubling:not(.stackable).grid
+        > .row
+        > .column,
+    .ui[class*="thirteen column"].doubling:not(.stackable).grid
+        > .column:not(.row),
+    .ui.ui.grid
+        > [class*="thirteen column"].doubling:not(.stackable).row
+        > .column {
+        width: 33.33333333% !important;
+    }
+    .ui[class*="fourteen column"].doubling:not(.stackable).grid
+        > .row
+        > .column,
+    .ui[class*="fourteen column"].doubling:not(.stackable).grid
+        > .column:not(.row),
+    .ui.ui.grid
+        > [class*="fourteen column"].doubling:not(.stackable).row
+        > .column {
+        width: 25% !important;
+    }
+    .ui[class*="fifteen column"].doubling:not(.stackable).grid > .row > .column,
+    .ui[class*="fifteen column"].doubling:not(.stackable).grid
+        > .column:not(.row),
+    .ui.ui.grid
+        > [class*="fifteen column"].doubling:not(.stackable).row
+        > .column {
+        width: 25% !important;
+    }
+    .ui[class*="sixteen column"].doubling:not(.stackable).grid > .row > .column,
+    .ui[class*="sixteen column"].doubling:not(.stackable).grid
+        > .column:not(.row),
+    .ui.ui.grid
+        > [class*="sixteen column"].doubling:not(.stackable).row
+        > .column {
+        width: 25% !important;
+    }
 }
 
 /* -------------------
           Stackable
     -------------------- */
 @media only screen and (max-width: 767.98px) {
-  body > .ui.stackable.grid,
-  .ui:not(.segment):not(.grid) .ui.stackable.grid {
-    width: auto;
-    margin-left: 0;
-    margin-right: 0;
-  }
-  .ui.stackable.grid > .row > .wide.column,
-  .ui.stackable.grid > .wide.column,
-  .ui.stackable.grid > .column.grid > .column,
-  .ui.stackable.grid > .column.row > .column,
-  .ui.stackable.grid > .row > .column,
-  .ui.stackable.grid > .column:not(.row),
-  .ui.grid > .stackable.stackable.stackable.row > .column {
-    width: 100% !important;
-    margin: 0 !important;
-    box-shadow: none !important;
-    padding: 1rem 1rem;
-  }
-  .ui.stackable.grid:not(.vertically) > .row {
-    margin: 0;
-    padding: 0;
-  }
-  
-/* Coupling */
-  .ui.container > .ui.stackable.grid > .column,
-  .ui.container > .ui.stackable.grid > .row > .column {
-    padding-left: 0 !important;
-    padding-right: 0 !important;
-  }
-  
-/* Don't pad inside segment or nested grid */
-  .ui.grid .ui.stackable.grid,
-  .ui.segment:not(.vertical) .ui.stackable.page.grid {
-    margin-left: -1rem;
-    margin-right: -1rem;
-  }
-  
-/* Divided Stackable */
-  .ui.stackable.divided.grid > .row:first-child > .column:first-child,
-  .ui.stackable.celled.grid > .row:first-child > .column:first-child,
-  .ui.stackable.divided.grid > .column:not(.row):first-child,
-  .ui.stackable.celled.grid > .column:not(.row):first-child {
-    border-top: none !important;
-  }
-  .ui.inverted.stackable.celled.grid > .column:not(.row),
-  .ui.inverted.stackable.divided.grid > .column:not(.row),
-  .ui.inverted.stackable.celled.grid > .row > .column,
-  .ui.inverted.stackable.divided.grid > .row > .column {
-    border-top: 1px solid rgba(255, 255, 255, 0.1);
-  }
-  .ui.stackable.celled.grid > .column:not(.row),
-  .ui.stackable.divided:not(.vertically).grid > .column:not(.row),
-  .ui.stackable.celled.grid > .row > .column,
-  .ui.stackable.divided:not(.vertically).grid > .row > .column {
-    border-top: 1px solid rgba(34, 36, 38, 0.15);
-    box-shadow: none !important;
-    padding-top: 2rem !important;
-    padding-bottom: 2rem !important;
-  }
-  .ui.stackable.celled.grid > .row {
-    box-shadow: none !important;
-  }
-  .ui.stackable.divided:not(.vertically).grid > .column:not(.row),
-  .ui.stackable.divided:not(.vertically).grid > .row > .column {
-    padding-left: 0 !important;
-    padding-right: 0 !important;
-  }
+    body > .ui.stackable.grid,
+    .ui:not(.segment):not(.grid) .ui.stackable.grid {
+        width: auto;
+        margin-left: 0;
+        margin-right: 0;
+    }
+    .ui.stackable.grid > .row > .wide.column,
+    .ui.stackable.grid > .wide.column,
+    .ui.stackable.grid > .column.grid > .column,
+    .ui.stackable.grid > .column.row > .column,
+    .ui.stackable.grid > .row > .column,
+    .ui.stackable.grid > .column:not(.row),
+    .ui.grid > .stackable.stackable.stackable.row > .column {
+        width: 100% !important;
+        margin: 0 !important;
+        box-shadow: none !important;
+        padding: 1rem 1rem;
+    }
+    .ui.stackable.grid:not(.vertically) > .row {
+        margin: 0;
+        padding: 0;
+    }
+
+    /* Coupling */
+    .ui.container > .ui.stackable.grid > .column,
+    .ui.container > .ui.stackable.grid > .row > .column {
+        padding-left: 0 !important;
+        padding-right: 0 !important;
+    }
+
+    /* Don't pad inside segment or nested grid */
+    .ui.grid .ui.stackable.grid,
+    .ui.segment:not(.vertical) .ui.stackable.page.grid {
+        margin-left: -1rem;
+        margin-right: -1rem;
+    }
+
+    /* Divided Stackable */
+    .ui.stackable.divided.grid > .row:first-child > .column:first-child,
+    .ui.stackable.celled.grid > .row:first-child > .column:first-child,
+    .ui.stackable.divided.grid > .column:not(.row):first-child,
+    .ui.stackable.celled.grid > .column:not(.row):first-child {
+        border-top: none !important;
+    }
+    .ui.inverted.stackable.celled.grid > .column:not(.row),
+    .ui.inverted.stackable.divided.grid > .column:not(.row),
+    .ui.inverted.stackable.celled.grid > .row > .column,
+    .ui.inverted.stackable.divided.grid > .row > .column {
+        border-top: 1px solid rgba(255, 255, 255, 0.1);
+    }
+    .ui.stackable.celled.grid > .column:not(.row),
+    .ui.stackable.divided:not(.vertically).grid > .column:not(.row),
+    .ui.stackable.celled.grid > .row > .column,
+    .ui.stackable.divided:not(.vertically).grid > .row > .column {
+        border-top: 1px solid rgba(34, 36, 38, 0.15);
+        box-shadow: none !important;
+        padding-top: 2rem !important;
+        padding-bottom: 2rem !important;
+    }
+    .ui.stackable.celled.grid > .row {
+        box-shadow: none !important;
+    }
+    .ui.stackable.divided:not(.vertically).grid > .column:not(.row),
+    .ui.stackable.divided:not(.vertically).grid > .row > .column {
+        padding-left: 0 !important;
+        padding-right: 0 !important;
+    }
 }
 
 /* ----------------------
@@ -1739,214 +1831,211 @@
 
 /* Mobile Only Hide */
 @media only screen and (max-width: 767.98px) {
-  .ui.ui.ui[class*="tablet only"].grid:not(.mobile),
-  .ui.ui.ui.grid > [class*="tablet only"].row:not(.mobile),
-  .ui.ui.ui.grid > [class*="tablet only"].column:not(.mobile),
-  .ui.ui.ui.grid > .row > [class*="tablet only"].column:not(.mobile) {
-    display: none !important;
-  }
-  .ui.ui.ui[class*="computer only"].grid:not(.mobile),
-  .ui.ui.ui.grid > [class*="computer only"].row:not(.mobile),
-  .ui.ui.ui.grid > [class*="computer only"].column:not(.mobile),
-  .ui.ui.ui.grid > .row > [class*="computer only"].column:not(.mobile) {
-    display: none !important;
-  }
-  .ui.ui.ui[class*="large screen only"].grid:not(.mobile),
-  .ui.ui.ui.grid > [class*="large screen only"].row:not(.mobile),
-  .ui.ui.ui.grid > [class*="large screen only"].column:not(.mobile),
-  .ui.ui.ui.grid > .row > [class*="large screen only"].column:not(.mobile) {
-    display: none !important;
-  }
-  .ui.ui.ui[class*="widescreen only"].grid:not(.mobile),
-  .ui.ui.ui.grid > [class*="widescreen only"].row:not(.mobile),
-  .ui.ui.ui.grid > [class*="widescreen only"].column:not(.mobile),
-  .ui.ui.ui.grid > .row > [class*="widescreen only"].column:not(.mobile) {
-    display: none !important;
-  }
+    .ui.ui.ui[class*="tablet only"].grid:not(.mobile),
+    .ui.ui.ui.grid > [class*="tablet only"].row:not(.mobile),
+    .ui.ui.ui.grid > [class*="tablet only"].column:not(.mobile),
+    .ui.ui.ui.grid > .row > [class*="tablet only"].column:not(.mobile) {
+        display: none !important;
+    }
+    .ui.ui.ui[class*="computer only"].grid:not(.mobile),
+    .ui.ui.ui.grid > [class*="computer only"].row:not(.mobile),
+    .ui.ui.ui.grid > [class*="computer only"].column:not(.mobile),
+    .ui.ui.ui.grid > .row > [class*="computer only"].column:not(.mobile) {
+        display: none !important;
+    }
+    .ui.ui.ui[class*="large screen only"].grid:not(.mobile),
+    .ui.ui.ui.grid > [class*="large screen only"].row:not(.mobile),
+    .ui.ui.ui.grid > [class*="large screen only"].column:not(.mobile),
+    .ui.ui.ui.grid > .row > [class*="large screen only"].column:not(.mobile) {
+        display: none !important;
+    }
+    .ui.ui.ui[class*="widescreen only"].grid:not(.mobile),
+    .ui.ui.ui.grid > [class*="widescreen only"].row:not(.mobile),
+    .ui.ui.ui.grid > [class*="widescreen only"].column:not(.mobile),
+    .ui.ui.ui.grid > .row > [class*="widescreen only"].column:not(.mobile) {
+        display: none !important;
+    }
 }
 
 /* Tablet Only Hide */
 @media only screen and (min-width: 768px) and (max-width: 991.98px) {
-  .ui.ui.ui[class*="mobile only"].grid:not(.tablet),
-  .ui.ui.ui.grid > [class*="mobile only"].row:not(.tablet),
-  .ui.ui.ui.grid > [class*="mobile only"].column:not(.tablet),
-  .ui.ui.ui.grid > .row > [class*="mobile only"].column:not(.tablet) {
-    display: none !important;
-  }
-  .ui.ui.ui[class*="computer only"].grid:not(.tablet),
-  .ui.ui.ui.grid > [class*="computer only"].row:not(.tablet),
-  .ui.ui.ui.grid > [class*="computer only"].column:not(.tablet),
-  .ui.ui.ui.grid > .row > [class*="computer only"].column:not(.tablet) {
-    display: none !important;
-  }
-  .ui.ui.ui[class*="large screen only"].grid:not(.mobile),
-  .ui.ui.ui.grid > [class*="large screen only"].row:not(.mobile),
-  .ui.ui.ui.grid > [class*="large screen only"].column:not(.mobile),
-  .ui.ui.ui.grid > .row > [class*="large screen only"].column:not(.mobile) {
-    display: none !important;
-  }
-  .ui.ui.ui[class*="widescreen only"].grid:not(.mobile),
-  .ui.ui.ui.grid > [class*="widescreen only"].row:not(.mobile),
-  .ui.ui.ui.grid > [class*="widescreen only"].column:not(.mobile),
-  .ui.ui.ui.grid > .row > [class*="widescreen only"].column:not(.mobile) {
-    display: none !important;
-  }
+    .ui.ui.ui[class*="mobile only"].grid:not(.tablet),
+    .ui.ui.ui.grid > [class*="mobile only"].row:not(.tablet),
+    .ui.ui.ui.grid > [class*="mobile only"].column:not(.tablet),
+    .ui.ui.ui.grid > .row > [class*="mobile only"].column:not(.tablet) {
+        display: none !important;
+    }
+    .ui.ui.ui[class*="computer only"].grid:not(.tablet),
+    .ui.ui.ui.grid > [class*="computer only"].row:not(.tablet),
+    .ui.ui.ui.grid > [class*="computer only"].column:not(.tablet),
+    .ui.ui.ui.grid > .row > [class*="computer only"].column:not(.tablet) {
+        display: none !important;
+    }
+    .ui.ui.ui[class*="large screen only"].grid:not(.mobile),
+    .ui.ui.ui.grid > [class*="large screen only"].row:not(.mobile),
+    .ui.ui.ui.grid > [class*="large screen only"].column:not(.mobile),
+    .ui.ui.ui.grid > .row > [class*="large screen only"].column:not(.mobile) {
+        display: none !important;
+    }
+    .ui.ui.ui[class*="widescreen only"].grid:not(.mobile),
+    .ui.ui.ui.grid > [class*="widescreen only"].row:not(.mobile),
+    .ui.ui.ui.grid > [class*="widescreen only"].column:not(.mobile),
+    .ui.ui.ui.grid > .row > [class*="widescreen only"].column:not(.mobile) {
+        display: none !important;
+    }
 }
 
 /* Computer Only Hide */
 @media only screen and (min-width: 992px) and (max-width: 1199.98px) {
-  .ui.ui.ui[class*="mobile only"].grid:not(.computer),
-  .ui.ui.ui.grid > [class*="mobile only"].row:not(.computer),
-  .ui.ui.ui.grid > [class*="mobile only"].column:not(.computer),
-  .ui.ui.ui.grid > .row > [class*="mobile only"].column:not(.computer) {
-    display: none !important;
-  }
-  .ui.ui.ui[class*="tablet only"].grid:not(.computer),
-  .ui.ui.ui.grid > [class*="tablet only"].row:not(.computer),
-  .ui.ui.ui.grid > [class*="tablet only"].column:not(.computer),
-  .ui.ui.ui.grid > .row > [class*="tablet only"].column:not(.computer) {
-    display: none !important;
-  }
-  .ui.ui.ui[class*="large screen only"].grid:not(.mobile),
-  .ui.ui.ui.grid > [class*="large screen only"].row:not(.mobile),
-  .ui.ui.ui.grid > [class*="large screen only"].column:not(.mobile),
-  .ui.ui.ui.grid > .row > [class*="large screen only"].column:not(.mobile) {
-    display: none !important;
-  }
-  .ui.ui.ui[class*="widescreen only"].grid:not(.mobile),
-  .ui.ui.ui.grid > [class*="widescreen only"].row:not(.mobile),
-  .ui.ui.ui.grid > [class*="widescreen only"].column:not(.mobile),
-  .ui.ui.ui.grid > .row > [class*="widescreen only"].column:not(.mobile) {
-    display: none !important;
-  }
+    .ui.ui.ui[class*="mobile only"].grid:not(.computer),
+    .ui.ui.ui.grid > [class*="mobile only"].row:not(.computer),
+    .ui.ui.ui.grid > [class*="mobile only"].column:not(.computer),
+    .ui.ui.ui.grid > .row > [class*="mobile only"].column:not(.computer) {
+        display: none !important;
+    }
+    .ui.ui.ui[class*="tablet only"].grid:not(.computer),
+    .ui.ui.ui.grid > [class*="tablet only"].row:not(.computer),
+    .ui.ui.ui.grid > [class*="tablet only"].column:not(.computer),
+    .ui.ui.ui.grid > .row > [class*="tablet only"].column:not(.computer) {
+        display: none !important;
+    }
+    .ui.ui.ui[class*="large screen only"].grid:not(.mobile),
+    .ui.ui.ui.grid > [class*="large screen only"].row:not(.mobile),
+    .ui.ui.ui.grid > [class*="large screen only"].column:not(.mobile),
+    .ui.ui.ui.grid > .row > [class*="large screen only"].column:not(.mobile) {
+        display: none !important;
+    }
+    .ui.ui.ui[class*="widescreen only"].grid:not(.mobile),
+    .ui.ui.ui.grid > [class*="widescreen only"].row:not(.mobile),
+    .ui.ui.ui.grid > [class*="widescreen only"].column:not(.mobile),
+    .ui.ui.ui.grid > .row > [class*="widescreen only"].column:not(.mobile) {
+        display: none !important;
+    }
 }
 
 /* Large Screen Only Hide */
 @media only screen and (min-width: 1200px) and (max-width: 1919.98px) {
-  .ui.ui.ui[class*="mobile only"].grid:not(.computer),
-  .ui.ui.ui.grid > [class*="mobile only"].row:not(.computer),
-  .ui.ui.ui.grid > [class*="mobile only"].column:not(.computer),
-  .ui.ui.ui.grid > .row > [class*="mobile only"].column:not(.computer) {
-    display: none !important;
-  }
-  .ui.ui.ui[class*="tablet only"].grid:not(.computer),
-  .ui.ui.ui.grid > [class*="tablet only"].row:not(.computer),
-  .ui.ui.ui.grid > [class*="tablet only"].column:not(.computer),
-  .ui.ui.ui.grid > .row > [class*="tablet only"].column:not(.computer) {
-    display: none !important;
-  }
-  .ui.ui.ui[class*="widescreen only"].grid:not(.mobile),
-  .ui.ui.ui.grid > [class*="widescreen only"].row:not(.mobile),
-  .ui.ui.ui.grid > [class*="widescreen only"].column:not(.mobile),
-  .ui.ui.ui.grid > .row > [class*="widescreen only"].column:not(.mobile) {
-    display: none !important;
-  }
+    .ui.ui.ui[class*="mobile only"].grid:not(.computer),
+    .ui.ui.ui.grid > [class*="mobile only"].row:not(.computer),
+    .ui.ui.ui.grid > [class*="mobile only"].column:not(.computer),
+    .ui.ui.ui.grid > .row > [class*="mobile only"].column:not(.computer) {
+        display: none !important;
+    }
+    .ui.ui.ui[class*="tablet only"].grid:not(.computer),
+    .ui.ui.ui.grid > [class*="tablet only"].row:not(.computer),
+    .ui.ui.ui.grid > [class*="tablet only"].column:not(.computer),
+    .ui.ui.ui.grid > .row > [class*="tablet only"].column:not(.computer) {
+        display: none !important;
+    }
+    .ui.ui.ui[class*="widescreen only"].grid:not(.mobile),
+    .ui.ui.ui.grid > [class*="widescreen only"].row:not(.mobile),
+    .ui.ui.ui.grid > [class*="widescreen only"].column:not(.mobile),
+    .ui.ui.ui.grid > .row > [class*="widescreen only"].column:not(.mobile) {
+        display: none !important;
+    }
 }
 
 /* Widescreen Only Hide */
 @media only screen and (min-width: 1920px) {
-  .ui.ui.ui[class*="mobile only"].grid:not(.computer),
-  .ui.ui.ui.grid > [class*="mobile only"].row:not(.computer),
-  .ui.ui.ui.grid > [class*="mobile only"].column:not(.computer),
-  .ui.ui.ui.grid > .row > [class*="mobile only"].column:not(.computer) {
-    display: none !important;
-  }
-  .ui.ui.ui[class*="tablet only"].grid:not(.computer),
-  .ui.ui.ui.grid > [class*="tablet only"].row:not(.computer),
-  .ui.ui.ui.grid > [class*="tablet only"].column:not(.computer),
-  .ui.ui.ui.grid > .row > [class*="tablet only"].column:not(.computer) {
-    display: none !important;
-  }
+    .ui.ui.ui[class*="mobile only"].grid:not(.computer),
+    .ui.ui.ui.grid > [class*="mobile only"].row:not(.computer),
+    .ui.ui.ui.grid > [class*="mobile only"].column:not(.computer),
+    .ui.ui.ui.grid > .row > [class*="mobile only"].column:not(.computer) {
+        display: none !important;
+    }
+    .ui.ui.ui[class*="tablet only"].grid:not(.computer),
+    .ui.ui.ui.grid > [class*="tablet only"].row:not(.computer),
+    .ui.ui.ui.grid > [class*="tablet only"].column:not(.computer),
+    .ui.ui.ui.grid > .row > [class*="tablet only"].column:not(.computer) {
+        display: none !important;
+    }
 }
 
 /* -----------------
           Compact
     ----------------- */
 .ui.ui.ui.compact.grid {
-  margin: -0.5rem;
+    margin: -0.5rem;
 }
 .ui.ui.ui.compact.grid > .column:not(.row),
 .ui.ui.ui.compact.grid > .row > .column {
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
 }
 .ui.ui.ui.compact.grid > * {
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
 }
 
 /* Row */
 .ui.ui.ui.compact.grid > .row {
-  padding: 0.5rem 0;
+    padding: 0.5rem 0;
 }
 
 /* Columns */
 .ui.ui.ui.compact.grid > .column:not(.row) {
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
 }
 
 /* Relaxed + Celled */
 .ui.compact.relaxed.celled.grid > .column:not(.row),
 .ui.compact.relaxed.celled.grid > .row > .column {
-  padding: 0.75em;
+    padding: 0.75em;
 }
 .ui.compact[class*="very relaxed"].celled.grid > .column:not(.row),
 .ui.compact[class*="very relaxed"].celled.grid > .row > .column {
-  padding: 1em;
+    padding: 1em;
 }
 
 /* -----------------
         Very compact
     ----------------- */
 .ui.ui.ui[class*="very compact"].grid {
-  margin: -0.25rem;
+    margin: -0.25rem;
 }
 .ui.ui.ui[class*="very compact"].grid > .column:not(.row),
 .ui.ui.ui[class*="very compact"].grid > .row > .column {
-  padding-left: 0.25rem;
-  padding-right: 0.25rem;
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
 }
 .ui.ui.ui[class*="very compact"].grid > * {
-  padding-left: 0.25rem;
-  padding-right: 0.25rem;
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
 }
 
 /* Row */
 .ui.ui.ui[class*="very compact"].grid > .row {
-  padding: 0.25rem 0;
+    padding: 0.25rem 0;
 }
 
 /* Columns */
 .ui.ui.ui[class*="very compact"].grid > .column:not(.row) {
-  padding-top: 0.25rem;
-  padding-bottom: 0.25rem;
+    padding-top: 0.25rem;
+    padding-bottom: 0.25rem;
 }
 
 /* Relaxed + Celled */
 .ui[class*="very compact"].relaxed.celled.grid > .column:not(.row),
 .ui[class*="very compact"].relaxed.celled.grid > .row > .column {
-  padding: 0.375em;
+    padding: 0.375em;
 }
-.ui[class*="very compact"][class*="very relaxed"].celled.grid > .column:not(.row),
+.ui[class*="very compact"][class*="very relaxed"].celled.grid
+    > .column:not(.row),
 .ui[class*="very compact"][class*="very relaxed"].celled.grid > .row > .column {
-  padding: 0.5em;
+    padding: 0.5em;
 }
 .ui.grid .left.attached.column {
-  padding-right: 0;
+    padding-right: 0;
 }
 .ui.grid .right.attached.column {
-  padding-left: 0;
+    padding-left: 0;
 }
-
 
 /*******************************
          Theme Overrides
 *******************************/
 
-
-
 /*******************************
          Site Overrides
 *******************************/
-

--- a/dist/semantic.css
+++ b/dist/semantic.css
@@ -47664,6 +47664,7 @@ span.ui.massive.text {
 .ui.grid {
   display: flex;
   /* flex-flow: row wrap; */
+  flex-direction: row;
   align-items: stretch;
   padding: 0;
 }

--- a/dist/semantic.css
+++ b/dist/semantic.css
@@ -47663,7 +47663,7 @@ span.ui.massive.text {
 
 .ui.grid {
   display: flex;
-  flex-flow: row wrap;
+  /* flex-flow: row wrap; */
   align-items: stretch;
   padding: 0;
 }


### PR DESCRIPTION
<!--
 Please read our Contributing Guide and Code of Conduct before you
 submit a pull request.
  
 Contributing Guide: https://github.com/fomantic/Fomantic-UI/blob/master/CONTRIBUTING.md
 Code of Conduct: https://github.com/fomantic/Fomantic-UI/blob/master/CODE_OF_CONDUCT.md

 ----

 Please use the following pull request title format:
 "[<scope>] <summary of what you fixed/changed>"
-->

## Description
Solved the issue with "fifteen wide column" element which is forced to next line on reducing the window size below 447px.
In the semantic.css file by removing the ' flex-wrap' property and setting it to default as no-wrap.

JsFiddle Link of issue: https://jsfiddle.net/xvzns35r/1/


![image](https://user-images.githubusercontent.com/111275/256093199-4fe3b070-8c4f-4fbe-a875-f642c2a5046f.gif)

## Testcase

Solved JsFiddle Link: https://jsfiddle.net/jaiminrathwa28/5ymr3s1a/9/

## Screenshot (if possible)

![chrome_lnBco9GFPq](https://github.com/fomantic/Fomantic-UI/assets/104933129/d55a35a8-2f49-43ad-aee8-208718447f11)

## Closes

#2856 
