### PR TITLE
feat(form): pass down element to prompt function call

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -552,7 +552,7 @@
                             $field        = module.get.field(field.identifier),
                             value         = $field.val(),
                             prompt        = isFunction(rule.prompt)
-                                ? rule.prompt(value)
+                                ? rule.prompt.call($field[0], value) 
                                 : rule.prompt || settings.prompt[ruleName] || settings.text.unspecifiedRule,
                             requiresValue = prompt.search('{value}') !== -1,
                             requiresName  = prompt.search('{name}') !== -1,

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -552,7 +552,7 @@
                             $field        = module.get.field(field.identifier),
                             value         = $field.val(),
                             prompt        = isFunction(rule.prompt)
-                                ? rule.prompt.call($field[0], value) 
+                                ? rule.prompt.call($field[0], value)
                                 : rule.prompt || settings.prompt[ruleName] || settings.text.unspecifiedRule,
                             requiresValue = prompt.search('{value}') !== -1,
                             requiresName  = prompt.search('{name}') !== -1,


### PR DESCRIPTION
## Description
passes down the element to the prompt function call as it might be needed to construct the prompt

non-breaking change
