### PR TITLE
feat(form): support id only input fields for validation

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -711,7 +711,7 @@
                             var
                                 $field       = $(field),
                                 $calendar    = $field.closest(selector.uiCalendar),
-                                name         = $field.prop('name'),
+                                name         = $field.prop('name') || $field.prop('id'),
                                 value        = $field.val(),
                                 isCheckbox   = $field.is(selector.checkbox),
                                 isRadio      = $field.is(selector.radio),


### PR DESCRIPTION
## Description

Form validation always assumes/requires a `name` property on each input field to work. While this is fine for "real" forms which are supposed to send data to a server, a pure div form or local validation only logic without using name (but id) properties did not work.

## Not working using ids only
https://jsfiddle.net/lubber/10yhpnk4/1/

## Working using ids only
https://jsfiddle.net/lubber/10yhpnk4/5/

## Closes
#2939 