### PR TITLE
fix(dropdown): support individual sizing inside forms

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -1853,8 +1853,8 @@ select.ui.dropdown {
 & when not (@variationDropdownSizes = false) {
     each(@variationDropdownSizes, {
         @s: @@value;
-        .ui.@{value}.dropdown,
-        .ui.@{value}.dropdown .menu > .item {
+        .ui.ui.@{value}.dropdown,
+        .ui.ui.@{value}.dropdown .menu > .item {
             font-size: @s;
         }
     });


### PR DESCRIPTION
## Decscription
Dropdown sizes were ignored when used inside forms.

### Testcase
Remove CSS to see issue
https://jsfiddle.net/lubber/jewyfngq/13/

## Closes
#2947 