### PR TITLE
feat(form): deprecated and rename empty to notEmpty rule

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1237,20 +1237,20 @@
                                 isRequired = $el.prop('required') || $elGroup.hasClass(className.required) || $elGroup.parent().hasClass(className.required),
                                 isDisabled = $el.is(':disabled') || $elGroup.hasClass(className.disabled) || $elGroup.parent().hasClass(className.disabled),
                                 validation = module.get.validation($el),
-                                hasEmptyRule = validation
+                                hasNotEmptyRule = validation
                                     ? $.grep(validation.rules, function (rule) {
-                                        return rule.type === 'empty';
-                                    }) !== 0
+                                        return ['notEmpty', 'checked', 'empty'].indexOf(rule.type) >= 0;
+                                    }).length > 0
                                     : false,
                                 identifier = module.get.identifier(validation, $el)
                             ;
-                            if (isRequired && !isDisabled && !hasEmptyRule && identifier !== undefined) {
+                            if (isRequired && !isDisabled && !hasNotEmptyRule && identifier !== undefined) {
                                 if (isCheckbox) {
                                     module.verbose("Adding 'checked' rule on field", identifier);
                                     module.add.rule(identifier, 'checked');
                                 } else {
-                                    module.verbose("Adding 'empty' rule on field", identifier);
-                                    module.add.rule(identifier, 'empty');
+                                    module.verbose("Adding 'notEmpty' rule on field", identifier);
+                                    module.add.rule(identifier, 'notEmpty');
                                 }
                             }
                         });
@@ -1669,6 +1669,7 @@
             maxValue: '{name} must have a maximum value of {ruleValue}',
             minValue: '{name} must have a minimum value of {ruleValue}',
             empty: '{name} must have a value',
+            notEmpty: '{name} must have a value',
             checked: '{name} must be checked',
             email: '{name} must be a valid e-mail',
             url: '{name} must be a valid url',
@@ -1801,8 +1802,14 @@
         rules: {
 
             // is not empty or blank string
-            empty: function (value) {
+            notEmpty: function (value) {
                 return !(value === undefined || value === '' || (Array.isArray(value) && value.length === 0));
+            },
+
+            empty: function (value, ancillary, module) {
+                module.debug('Rule "empty" is deprecated and will be removed in a future version. Use the "notEmpty" rule instead.');
+
+                return $.fn.form.settings.rules.notEmpty(value);
             },
 
             // checkbox checked

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -538,6 +538,14 @@
                                     fullFields[name].rules.push({ type: rule });
                                 });
                             }
+
+                            $.each(fullFields[name].rules, function (index, rule) {
+                                var ruleName = module.get.ruleName(rule);
+                                if (ruleName === 'empty') {
+                                    module.warn('*** DEPRECATED *** : Rule "empty" for field "' + name +'" will be removed in a future version. -> Use "notEmpty" rule instead.');
+                                }
+                            });
+
                         });
 
                         return fullFields;
@@ -591,10 +599,10 @@
                     },
                     settings: function () {
                         if ($.isPlainObject(parameters)) {
-                            if (parameters.fields) {
-                                parameters.fields = module.get.fieldsFromShorthand(parameters.fields);
-                            }
                             settings = $.extend(true, {}, $.fn.form.settings, parameters);
+                            if (settings.fields) {
+                                settings.fields = module.get.fieldsFromShorthand(settings.fields);
+                            }
                             validation = $.extend(true, {}, $.fn.form.settings.defaults, settings.fields);
                             module.verbose('Extending settings', validation, settings);
                         } else {
@@ -1491,6 +1499,12 @@
                         module.error.apply(console, arguments);
                     }
                 },
+                warn: function () {
+                    if (!settings.silent) {
+                        module.warn = Function.prototype.bind.call(console.warn, console, settings.name + ':');
+                        module.warn.apply(console, arguments);
+                    }
+                },
                 performance: {
                     log: function (message) {
                         var
@@ -1605,6 +1619,7 @@
         name: 'Form',
         namespace: 'form',
 
+        silent: false,
         debug: false,
         verbose: false,
         performance: true,
@@ -1806,9 +1821,8 @@
                 return !(value === undefined || value === '' || (Array.isArray(value) && value.length === 0));
             },
 
-            empty: function (value, ancillary, module) {
-                module.debug('Rule "empty" is deprecated and will be removed in a future version. Use the "notEmpty" rule instead.');
-
+            /* Deprecated */
+            empty: function (value) {
                 return $.fn.form.settings.rules.notEmpty(value);
             },
 

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -542,10 +542,9 @@
                             $.each(fullFields[name].rules, function (index, rule) {
                                 var ruleName = module.get.ruleName(rule);
                                 if (ruleName === 'empty') {
-                                    module.warn('*** DEPRECATED *** : Rule "empty" for field "' + name +'" will be removed in a future version. -> Use "notEmpty" rule instead.');
+                                    module.warn('*** DEPRECATED *** : Rule "empty" for field "' + name + '" will be removed in a future version. -> Use "notEmpty" rule instead.');
                                 }
                             });
-
                         });
 
                         return fullFields;


### PR DESCRIPTION
## Description

This PR renames the `empty`  rule to `notEmpy` but keeps the `empty` rule working for backward compatibility, so people can just upgrade their code for while. A console warning will tell them about.
Reasons for renaming is that the code actually checks if a field is not empty. More explanation inside the related issue

## Closes
#2937 