### PR TITLE
style(form): ensure consistent inverted label color in grouped fields

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -866,6 +866,7 @@
     .ui.form .inverted.segment label,
     .ui.form .inverted.segment .ui.checkbox label,
     .ui.inverted.form .ui.checkbox label,
+    .ui.inverted.form .grouped.fields > label,
     .ui.inverted.form .inline.fields > label,
     .ui.inverted.form .inline.fields .field > label,
     .ui.inverted.form .inline.fields .field > p,


### PR DESCRIPTION
## Description
Added the `.grouped.fields > label` selector for targeted styling, ensuring labels within grouped fields inherit the inverted color in inverted forms. Used `@invertedLabelColor` for color consistency. Tested in various configurations and browsers.

## Testcase
https://jsfiddle.net/Festiis/8t6fgkjo/
