### PR TITLE
fix(firefox): has selector freezes in certain situations

### DIFF
--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -250,7 +250,7 @@
             margin-bottom: 0;
         }
     }
-    @supports selector(:has(.f)) and (not(-moz-appearance: none)) {
+    @supports selector(:has(.f)) and (not (-moz-appearance: none)) {
         *:has(> .ui.piled.segment) {
             z-index: 0;
             position: relative;

--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -250,7 +250,7 @@
             margin-bottom: 0;
         }
     }
-    @supports selector(:has(.f)) {
+    @supports selector(:has(.f)) and (not(-moz-appearance: none)) {
         *:has(> .ui.piled.segment) {
             z-index: 0;
             position: relative;

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -1635,7 +1635,7 @@ select.ui.dropdown {
         z-index: @pointingArrowZIndex;
     }
 
-    @supports selector(:has(.f)) {
+    @supports selector(:has(.f)) and (not(-moz-appearance: none)) {
         .ui.pointing.dropdown:not(.upward) .menu:has(:first-child:hover)::after,
         .ui.upward.pointing.dropdown .menu:has(:last-child:hover)::after {
             background: @hoveredItemBackground;
@@ -2060,7 +2060,7 @@ select.ui.dropdown {
                 box-shadow: @invertedPointingUpwardArrowBoxShadow;
             }
         }
-        @supports selector(:has(.f)) {
+        @supports selector(:has(.f)) and (not(-moz-appearance: none)) {
             .ui.inverted.pointing.dropdown:not(.upward) .menu:has(:first-child:hover)::after,
             .ui.inverted.upward.pointing.dropdown .menu:has(:last-child:hover)::after {
                 background: @invertedHoveredItemBackground;

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -1635,7 +1635,7 @@ select.ui.dropdown {
         z-index: @pointingArrowZIndex;
     }
 
-    @supports selector(:has(.f)) and (not(-moz-appearance: none)) {
+    @supports selector(:has(.f)) and (not (-moz-appearance: none)) {
         .ui.pointing.dropdown:not(.upward) .menu:has(:first-child:hover)::after,
         .ui.upward.pointing.dropdown .menu:has(:last-child:hover)::after {
             background: @hoveredItemBackground;
@@ -2060,7 +2060,7 @@ select.ui.dropdown {
                 box-shadow: @invertedPointingUpwardArrowBoxShadow;
             }
         }
-        @supports selector(:has(.f)) and (not(-moz-appearance: none)) {
+        @supports selector(:has(.f)) and (not (-moz-appearance: none)) {
             .ui.inverted.pointing.dropdown:not(.upward) .menu:has(:first-child:hover)::after,
             .ui.inverted.upward.pointing.dropdown .menu:has(:last-child:hover)::after {
                 background: @invertedHoveredItemBackground;


### PR DESCRIPTION
## Description

Firefox's implementation of the `:has` selector (perhaps in combination with the `@supports` selector) makes firefox freeze in certain situations.
After some investigation the reason are 3 of those selectors we implemented in 2.9.3. 
As Firefox had officially enabled the `:has` feature by default starting with FF 121 it was not happening before (and perhaps no FUI user was actively enabling it in older FF versions)

As all other browsers work just fine this PR removed Firefox support for now until it's fixed by mozilla
I detected only the changed three `@supports selector(:has)` selectors (in combination!) to trigger the freeze. In my tests, every other existing `@supports selector(:has)` selectors invented in 2.9.3 were not affected  so i kept them untouched in this PR

## Testcase
- Use Firefox
- starting to type "Computer" in the input field

Keep in mind that the selectors in question do not even belong to the example code! There is no piled segment and no pointing dropdown so the selector will not even trigger. 

### Broken
The tab freezes.
https://jsfiddle.net/e70xjovw/8/

### Fixed
https://jsfiddle.net/e70xjovw/9/

## Closes
#2971 

