### PR TITLE
fix(dropdown): direction calculation

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -3654,6 +3654,7 @@
                             ? callback
                             : function () {};
                         module.verbose('Doing menu show animation', $currentMenu);
+                        $currentMenu.removeClass(className.hidden);
                         module.set.direction($subMenu);
                         transition = settings.transition.showMethod || module.get.transition($subMenu);
                         if (module.is.selection()) {


### PR DESCRIPTION
## Description
fixes menu calculation while inferring direction

when using the api settings, after the second request the menu list element has the 
display: hidden !important;
css prop, producing a zero inner height of the menu during the direction calculation.
