### PR TITLE
feat(formvalidation): support prompt functions for settings value

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -558,9 +558,10 @@
                             ancillary     = module.get.ancillaryValue(rule),
                             $field        = module.get.field(field.identifier),
                             value         = $field.val(),
-                            prompt        = isFunction(rule.prompt)
-                                ? rule.prompt.call($field[0], value)
-                                : rule.prompt || settings.prompt[ruleName] || settings.text.unspecifiedRule,
+                            promptCheck   = rule.prompt || settings.prompt[ruleName] || settings.text.unspecifiedRule,
+                            prompt        = String(isFunction(promptCheck)
+                                ? promptCheck.call($field[0], value)
+                                : promptCheck),
                             requiresValue = prompt.search('{value}') !== -1,
                             requiresName  = prompt.search('{name}') !== -1,
                             parts,


### PR DESCRIPTION
## Description
Prompt functions are only supported when specified via custom rule declarations.
In case one wants to supply a prompt function as a setting instead, this breaks the code and results into "prompt.search is not a function" when validatin the form

## Testcase
### Broken
https://jsfiddle.net/0tsurydw/2/

### Fixed
https://jsfiddle.net/lubber/5vre3aLo/10/

## Closes
#2976 