### PR TITLE
fix(dropdown): fix map parameter on htmlentities

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -3787,6 +3787,7 @@
                         return text.replace(regExp.escape, '\\$&');
                     },
                     htmlEntities: function (string, forceAmpersand) {
+                        forceAmpersand = typeof forceAmpersand === 'number' ? false : forceAmpersand;
                         var
                             badChars     = /["'<>`]/g,
                             shouldEscape = /["&'<>`]/,


### PR DESCRIPTION
## Description

Multiple preselected values containing characters needed to be converted into htmlentities were encoded wrong (from the second value) because the related method was called as a .map() callback. However, .map callbacks are called given the index of the array as a second parameter. Unfortunately the given method expected something different which resulted in always encoding the ampersand character which broke the preselection

## Testcase
### Broken
Only the first preselected value is shown
https://jsfiddle.net/nae8ypo3/1/

### Fixed
Both preselected values are shown
https://jsfiddle.net/lubber/40qm6krt/

## Closes
#2979 


 