### PR TITLE
fix(dropdown): keep searchterm in menu search

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1187,7 +1187,7 @@
                                 if (!itemActivated && !pageLostFocus) {
                                     if (settings.forceSelection) {
                                         module.forceSelection();
-                                    } else if (!settings.allowAdditions) {
+                                    } else if (!settings.allowAdditions && !settings.keepSearchTerm && !module.has.menuSearch()) {
                                         module.remove.searchTerm();
                                     }
                                     module.hide();


### PR DESCRIPTION
## Description

Whenever a dropdown menu contains a separate search input to filter the menu items, the input value was removed when the field was blurred without selecting anything. This leaves the items filtered without a clue what to filter the next time the dropdown is opened again. 

## Testcase
- Click the button to open the dropwodn
- Enter "im" into the search field inside
- click outside of the dropdown, so it closes
- open the dropdown again

### Broken
- Item still filtered, but searchterm is lost
https://jsfiddle.net/k5oqbmaj/1/

### Fixed
- Item still filtered, searchterm still there
https://jsfiddle.net/lubber/nckm1sy2/5/

## Closes
#2983 

