### PR TITLE
fix(types): highlightmatches setting

### DIFF
--- a/types/fomantic-ui-dropdown.d.ts
+++ b/types/fomantic-ui-dropdown.d.ts
@@ -386,6 +386,12 @@ declare namespace FomanticUI {
         ignoreSearchCase: boolean;
 
         /**
+         * Whether search result should highlight matching strings
+         * @default false
+         */
+        highlightMatches: boolean;
+
+        /**
          * If disabled user additions will appear in the dropdown's menu using a specially formatted selection item formatted by 'templates.addition'.
          * @default true
          */

--- a/types/fomantic-ui-search.d.ts
+++ b/types/fomantic-ui-search.d.ts
@@ -229,6 +229,18 @@ declare namespace FomanticUI {
         ignoreDiacritics: boolean;
 
         /**
+         * Whether to consider case sensitivity on local searching
+         * @default true
+         */
+        ignoreSearchCase: boolean;
+
+        /**
+         * Whether search result should highlight matching strings
+         * @default false
+         */
+        highlightMatches: boolean;
+
+        /**
          * Template to use (specified in settings.templates)
          * @default 'standard'
          */


### PR DESCRIPTION
## Description

Type additions for new `highlightMatches` and `ignoreSearchCase` setting as of #2963 