### PR TITLE
fix(nag): fetch missing event on manual dismiss call

### DIFF
--- a/src/definitions/modules/nag.js
+++ b/src/definitions/modules/nag.js
@@ -144,8 +144,10 @@
                         module.debug('Dismissing nag', settings.storageMethod, settings.key, settings.value, settings.expires);
                         module.storage.set(settings.key, settings.value);
                     }
-                    event.stopImmediatePropagation();
-                    event.preventDefault();
+                    if (event) {
+                        event.stopImmediatePropagation();
+                        event.preventDefault();
+                    }
                 },
 
                 should: {


### PR DESCRIPTION
## Description
When the dismiss function is called manually via behavior `.nag('dismiss')` rather than being called inside an event (like when clicking on the close icon) a JS console error occured.

## Testcase
- Watch console
- Click the button

### Broken
`Uncaught TypeError: Cannot read properties of undefined (reading 'stopImmediatePropagation')`
https://jsfiddle.net/lubber/ofpc3du0/1/

### Fixed
All fine
https://jsfiddle.net/lubber/ofpc3du0/2/

## Closes
#2996 