### PR TITLE
fix(dropdown): support manual removed entries

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -2798,19 +2798,27 @@
                         $selectedItem = settings.allowAdditions
                             ? $selectedItem || module.get.itemWithAdditions(value)
                             : $selectedItem || module.get.item(value);
+                        if (!$selectedItem && value !== undefined) {
+                            return false;
+                        }
+                        if (isMultiple) {
+                            if (!keepSearchTerm) {
+                                module.remove.searchWidth();
+                            }
+                            if (settings.useLabels) {
+                                module.remove.selectedItem();
+                                if (value === undefined) {
+                                    module.remove.labels($module.find(selector.label), true);
+                                }
+                            }
+                        } else {
+                            module.remove.activeItem();
+                            module.remove.selectedItem();
+                        }
                         if (!$selectedItem) {
                             return false;
                         }
                         module.debug('Setting selected menu item to', $selectedItem);
-                        if (module.is.multiple() && !keepSearchTerm) {
-                            module.remove.searchWidth();
-                        }
-                        if (module.is.single()) {
-                            module.remove.activeItem();
-                            module.remove.selectedItem();
-                        } else if (settings.useLabels) {
-                            module.remove.selectedItem();
-                        }
                         // select each item
                         $selectedItem
                             .each(function () {


### PR DESCRIPTION
## Description

When the input of a dropdown (which holds the selected values) was changed , the change does not recognize when values are missing, which have been selected before.

## Testcase
- Click "add item"
- "Ghana" gets added to the dropdown because the input reads "gh"
- Click "remove item"

### Broken
- Nothing changes, although the input is empty now
https://jsfiddle.net/s13w0og6/28/

### Fixed
- Items gets deleted
https://jsfiddle.net/lubber/v6eth3qu/

## Closes
#2998 