### PR TITLE
fix(checkbox): disallow keynav on readonly radios

### DIFF
--- a/src/definitions/modules/checkbox.js
+++ b/src/definitions/modules/checkbox.js
@@ -210,7 +210,7 @@
                         ;
 
                         var
-                            r = module.get.radios(),
+                            r = module.get.radios().not(selector.disabled),
                             rIndex = r.index($module),
                             rLen = r.length,
                             checkIndex = false
@@ -228,7 +228,10 @@
 
                                 return false;
                             }
-                            if (settings.beforeChecked.apply($(r[checkIndex]).children(selector.input)[0]) === false) {
+                            var nextOption = $(r[checkIndex]),
+                                nextInput = nextOption.children(selector.input),
+                                disallowOption = nextOption.hasClass(className.readOnly) || nextInput.prop('readonly');
+                            if (disallowOption || settings.beforeChecked.apply(nextInput[0]) === false) {
                                 module.verbose('Next option should not allow check, cancelling key navigation');
 
                                 return false;
@@ -875,6 +878,7 @@
 
         selector: {
             checkbox: '.ui.checkbox',
+            disabled: '.disabled, :has(input[disabled])',
             label: 'label',
             input: 'input[type="checkbox"], input[type="radio"]',
             link: 'a[href]',


### PR DESCRIPTION
## Description
A readyonly radio checkbox should not change its state via keynav from another radio of the same group.
This PR covers the situation when the readonly radio is already unchecked. 

When it is already checked, it doesn't make sense to set this as the_only_ option to readonly as a radio is part of a radio group which, by nature, only has 1 active selection. And if one does not want this already selected option to be changed, all the other options from the same radio group should be either set to readonly or disabled.

## Testcase
- Click the Z1 option
- Press down arrow, nothing happens because the next option is readonly
https://jsfiddle.net/lubber/xud45evh/12/

## Closes
#2812 