### PR TITLE
feat(dropdown): support custom data attributes for items

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -793,7 +793,7 @@
                                 }
                                 if (module.is.multiple()) {
                                     $.each(preSelected, function (index, value) {
-                                        $item.filter('[data-value="' + value + '"]')
+                                        $item.filter('[data-' + metadata.value + '="' + value + '"]')
                                             .addClass(className.filtered)
                                         ;
                                     });
@@ -4163,6 +4163,7 @@
             descriptionVertical: 'descriptionVertical', // whether description should be vertical
             value: 'value', // actual dropdown value
             text: 'text', // displayed text when selected
+            data: 'data', // custom data attributes
             type: 'type', // type of dropdown element
             image: 'image', // optional image path
             imageClass: 'imageClass', // optional individual class for image
@@ -4307,9 +4308,21 @@
             $.each(values, function (index, option) {
                 var
                     itemType = option[fields.type] || 'item',
-                    isMenu = itemType.indexOf('menu') !== -1
+                    isMenu = itemType.indexOf('menu') !== -1,
+                    maybeData = ' ',
+                    dataObject = option[fields.data]
                 ;
-
+                if (dataObject) {
+                    var dataKey,
+                        dataKeyEscaped
+                    ;
+                    for (dataKey in dataObject) {
+                        dataKeyEscaped = String(dataKey).replace(/\W/g, '');
+                        if (Object.prototype.hasOwnProperty.call(dataObject, dataKey) && ['text', 'value'].indexOf(dataKeyEscaped.toLowerCase()) === -1) {
+                            maybeData += 'data-' + dataKeyEscaped + '="' + deQuote(String(dataObject[dataKey])) + '" ';
+                        }
+                    }
+                }
                 if (itemType === 'item' || isMenu) {
                     var
                         maybeText = option[fields.text]
@@ -4326,7 +4339,7 @@
                             : '',
                         hasDescription = escape(option[fields.description] || '', preserveHTML) !== ''
                     ;
-                    html += '<div class="' + deQuote(maybeActionable + maybeDisabled + maybeDescriptionVertical + (option[fields.class] || className.item)) + '" data-value="' + deQuote(option[fields.value], true) + '"' + maybeText + '>';
+                    html += '<div class="' + deQuote(maybeActionable + maybeDisabled + maybeDescriptionVertical + (option[fields.class] || className.item)) + '" data-value="' + deQuote(option[fields.value], true) + '"' + maybeText + maybeData + '>';
                     if (isMenu) {
                         html += '<i class="' + (itemType.indexOf('left') !== -1 ? 'left' : '') + ' dropdown icon"></i>';
                     }

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -4309,7 +4309,7 @@
                 var
                     itemType = option[fields.type] || 'item',
                     isMenu = itemType.indexOf('menu') !== -1,
-                    maybeData = ' ',
+                    maybeData = '',
                     dataObject = option[fields.data]
                 ;
                 if (dataObject) {
@@ -4319,7 +4319,7 @@
                     for (dataKey in dataObject) {
                         dataKeyEscaped = String(dataKey).replace(/\W/g, '');
                         if (Object.prototype.hasOwnProperty.call(dataObject, dataKey) && ['text', 'value'].indexOf(dataKeyEscaped.toLowerCase()) === -1) {
-                            maybeData += 'data-' + dataKeyEscaped + '="' + deQuote(String(dataObject[dataKey])) + '" ';
+                            maybeData += ' data-' + dataKeyEscaped + '="' + deQuote(String(dataObject[dataKey])) + '"';
                         }
                     }
                 }


### PR DESCRIPTION
## Description
This PR allows to render custom data- attributes for each dropdown item by providing a `data` key object.
Every key inside the data object will be rendered as data attribute (only "text" and "value" will be ignored as those are already used by the dropdown module internally)

## Testcase
```javascript
$('.ui.dropdown').dropdown({
    values: [
      {
        name: 'Mother',
        value: 'mom',
        data: {
          husband: 'george',
          age: 73
        }
      }
    ]
  })
;
```

which results in

```html
<div class="item" data-value="mom" data-husband="george" data-age="73">Mother</div>
```

## Screenshot
![image](https://github.com/fomantic/Fomantic-UI/assets/18379884/fd94cb15-d432-4c55-bac4-bcea3a4d70a8)

## Closes
#1236 