### PR TITLE
fix(dropdown): clearable icon was missing or misaligned

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -3468,7 +3468,12 @@
                         return $selectedMenu.hasClass(className.leftward);
                     },
                     clearable: function () {
-                        return $module.hasClass(className.clearable) || settings.clearable;
+                        var hasClearableClass =  $module.hasClass(className.clearable);
+                        if (!hasClearableClass && settings.clearable) {
+                            $module.addClass(className.clearable);
+                        }
+
+                        return hasClearableClass || settings.clearable;
                     },
                     disabled: function () {
                         return $module.hasClass(className.disabled);

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -3468,7 +3468,7 @@
                         return $selectedMenu.hasClass(className.leftward);
                     },
                     clearable: function () {
-                        var hasClearableClass =  $module.hasClass(className.clearable);
+                        var hasClearableClass = $module.hasClass(className.clearable);
                         if (!hasClearableClass && settings.clearable) {
                             $module.addClass(className.clearable);
                         }

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -811,14 +811,14 @@ select.ui.dropdown {
         }
     }
 
-    .ui.clearable.dropdown .text,
-    .ui.clearable.dropdown a:last-of-type {
+    .ui.clearable.dropdown .text:not(.default),
+    .ui.clearable.dropdown:not(.search) > .ui.label:last-of-type {
         margin-right: @clearableTextMargin;
     }
 
     .ui.dropdown select.noselection ~ .remove.icon,
     .ui.dropdown input[value=""] ~ .remove.icon,
-    .ui.dropdown input:not([value]) ~ .remove.icon,
+    .ui.dropdown input:not([value]):not(.search) ~ .remove.icon,
     .ui.dropdown.loading > .remove.icon {
         display: none;
     }


### PR DESCRIPTION
## Description
clearable icon ...
- was missing when used inside a search selection dropdown
- was misaligned when used inside an inline dropdown

The basic fixes where already implemented but only if the `clearable` class was set manually, which this PR now automatically adds when the clearable setting is used.

## Testcase
https://jsfiddle.net/lubber/nwjqr7Le/

## Screenshot
### Broken
![image](https://github.com/fomantic/Fomantic-UI/assets/18379884/ec06ef5c-d132-436f-943b-eac615e0d46d)

### Fixed
![image](https://github.com/fomantic/Fomantic-UI/assets/18379884/eb50dcd4-b5a0-4643-91af-38b15e3bcace)
