### PR TITLE
fix(core): use scrollbar-width and color on firefox only

### DIFF
--- a/src/definitions/collections/table.less
+++ b/src/definitions/collections/table.less
@@ -458,11 +458,19 @@
         display: block;
         overflow-y: scroll;
         overscroll-behavior: @overscrollBehavior;
-        scrollbar-width: thin; /* Firefox */
         & > tr {
             display: table;
             table-layout: fixed;
             width: 100%;
+        }
+    }
+    & when (@useCustomScrollbars) {
+        @supports (-moz-appearance: none) {
+            .ui.scrolling.table > thead,
+            .ui.scrolling.table > tfoot,
+            .ui.scrolling.table > tbody {
+                scrollbar-width: thin;
+            }
         }
     }
 
@@ -492,61 +500,68 @@
         background: inherit;
         border-radius: @borderRadius;
     }
-
-    /* Firefox & IE */
-    .ui.scrolling.table > thead,
-    .ui.scrolling.table > tfoot {
-        scrollbar-color: currentColor currentColor;
-        & when (@supportIE) {
-            scrollbar-face-color: currentColor;
-            scrollbar-shadow-color: currentColor;
-            scrollbar-track-color: currentColor;
-            scrollbar-arrow-color: currentColor;
-        }
-    }
-    & when (@supportIE) {
-        /* IE scrollbar color needs hex values */
-        @media all and (-ms-high-contrast: none) {
-            .ui.scrolling.table > thead {
-                color: @headerBackgroundHex;
-            }
+    & when (@useCustomScrollbars) {
+        @supports (-moz-appearance: none) {
+            .ui.scrolling.table > thead,
             .ui.scrolling.table > tfoot {
-                color: @footerBackgroundHex;
-            }
-            & when (@variationTableInverted) {
-                .ui.inverted.scrolling.table > thead {
-                    color: @invertedHeaderBackgroundHex;
-                }
-                .ui.inverted.scrolling.table > tfoot {
-                    color: @invertedFooterBackgroundHex;
-                }
+                scrollbar-color: currentColor currentColor;
             }
         }
-    }
-    & when (@variationTableInverted) {
-        .ui.inverted.scrolling.table > tbody::-webkit-scrollbar-track {
-            background: @trackInvertedBackground;
-        }
-        .ui.inverted.scrolling.table > tbody::-webkit-scrollbar-thumb {
-            background: @thumbInvertedBackground;
-        }
-        .ui.inverted.scrolling.table > tbody::-webkit-scrollbar-thumb:window-inactive {
-            background: @thumbInvertedInactiveBackground;
-        }
-        .ui.inverted.scrolling.table > tbody::-webkit-scrollbar-thumb:hover {
-            background: @thumbInvertedHoverBackground;
-        }
-        .ui.inverted.scrolling.table > tbody {
-            & when (@supportIE) {
-                /* IE11 */
-                scrollbar-face-color: @thumbInvertedBackgroundHex;
-                scrollbar-shadow-color: @thumbInvertedBackgroundHex;
-                scrollbar-track-color: @trackInvertedBackgroundHex;
-                scrollbar-arrow-color: @trackInvertedBackgroundHex;
-            }
 
-            /* firefox: first color thumb, second track */
-            scrollbar-color: @thumbInvertedBackground @trackInvertedBackground;
+        & when (@supportIE) {
+            /* IE scrollbar color needs hex values */
+            @media all and (-ms-high-contrast: none) {
+                .ui.scrolling.table > thead,
+                .ui.scrolling.table > tfoot {
+                    scrollbar-face-color: currentColor;
+                    scrollbar-shadow-color: currentColor;
+                    scrollbar-track-color: currentColor;
+                    scrollbar-arrow-color: currentColor;
+                }
+                .ui.scrolling.table > thead {
+                    color: @headerBackgroundHex;
+                }
+                .ui.scrolling.table > tfoot {
+                    color: @footerBackgroundHex;
+                }
+                & when (@variationTableInverted) {
+                    .ui.inverted.scrolling.table > thead {
+                        color: @invertedHeaderBackgroundHex;
+                    }
+                    .ui.inverted.scrolling.table > tfoot {
+                        color: @invertedFooterBackgroundHex;
+                    }
+                }
+            }
+        }
+        & when (@variationTableInverted) {
+            .ui.inverted.scrolling.table > tbody::-webkit-scrollbar-track {
+                background: @trackInvertedBackground;
+            }
+            .ui.inverted.scrolling.table > tbody::-webkit-scrollbar-thumb {
+                background: @thumbInvertedBackground;
+            }
+            .ui.inverted.scrolling.table > tbody::-webkit-scrollbar-thumb:window-inactive {
+                background: @thumbInvertedInactiveBackground;
+            }
+            .ui.inverted.scrolling.table > tbody::-webkit-scrollbar-thumb:hover {
+                background: @thumbInvertedHoverBackground;
+            }
+            & when (@supportIE) {
+                .ui.inverted.scrolling.table > tbody {
+                    /* IE11 */
+                    scrollbar-face-color: @thumbInvertedBackgroundHex;
+                    scrollbar-shadow-color: @thumbInvertedBackgroundHex;
+                    scrollbar-track-color: @trackInvertedBackgroundHex;
+                    scrollbar-arrow-color: @trackInvertedBackgroundHex;
+                }
+            }
+            @supports (-moz-appearance: none) {
+                .ui.inverted.scrolling.table > tbody {
+                    /* firefox: first color thumb, second track */
+                    scrollbar-color: @thumbInvertedBackground @trackInvertedBackground;
+                }
+            }
         }
     }
     & when (@variationTableResizable) {

--- a/src/definitions/globals/site.less
+++ b/src/definitions/globals/site.less
@@ -148,18 +148,21 @@ a:hover {
     body ::-webkit-scrollbar-thumb:hover {
         background: @thumbHoverBackground;
     }
-    body .ui {
-        & when (@supportIE) {
+    & when (@supportIE) {
+        body .ui {
             /* IE11 */
             scrollbar-face-color: @thumbBackgroundHex;
             scrollbar-shadow-color: @thumbBackgroundHex;
             scrollbar-track-color: @trackBackgroundHex;
             scrollbar-arrow-color: @trackBackgroundHex;
         }
-
-        /* firefox: first color thumb, second track */
-        scrollbar-color: @thumbBackground @trackBackground;
-        scrollbar-width: thin;
+    }
+    @supports (-moz-appearance: none) {
+        body .ui {
+            /* firefox: first color thumb, second track */
+            scrollbar-color: @thumbBackground @trackBackground;
+            scrollbar-width: thin;
+        }
     }
 
     /* Inverted UI */
@@ -175,18 +178,20 @@ a:hover {
     body .ui.inverted:not(.dimmer)::-webkit-scrollbar-thumb:hover {
         background: @thumbInvertedHoverBackground;
     }
-
-    body .ui.inverted:not(.dimmer) {
-        & when (@supportIE) {
+    & when (@supportIE) {
+        body .ui.inverted:not(.dimmer) {
             /* IE11 */
             scrollbar-face-color: @thumbInvertedBackgroundHex;
             scrollbar-shadow-color: @thumbInvertedBackgroundHex;
             scrollbar-track-color: @trackInvertedBackgroundHex;
             scrollbar-arrow-color: @trackInvertedBackgroundHex;
         }
-
-        /* firefox: first color thumb, second track */
-        scrollbar-color: @thumbInvertedBackground @trackInvertedBackground;
+    }
+    @supports (-moz-appearance: none) {
+        body .ui.inverted:not(.dimmer) {
+            /* firefox: first color thumb, second track */
+            scrollbar-color: @thumbInvertedBackground @trackInvertedBackground;
+        }
     }
 }
 

--- a/src/definitions/modules/dimmer.less
+++ b/src/definitions/modules/dimmer.less
@@ -74,17 +74,20 @@
     .ui.dimmer:not(.inverted)::-webkit-scrollbar-thumb:hover {
         background: @thumbInvertedHoverBackground;
     }
-    .ui.dimmer:not(.inverted) {
-        & when (@supportIE) {
+    & when (@supportIE) {
+        .ui.dimmer:not(.inverted) {
             /* IE11 */
             scrollbar-face-color: @thumbInvertedBackgroundHex;
             scrollbar-shadow-color: @thumbInvertedBackgroundHex;
             scrollbar-track-color: @trackInvertedBackgroundHex;
             scrollbar-arrow-color: @trackInvertedBackgroundHex;
         }
-
-        /* firefox: first color thumb, second track */
-        scrollbar-color: @thumbInvertedBackground @trackInvertedBackground;
+    }
+    @supports (-moz-appearance: none) {
+        .ui.dimmer:not(.inverted) {
+            /* firefox: first color thumb, second track */
+            scrollbar-color: @thumbInvertedBackground @trackInvertedBackground;
+        }
     }
 }
 

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -2042,18 +2042,22 @@ select.ui.dropdown {
         .ui.inverted.dropdown .menu::-webkit-scrollbar-thumb:hover {
             background: @thumbInvertedHoverBackground;
         }
-        .ui.dropdown .inverted.menu,
-        .ui.inverted.dropdown .menu {
-            & when (@supportIE) {
+        & when (@supportIE) {
+            .ui.dropdown .inverted.menu,
+            .ui.inverted.dropdown .menu {
                 /* IE11 */
                 scrollbar-face-color: @thumbInvertedBackgroundHex;
                 scrollbar-shadow-color: @thumbInvertedBackgroundHex;
                 scrollbar-track-color: @trackInvertedBackgroundHex;
                 scrollbar-arrow-color: @trackInvertedBackgroundHex;
             }
-
-            /* firefox: first color thumb, second track */
-            scrollbar-color: @thumbInvertedBackground @trackInvertedBackground;
+        }
+        @supports (-moz-appearance: none) {
+            .ui.dropdown .inverted.menu,
+            .ui.inverted.dropdown .menu {
+                /* firefox: first color thumb, second track */
+                scrollbar-color: @thumbInvertedBackground @trackInvertedBackground;
+            }
         }
     }
     & when (@variationDropdownPointing) {


### PR DESCRIPTION
## Description

The `scrollbar-width` and `scrollbar-color` properties are also supported by Chromium based Browsers nowadays (Since 121).
However, the properties in chromium based browsers don't visually work the same (and old FUI) way as it does in firefox.

This PR makes sure those CSS properties are only applied in firefox  so chromium based browsers will still only use the old `::-webit-scrollbar-xxxx` approach.

## Closes
#3002 