### PR TITLE
fix(feed): inverted anchor and icon meta

### DIFF
--- a/src/definitions/collections/table.less
+++ b/src/definitions/collections/table.less
@@ -117,16 +117,16 @@
 .ui.table > tfoot > tr > td:first-child {
     border-left: none;
 }
-.ui.table > tfoot > tr:first-child > th:first-child,
-.ui.table > tfoot > tr:first-child > td:first-child {
+.ui.table > tfoot > tr:last-child > th:first-child,
+.ui.table > tfoot > tr:last-child > td:first-child {
     border-radius: 0 0 0 @borderRadius;
 }
-.ui.table > tfoot > tr:first-child > th:last-child,
-.ui.table > tfoot > tr:first-child > td:last-child {
+.ui.table > tfoot > tr:last-child > th:last-child,
+.ui.table > tfoot > tr:last-child > td:last-child {
     border-radius: 0 0 @borderRadius 0;
 }
-.ui.table > tfoot > tr:first-child > th:only-child,
-.ui.table > tfoot > tr:first-child > td:only-child {
+.ui.table > tfoot > tr:last-child > th:only-child,
+.ui.table > tfoot > tr:last-child > td:only-child {
     border-radius: 0 0 @borderRadius @borderRadius;
 }
 

--- a/src/definitions/views/feed.less
+++ b/src/definitions/views/feed.less
@@ -459,6 +459,18 @@
             color: @invertedLikeActiveColor;
         }
     }
+
+    & when (@varitaionFeedMeta) {
+        .ui.inverted.feed > .event > .content .meta a,
+        .ui.inverted.feed > .event > .content .meta > i.icon {
+            color: @invertedMetadataActionColor;
+        }
+        .ui.inverted.feed > .event > .content .meta a:hover,
+        .ui.inverted.feed > .event > .content .meta a:hover i.icon,
+        .ui.inverted.feed > .event > .content .meta > i.icon:hover {
+            color: @invertedMetadataActionHoverColor;
+        }
+    }
 }
 
 /* --------------

--- a/src/themes/default/views/feed.variables
+++ b/src/themes/default/views/feed.variables
@@ -190,6 +190,9 @@
 @invertedLikeHoverColor: @invertedSelectedTextColor;
 @invertedLikeActiveColor: @invertedLikeColor;
 
+@invertedMetadataActionColor: @invertedLightTextColor;
+@invertedMetadataActionHoverColor: @selectedTextColor;
+
 @invertedConnectedBorderColor: @whiteBorderColor;
 @invertedDividedBorderColor: @whiteBorderColor;
 @invertedTextLabelColor: @white;


### PR DESCRIPTION
## Description
Added support for inverted feed metadata actions by adding styles in feed.less and defining corresponding color variables in feed.variables

## Testcase
https://jsfiddle.net/Festiis/sn82grqL/1/