### PR TITLE
fix(dropdown): fetch js error on non existing letter selections

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -2677,7 +2677,7 @@
                             module.set.scrollPosition($nextValue);
                             $selectedItem.removeClass(className.selected);
                             $nextValue.addClass(className.selected);
-                            if (settings.selectOnKeydown && module.is.single() && !$nextItem.hasClass(className.actionable)) {
+                            if (settings.selectOnKeydown && module.is.single() && (!$nextItem || !$nextItem.hasClass(className.actionable))) {
                                 module.set.selectedItem($nextValue);
                             }
                         }


### PR DESCRIPTION
## Description

When a dropdown is open, if you type a letter to match a label in the dropdown, an error occurs:

![image](https://github.com/fomantic/Fomantic-UI/assets/18379884/7a4ff841-eeb7-41c0-afc8-e026635e4d28)

Note that you have to type a letter to match a label in the dropdown. If there isn't an entry starting with the letter given, no error will occur.

## Testcase
- Open the dropdown
- Type "d" on your keyboard

### Broken
Console Error
https://jsfiddle.net/lubber/x25f369y/

### Fixed
No error, all fine
https://jsfiddle.net/lubber/x25f369y/1/

## Closes
#3027