### PR TITLE
feat(calendar): remove data values on destroy

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -102,7 +102,17 @@
 
                 destroy: function () {
                     module.verbose('Destroying previous calendar for', element);
-                    $module.removeData(moduleNamespace);
+                    $module.removeData([
+                        metadata.date,
+                        metadata.focusDate,
+                        metadata.startDate,
+                        metadata.endDate,
+                        metadata.minDate,
+                        metadata.maxDate,
+                        metadata.mode,
+                        metadata.monthOffset,
+                        moduleNamespace,
+                    ]);
                     module.unbind.events();
                     module.disconnect.classObserver();
                 },


### PR DESCRIPTION
## Description
data saved to the jquery calendar object was not removed on destroy. This leads to situations when a re-instantiation of the same calendar gets confused about different setting than the previous (data()-stored) values.

## Testcase
- Open the calendar, it should show the 6th of April in the header

### Broken
- It shows the first of April
https://jsfiddle.net/978rct0k/7/

###
- It shows the 6th of April
https://jsfiddle.net/lubber/b04zkxf6/

## Closes
#3031 