### PR TITLE
fix(button): circular spaced and circular icon group was not respected

### DIFF
--- a/src/definitions/elements/button.less
+++ b/src/definitions/elements/button.less
@@ -1098,8 +1098,10 @@
     .ui.ui.circular.buttons .button,
     .ui.ui.ui.ui.circular.button {
         border-radius: @circularBorderRadius;
+        min-width: @circularMinWidth;
     }
 
+    .ui.circular.buttons .button > .icon,
     .ui.circular.button > .icon {
         width: @circularIconWidth;
         vertical-align: baseline;

--- a/src/definitions/elements/button.less
+++ b/src/definitions/elements/button.less
@@ -1098,7 +1098,6 @@
     .ui.ui.circular.buttons .button,
     .ui.ui.ui.ui.circular.button {
         border-radius: @circularBorderRadius;
-        min-width: @circularMinWidth;
     }
 
     .ui.circular.buttons .button > .icon,

--- a/src/definitions/elements/button.less
+++ b/src/definitions/elements/button.less
@@ -1105,7 +1105,7 @@
         vertical-align: baseline;
     }
 
-    .ui.circular.buttons:not(.vertical) .button {
+    .ui.circular.buttons:not(.vertical):not(.spaced) .button {
         margin-right: @circularGroupMargin;
     }
 

--- a/src/themes/default/elements/button.variables
+++ b/src/themes/default/elements/button.variables
@@ -393,7 +393,6 @@
 
 /* Circular */
 @circularBorderRadius: 10em;
-@circularMinWidth: 2.5em;
 @circularIconWidth: 1em;
 @circularGroupMargin: 0.25em;
 @circularVerticalGroupMargin: @circularGroupMargin;

--- a/src/themes/default/elements/button.variables
+++ b/src/themes/default/elements/button.variables
@@ -393,6 +393,7 @@
 
 /* Circular */
 @circularBorderRadius: 10em;
+@circularMinWidth: 2.5em;
 @circularIconWidth: 1em;
 @circularGroupMargin: 0.25em;
 @circularVerticalGroupMargin: @circularGroupMargin;


### PR DESCRIPTION
## Description
The new circular button group variant did not respect the spaced variant for right margin and did not respect the icon variant for width

## Testcase
### Before
https://jsfiddle.net/lubber/yh25feLd/21/

### After
https://jsfiddle.net/lubber/yh25feLd/24/

## Screenshot
### Before
![image](https://github.com/fomantic/Fomantic-UI/assets/18379884/08cea5d7-0fb3-418e-918a-92b70a11a1ee)
![image](https://github.com/fomantic/Fomantic-UI/assets/18379884/45db452c-4b65-47c1-aad8-0de5bc35d4bf)

### After
![image](https://github.com/fomantic/Fomantic-UI/assets/18379884/866bed0d-dc41-4ac4-adb2-52d3dd624001)
![image](https://github.com/fomantic/Fomantic-UI/assets/18379884/1875acc5-a56d-4bcb-811b-8ca96595585f)

## Corrects
#2946 
