### PR TITLE
feat(progress): basic variant and support empty bar

### DIFF
--- a/src/definitions/modules/progress.less
+++ b/src/definitions/modules/progress.less
@@ -33,6 +33,14 @@
     border-radius: @borderRadius;
 }
 
+& when (@variationProgressBasic) {
+    .ui.basic.progress {
+        background: transparent;
+        border: none;
+        box-shadow: none;
+    }
+}
+
 .ui.progress:first-child {
     margin: @firstMargin;
 }
@@ -50,14 +58,16 @@
     line-height: 1;
     position: @barPosition;
     width: @barInitialWidth;
-    min-width: @barMinWidth;
     background: @barBackground;
     border-radius: @barBorderRadius;
     transition: @barTransition;
     overflow: hidden;
+    &:not(:empty) {
+        min-width: @barMinWidth;
+    }
 }
-.ui.ui.ui.progress:not([data-percent]):not(.indeterminate) .bar,
-.ui.ui.ui.progress[data-percent="0"]:not(.indeterminate) .bar {
+.ui.ui.ui.progress:not([data-percent]):not(.indeterminate) .bar:not(:empty),
+.ui.ui.ui.progress[data-percent="0"]:not(.indeterminate) .bar:not(:empty) {
     background: transparent;
 }
 .ui.progress[data-percent="0"] .bar .progress {
@@ -328,7 +338,9 @@
 
     .ui.active.progress .bar {
         position: relative;
-        min-width: @activeMinWidth;
+        &:not(:empty) {
+            min-width: @activeMinWidth;
+        }
     }
     .ui.active.progress .bar::after {
         content: "";
@@ -384,7 +396,7 @@
         Inverted
     --------------- */
 
-    .ui.inverted.progress {
+    .ui.inverted.progress:not(.basic) {
         background: @invertedBackground;
         border: @invertedBorder;
     }

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -643,6 +643,7 @@
 /* Progress */
 @variationProgressInverted: true;
 @variationProgressDisabled: true;
+@variationProgressBasic: true;
 @variationProgressIndicating: true;
 @variationProgressIndeterminate: true;
 @variationProgressSliding: true;


### PR DESCRIPTION
## Description
- Added new `basic` variant for progress, which removes the remaining bar background
- Supported a proper minimum bar width when it does not contain any content

## Testcase
Remove CSS to see difference
https://jsfiddle.net/lubber/1f0jtgq8/14/

## Screenshots
### Before
- First progressbars as usual
- Last progress bar should have a proper width of 1%, but still shows a wider width because this is occupied for a possible text of "1%"
![image](https://github.com/fomantic/Fomantic-UI/assets/18379884/0ae6c3d6-e1de-4aeb-b2ec-52c25337c8be)

### After
- first two dont show remaining bar background anymore as expected for the new "basic" variant
- 1% width as expected
![image](https://github.com/fomantic/Fomantic-UI/assets/18379884/121a723d-c996-45fe-90a3-92ad3245ff88)

