### PR TITLE
fix(dropdown): add given placeholder

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -126,6 +126,8 @@
                             module.set.initialLoad();
                             module.change.values(settings.values);
                             module.remove.initialLoad();
+                        } else if (module.get.placeholderText() !== '') {
+                            module.set.placeholderText();
                         }
 
                         module.refreshData();


### PR DESCRIPTION
## Description
When the dropdown settings do not contain any data, so either a given HTML structure should be used or the data should be fetched via apiSettings, and also a placeholderText is provided via settings, such placeholder wont be set.

## Testcase
https://jsfiddle.net/lubber/qkLs2xzp/1/

## Closes
#2837 