### PR TITLE
fix(message): compact message should not exceed max width

### DIFF
--- a/src/definitions/collections/message.less
+++ b/src/definitions/collections/message.less
@@ -195,6 +195,7 @@
 
     .ui.compact.message {
         display: inline-block;
+        max-width: 100%;
     }
     .ui.compact.icon.message {
         display: inline-flex;


### PR DESCRIPTION
## Description
In some situations when specific nested width limited elements are inside a `compact message`, the message could overflow the screen width

## Testcase
Open https://fomantic-ui.com/modules/accordion.html#right-icon on a mobile device or switch your browser to mobile view
This example wraps an accordion inside a compact message and overflows the screen.

## Screenshot
|Before|After|
|-|-|
|![image](https://github.com/fomantic/Fomantic-UI/assets/18379884/b7307c9f-ee69-4c0e-9f5d-591d40ccc4b8)|![image](https://github.com/fomantic/Fomantic-UI/assets/18379884/5bd6c5a5-e531-4bac-aedb-9c99b9cea5c0)| 