### PR TITLE
fix(form): dont add whitespace on empty required field labels

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -849,8 +849,8 @@
     }
 }
 
-.ui.ui.ui.ui.form .fields > label:empty::after,
-.ui.ui.ui.ui.form .field > label:empty::after {
+.ui.ui.ui.ui.form .fields:not(.required) > label:empty::after,
+.ui.ui.ui.ui.form .field:not(.required) > label:empty::after {
     content: " ";
     display: inline-block;
 }

--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -850,7 +850,7 @@
 }
 
 .ui.ui.ui.ui.form .fields:not(.required) > label:empty::after,
-.ui.ui.ui.ui.form .field:not(.required) > label:empty::after {
+.ui.ui.ui.ui.form .fields:not(.grouped):not(.inline) > .field:not(.required) > label:empty::after {
     content: " ";
     display: inline-block;
 }

--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -855,6 +855,10 @@
     display: inline-block;
 }
 
+.ui.ui.ui.ui.form .inline.fields .field:not(.required) > label:empty {
+    display: none;
+}
+
 /*******************************
            Variations
 *******************************/


### PR DESCRIPTION
## Description
Followup of #2711

Whenever an empty label was used for a required single field or non-grouped, non-inline fields group, the label was still receiving an extra space to create a default height and did not display the asterisk. The intention of the space character was for empty non required fields to match same height when used inside a fields row.

If one does not want a label at all and does not want to make this field required, you would not render the label at all and wont get additional space then

## Closes
https://github.com/fomantic/Fomantic-UI/pull/2711#issuecomment-2176221081