### PR TITLE
fix(form): duplicate error displays on invalid form field value

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1398,7 +1398,7 @@
                                                 // Also allow multiple error prompts per field identifier but make sure each prompt is unique
                                                 || !(formErrorsTracker[identifier].includes(fieldError))
                                                 // Limit the number of unique error prompts for every field identifier if specified
-                                                && formErrorsTracker[identifier].length < errorLimit
+                                                && (!errorLimit || formErrorsTracker[identifier].length < errorLimit)
                                             ) {
                                                     fieldErrors.push(fieldError);
                                                     (formErrorsTracker[identifier] = formErrorsTracker[identifier] || []).push(fieldError);

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1394,14 +1394,14 @@
                                         if (!settings.inline) {
                                             if (
                                                 // Always allow the first error prompt for new field identifiers
-                                                !(identifier in formErrorsTracker) 
+                                                (!(identifier in formErrorsTracker)
                                                 // Also allow multiple error prompts per field identifier but make sure each prompt is unique
-                                                || !(formErrorsTracker[identifier].includes(fieldError))
+                                                || !formErrorsTracker[identifier].includes(fieldError))
                                                 // Limit the number of unique error prompts for every field identifier if specified
                                                 && (!errorLimit || formErrorsTracker[identifier].length < errorLimit)
                                             ) {
-                                                    fieldErrors.push(fieldError);
-                                                    (formErrorsTracker[identifier] = formErrorsTracker[identifier] || []).push(fieldError);
+                                                fieldErrors.push(fieldError);
+                                                (formErrorsTracker[identifier] = formErrorsTracker[identifier] || []).push(fieldError);
                                             }
                                         } else {
                                             fieldErrors.push(fieldError);

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -949,7 +949,7 @@
                                     $prompt.css('display', 'none');
                                 }
                                 $prompt
-                                    .appendTo($fieldGroup.filter('.error'))
+                                    .appendTo($fieldGroup.filter('.' + className.error))
                                 ;
                             }
                             $prompt
@@ -1396,7 +1396,7 @@
                                                 // Always allow the first error prompt for new field identifiers
                                                 (!(identifier in formErrorsTracker)
                                                 // Also allow multiple error prompts per field identifier but make sure each prompt is unique
-                                                || !formErrorsTracker[identifier].includes(fieldError))
+                                                || !formErrorsTracker[identifier].indexOf(fieldError))
                                                 // Limit the number of unique error prompts for every field identifier if specified
                                                 && (!errorLimit || formErrorsTracker[identifier].length < errorLimit)
                                             ) {

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1398,7 +1398,7 @@
                                                 // Also allow multiple error prompts per field identifier but make sure each prompt is unique
                                                 || formErrorsTracker[identifier].indexOf(fieldError) === -1)
                                                 // Limit the number of unique error prompts for every field identifier if specified
-                                                && (!errorLimit || formErrorsTracker[identifier].length < errorLimit)
+                                                && (!errorLimit || (formErrorsTracker[identifier] || []).length < errorLimit)
                                             ) {
                                                 fieldErrors.push(fieldError);
                                                 (formErrorsTracker[identifier] = formErrorsTracker[identifier] || []).push(fieldError);

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -949,7 +949,7 @@
                                     $prompt.css('display', 'none');
                                 }
                                 $prompt
-                                    .appendTo($fieldGroup)
+                                    .appendTo($fieldGroup.filter('.error'))
                                 ;
                             }
                             $prompt
@@ -1390,11 +1390,21 @@
                                     var invalidFields = module.validate.rule(field, rule, true) || [];
                                     if (invalidFields.length > 0) {
                                         module.debug('Field is invalid', identifier, rule.type);
-                                        // Only add a field error prompt once per unique identifier
-                                        if (!(identifier in formErrorsTracker)) {
-                                            var fieldError = module.get.prompt(rule, field);
+                                        var fieldError = module.get.prompt(rule, field);
+                                        if (!settings.inline) {
+                                            if (
+                                                // Always allow the first error prompt for new field identifiers
+                                                !(identifier in formErrorsTracker) 
+                                                // Also allow multiple error prompts per field identifier but make sure each prompt is unique
+                                                || !(formErrorsTracker[identifier].includes(fieldError))
+                                                // Limit the number of unique error prompts for every field identifier if specified
+                                                && formErrorsTracker[identifier].length < errorLimit
+                                            ) {
+                                                    fieldErrors.push(fieldError);
+                                                    (formErrorsTracker[identifier] = formErrorsTracker[identifier] || []).push(fieldError);
+                                            }
+                                        } else {
                                             fieldErrors.push(fieldError);
-                                            formErrorsTracker[identifier] = fieldError;
                                         }
                                         fieldValid = false;
                                         if (showErrors) {

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1358,7 +1358,6 @@
                                 : false,
                             fieldValid  = true,
                             fieldErrors = [],
-                            newIdentifier = false,
                             isDisabled = $field.filter(':not(:disabled)').length === 0 || $fieldGroup.hasClass(className.disabled) || $fieldGroup.parent().hasClass(className.disabled),
                             validationMessage = $field[0].validationMessage,
                             noNativeValidation = field.noNativeValidation || settings.noNativeValidation || $field.filter('[formnovalidate],[novalidate]').length > 0 || $module.filter('[novalidate]').length > 0,
@@ -1396,7 +1395,6 @@
                                             var fieldError = module.get.prompt(rule, field);
                                             fieldErrors.push(fieldError);
                                             formErrorsTracker[identifier] = fieldError;
-                                            newIdentifier = true;
                                         }
                                         fieldValid = false;
                                         if (showErrors) {
@@ -1412,7 +1410,7 @@
                                 settings.onValid.call($field);
                             }
                         } else {
-                            if (showErrors && newIdentifier) {
+                            if (showErrors && fieldErrors.length > 0) {
                                 formErrors = formErrors.concat(fieldErrors);
                                 module.add.prompt(identifier, fieldErrors, true);
                                 settings.onInvalid.call($field, fieldErrors);

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1396,7 +1396,7 @@
                                                 // Always allow the first error prompt for new field identifiers
                                                 (!(identifier in formErrorsTracker)
                                                 // Also allow multiple error prompts per field identifier but make sure each prompt is unique
-                                                || !formErrorsTracker[identifier].indexOf(fieldError))
+                                                || formErrorsTracker[identifier].indexOf(fieldError) === -1)
                                                 // Limit the number of unique error prompts for every field identifier if specified
                                                 && (!errorLimit || formErrorsTracker[identifier].length < errorLimit)
                                             ) {


### PR DESCRIPTION
<!--
 Please read our Contributing Guide and Code of Conduct before you
 submit a pull request.
  
 Contributing Guide: https://github.com/fomantic/Fomantic-UI/blob/master/CONTRIBUTING.md
 Code of Conduct: https://github.com/fomantic/Fomantic-UI/blob/master/CODE_OF_CONDUCT.md

 ----

 Please use the following pull request title format:
 "[<scope>] <summary of what you fixed/changed>"
-->

## Description
<!-- Describe what you fixed/changed in great detail (required). -->
Adds a variable `formErrorsTracker` that tracks which field identifiers have already pushed an error prompt in the `formErrors` variable which limits the number of error prompt for every field identifier into 1.

## Test

https://jsfiddle.net/94oer63c/

## Screenshot (if possible)
![image](https://github.com/fomantic/Fomantic-UI/assets/105766366/4f87bd3a-017a-46a6-8ccf-b06b00d97f47)
<!--
  If possible include images or gifs of your issue.

  E.g. Incorrect component CSS should include an image of what the
  component looks like.
  
  If your looking for a tool we recommend ShareX - https://github.com/ShareX/ShareX
-->

## Closes
<!--
  List all the issues this pull request closes (only if it does).
-->
#2923
