### PR TITLE
fix(progress): wider bar min width

### DIFF
--- a/src/themes/default/modules/progress.variables
+++ b/src/themes/default/modules/progress.variables
@@ -28,7 +28,7 @@
     width @barTransitionDuration @barTransitionEasing,
     background-color @barTransitionDuration @barTransitionEasing;
 @barInitialWidth: 0;
-@barMinWidth: 2em;
+@barMinWidth: 2.5em;
 
 /* Progress Bar Label */
 @progressWidth: auto;


### PR DESCRIPTION
## Description
When a progress is very short, the bar could contain a value > "10%" which then does not completely fit into the bar anymore.
By slightly increasing the min-width, this should cover almost every usecase.

## Testcase
https://jsfiddle.net/gq045pk7/3/

The second example is using the fix from this PR

## Screenshot
The progess should show "11%"

### Broken
![image](https://github.com/fomantic/Fomantic-UI/assets/18379884/247fae98-56a6-4bde-adda-3e7a8881c802)

### Fixed
![image](https://github.com/fomantic/Fomantic-UI/assets/18379884/c7f4adfd-5818-4094-a6bb-bdaa750d813f)


## Closes
#3068 