### PR TITLE
chore(types): fix missing types on some module

### DIFF
--- a/types/fomantic-ui-calendar.d.ts
+++ b/types/fomantic-ui-calendar.d.ts
@@ -327,6 +327,22 @@ declare namespace FomanticUI {
 
         formatter: Calendar.FormatterSettings;
 
+        /**
+         * Customizable methods to parse a given date
+         * Has to return a date object
+         */
+        parser: {
+            date: (text: string, settings: CalendarSettings) => Date;
+        }
+
+        /**
+         * DOM selector where the calendar popup should be attached to. By default (false) the calendar popoup 
+         * is attached as direct child of the triggering element.
+         * 
+         * @default false
+         */
+        context: string | JQuery | false
+
         // endregion
 
         // region Callbacks

--- a/types/fomantic-ui-calendar.d.ts
+++ b/types/fomantic-ui-calendar.d.ts
@@ -336,14 +336,14 @@ declare namespace FomanticUI {
         }
 
         /**
-         * DOM selector where the calendar popup should be attached to. By default (false) the calendar popoup 
+         * DOM selector where the calendar popup should be attached to. By default (false) the calendar popup
          * is attached as direct child of the triggering element.
-         * 
+         *
          * @default false
          */
         context: string | JQuery | false
 
-        // endregion
+        // end region
 
         // region Callbacks
 

--- a/types/fomantic-ui-search.d.ts
+++ b/types/fomantic-ui-search.d.ts
@@ -183,10 +183,15 @@ declare namespace FomanticUI {
         showNoResults: boolean;
 
         /**
-         * Specifying to "true" will use a fuzzy full text search, setting to "exact" will force the exact search to be matched somewhere in the string, setting to false will only match to start of string.
+         * Possible values
+         * * `exact` will force the exact search to be matched somewhere in the string.
+         * * `some` Will do the same as exact but supports multiple search values separated by whitespace. At least one word must match. (New in v2.9.1)
+         * * `all` is same as some but all words have to match in all given search fields of each record altogether. (New in v2.9.1)
+         * * `true` will use a fuzzy full text search.
+         * * `false` will only match to start of string.
          * @default 'exact'
          */
-        fullTextSearch: 'exact' | boolean;
+        fullTextSearch: 'exact' | 'some' | 'all' | boolean;
 
         /**
          * List mapping display content to JSON property, either with API or 'source'.


### PR DESCRIPTION
<!--
 Please read our Contributing Guide and Code of Conduct before you
 submit a pull request.
  
 Contributing Guide: https://github.com/fomantic/Fomantic-UI/blob/master/CONTRIBUTING.md
 Code of Conduct: https://github.com/fomantic/Fomantic-UI/blob/master/CODE_OF_CONDUCT.md

 ----

 Please use the following pull request title format:
 "[<scope>] <summary of what you fixed/changed>"
-->

## Description
<!-- Describe what you fixed/changed in great detail (required). -->
There was a missing type declaration on module `search.fullTextSearch`. I added these changes based on the current document: https://fomantic-ui.com/modules/dropdown.html#additional-settings
## Testcase
<!--
  If possible create an example of your change via a JSFiddle. 

  How to create an example:
   1. Open the following JSFiddle - https://jsfiddle.net/31d6y7mn
   2. Click "Fork" at the top
   3. Add the minimum required HTML, CSS and JavaScript which shows your change
   4. Click "Save" at the top
   5. Copy the URL of your fiddle and link it here
-->
N/A
## Screenshot (if possible)
<!--
  If possible include images or gifs of your issue.

  E.g. Incorrect component CSS should include an image of what the
  component looks like.
  
  If your looking for a tool we recommend ShareX - https://github.com/ShareX/ShareX
-->
N/A
## Closes
<!--
  List all the issues this pull request closes (only if it does).
-->
N/A
