### PR TITLE
fix(types): satisfy lint rule no-unsafe-function-type

### DIFF
--- a/types/fomantic-ui-dropdown.d.ts
+++ b/types/fomantic-ui-dropdown.d.ts
@@ -29,14 +29,14 @@ declare namespace FomanticUI {
          * If a function is provided to callback, it's called after the dropdown-menu is shown.
          * Set preventFocus to true if you don't want the dropdown field to focus after the menu is shown
          */
-        (behavior: 'show', callback?: Function, preventFocus?: boolean): void;
+        (behavior: 'show', callback?: () => void, preventFocus?: boolean): void;
 
         /**
          * Hides dropdown.
          * If a function is provided to callback, it's called after the dropdown-menu is hidden.
          * Set preventBlur to true if you don't want the dropdown field to blur after the menu is hidden
          */
-        (behavior: 'hide', callback?: Function, preventBlur?: boolean): void;
+        (behavior: 'hide', callback?: () => void, preventBlur?: boolean): void;
 
         /**
          * Clears dropdown of selection.
@@ -358,7 +358,7 @@ declare namespace FomanticUI {
          * Whether to sort values when creating a dropdown automatically from a select element.
          * @default false
          */
-        sortSelect: boolean | 'natural' | Function;
+        sortSelect: boolean | 'natural' | ((a: any, b: any) => number);
 
         /**
          * Whether search selection will force currently selected choice when element is blurred.

--- a/types/fomantic-ui-flyout.d.ts
+++ b/types/fomantic-ui-flyout.d.ts
@@ -6,7 +6,7 @@ declare namespace FomanticUI {
          * Attaches flyout action to given selector.
          * Default event if none specified is toggle.
          */
-        (behavior: 'attach events', selector: JQuery, event: Function): JQuery;
+        (behavior: 'attach events', selector: JQuery, event?: string): JQuery;
 
         /**
          * Shows the flyout.

--- a/types/fomantic-ui-form.d.ts
+++ b/types/fomantic-ui-form.d.ts
@@ -164,7 +164,7 @@ declare namespace FomanticUI {
         (settings?: Partial<Pick<FormSettings, keyof FormSettings>>): JQuery;
     }
 
-    type FormFields = Record<string, FormField | string[] | string | {}>;
+    type FormFields = Record<string, FormField | string[] | string | object>;
 
     interface FormRule {
         type: string;

--- a/types/fomantic-ui-modal.d.ts
+++ b/types/fomantic-ui-modal.d.ts
@@ -5,12 +5,12 @@ declare namespace FomanticUI {
         /**
          * Shows the modal.
          */
-        (behavior: 'show', callback?: Function): JQuery;
+        (behavior: 'show', callback?: () => void): JQuery;
 
         /**
          * Hides the modal.
          */
-        (behavior: 'hide', callback?: Function): JQuery;
+        (behavior: 'hide', callback?: () => void): JQuery;
 
         /**
          * Toggles the modal.

--- a/types/fomantic-ui-search.d.ts
+++ b/types/fomantic-ui-search.d.ts
@@ -5,7 +5,7 @@ declare namespace FomanticUI {
         /**
          * Search for value currently set in search input.
          */
-        (behavior: 'query', callback: Function): JQuery;
+        (behavior: 'query', callback?: () => void): JQuery;
 
         /**
          * Displays message in search results with text, using template matching type.
@@ -30,7 +30,7 @@ declare namespace FomanticUI {
         /**
          * Search remote endpoint for specified query and display results.
          */
-        (behavior: 'search remote', query: string, callback: Function): JQuery;
+        (behavior: 'search remote', query: string, callback?: () => void): JQuery;
 
         /**
          * Search object for specified query and return results.
@@ -90,17 +90,17 @@ declare namespace FomanticUI {
         /**
          * Shows results container.
          */
-        (behavior: 'show results', callback: Function): JQuery;
+        (behavior: 'show results', callback?: () => void): JQuery;
 
         /**
          * Hide results container.
          */
-        (behavior: 'hide results', callback: Function): JQuery;
+        (behavior: 'hide results', callback?: () => void): JQuery;
 
         /**
          * Generates results using parser specified by 'settings.template'.
          */
-        (behavior: 'generate results', response: Function): JQuery;
+        (behavior: 'generate results', response: object): JQuery;
 
         /**
          * Removes all events.

--- a/types/fomantic-ui-slider.d.ts
+++ b/types/fomantic-ui-slider.d.ts
@@ -89,7 +89,7 @@ declare namespace FomanticUI {
          * You can specify a function here which consumes the current label value as parameter and should return a custom label text according to the given value.
          * @default false
          */
-        interpretLabel: false | Function;
+        interpretLabel: false | ((value: any) => string);
 
         /**
          * Show ticks on a labeled slider.

--- a/types/fomantic-ui-tab.d.ts
+++ b/types/fomantic-ui-tab.d.ts
@@ -276,7 +276,7 @@ declare namespace FomanticUI {
                  * Returns page title
                  * @default Function
                  */
-                determineTitle: Function;
+                determineTitle: (tabPath: string) => string | void;
             }
 
             interface Selectors {

--- a/types/fomantic-ui-transition.d.ts
+++ b/types/fomantic-ui-transition.d.ts
@@ -227,7 +227,7 @@ declare namespace FomanticUI {
          * Callback right before the show transition should start.
          * The 'showFunction' parameter has to be called inside the callback to trigger the transition show
          */
-        onBeforeShow(this: JQuery, showFunction: Function): void;
+        onBeforeShow(this: JQuery, showFunction: () => void): void;
 
         /**
          * Callback once the show transition has finished.
@@ -244,7 +244,7 @@ declare namespace FomanticUI {
          * Callback right before the hide transition should start.
          * The 'hideFunction' parameter has to be called inside the callback to trigger the transition hide.
          */
-        onBeforeHide(this: JQuery, hideFunction: Function): void;
+        onBeforeHide(this: JQuery, hideFunction: () => void): void;
 
         /**
          * Callback once the transition hide has finished.


### PR DESCRIPTION
## Description

Latest linting rule [no-unsafe-function-type](https://typescript-eslint.io/rules/no-unsafe-function-type/) breaks existing types which results in failed CI checks on every other PR.
