### PR TITLE
fix(types): correct transition behavior "set looping"

### DIFF
--- a/types/fomantic-ui-transition.d.ts
+++ b/types/fomantic-ui-transition.d.ts
@@ -50,7 +50,7 @@ declare namespace FomanticUI {
         /**
          * Enables animation looping.
          */
-        (behavior: 'looping'): JQuery;
+        (behavior: 'set looping'): JQuery;
 
         /**
          * Removes looping state from element.


### PR DESCRIPTION
fixing the transition looping enabling call signature. The passed behavior gets interpreted as a nonexistent animation otherwise.

