### PR TITLE
fix(flag): update macedonia flag name

### DIFF
--- a/src/themes/default/elements/flag.variables
+++ b/src/themes/default/elements/flag.variables
@@ -815,9 +815,9 @@
     };
     @1f1f2-1f1f0: {
         countrycode: mk;
-        class: macedonia;
-        aliasClass: false;
-        aliasClass2: false;
+        class: republic_of_north_macedonia;
+        aliasClass: north_macedonia;
+        aliasClass2: macedonia;
     };
     @1f1f2-1f1ec: {
         countrycode: mg;


### PR DESCRIPTION
## Description
According to https://en.wikipedia.org/wiki/North_Macedonia , the related country flags name needs correction

To avoid a breaking change, i still left the previous name as a second alias. This will be removed again in 2.10.0

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/7143