### PR TITLE
fix(label): grouping image labels margin

### DIFF
--- a/src/definitions/elements/label.less
+++ b/src/definitions/elements/label.less
@@ -184,6 +184,7 @@ a.ui.label {
              Types
 *******************************/
 & when (@variationLabelImage) {
+    .ui.image.labels .label,
     .ui.image.label {
         width: auto;
         margin-top: 0;
@@ -198,6 +199,10 @@ a.ui.label {
         &.attached:not(.basic) when (@variationLabelAttached) {
             padding: @imageLabelPadding;
         }
+    }
+    .ui.labels .image.label,
+    .ui.image.labels .label {
+        margin-bottom: @groupVerticalMargin;
     }
 
     .ui.image.label img {


### PR DESCRIPTION
## Description

Tihs PR supports grouping of image labels and fixes bottom margin

## Screenshot
### Before
![image](https://github.com/user-attachments/assets/c690c8ac-a2ac-4072-afd5-37cffb5fe58e)

### After
![image](https://github.com/user-attachments/assets/b32ffb96-dba4-4e2d-96cf-ee894d920754)

## Testcase
Remove CSS to see issue
https://jsfiddle.net/lubber/v0tqdh65/6


## Closes
https://github.com/fomantic/Fomantic-UI/issues/2986#issuecomment-2245741558
