### PR TITLE
fix(ci): dont let job fail for latest node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12, 14, 16, 18, latest]
+        node-version: [12, 14, 16, 18, 20, 22]
     steps:
     - uses: actions/checkout@v4
     - name: Setup Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
## Description
Latest node 23 ci check fails because of active development and dependencies would need an update or fix
However, even if this check is declared as not required, the github actions still fail, which is a false positive as long as it's not an LTS version (which node 23 isn't)

To get rid of the failures, this PR removes the latest node check and adds dedicated LTS version instead which makes the CI succeed again.

Will review this for latest node again when working on 2.10.x soon