### PR TITLE
feat(dropdown): collapse on clearable optional

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1230,7 +1230,9 @@
                             if (module.is.searchSelection()) {
                                 module.remove.searchTerm();
                             }
-                            module.hide();
+                            if (settings.collapseOnClearable) {
+                                module.hide();
+                            }
                             event.stopPropagation();
                         },
                     },
@@ -4096,6 +4098,7 @@
         headerDivider: true, // whether option headers should have an additional divider line underneath when converted from <select> <optgroup>
 
         collapseOnActionable: true, // whether the dropdown should collapse upon selection of an actionable item
+        collapseOnClearable: false, // whether the dropdown should collapse upon clicking the clearable icon
 
         // label settings on multi-select
         label: {

--- a/types/fomantic-ui-dropdown.d.ts
+++ b/types/fomantic-ui-dropdown.d.ts
@@ -481,6 +481,12 @@ declare namespace FomanticUI {
         collapseOnActionable: boolean;
 
         /**
+         * Whether the dropdown should collapse upon clicking the clearable icon.
+         * @default false
+         */
+        collapseOnClearable: boolean;
+
+        /**
          * Allows customization of multi-select labels.
          * @default true
          */


### PR DESCRIPTION
## Description
Added an option `collapseOnClearable` to collapse the dropdown upon clicking on the clearable icon

SUI does not collapse, but FUI does, so i made this option false by default so the behavior matches SUI.

## Testcase
- Open the dropdowns
- Click the clearable icon
https://jsfiddle.net/lubber/pLqm72cg/

## Closes
#3114 