### PR TITLE
Reduce CSS by removing :not() selectors if variation is disabled

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -82,7 +82,7 @@
     font-weight: @labelFontWeight;
     text-transform: @labelTextTransform;
 }
-.ui.form:not(.inverted) .field > label:not(.button) {
+.ui.form@{notInverted} .field > label:not(.button) {
     color: @labelColor;
 }
 

--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -17,6 +17,19 @@
 
 @import (multiple) "../../theme.config";
 
+@notInline: if(@variationFormInline, e(":not(.inline)"));
+@notInverted: if(@variationFormInverted, e(":not(.inverted)"));
+@notWide: if(@variationFormWide, e(":not(.wide)"));
+@notGrouped: if(@variationFormGrouped, e(":not(.grouped)"));
+@notRequired: if(@variationFormRequired, e(":not(.required)"));
+@notUnstackable: if(@variationFormUnstackable, e(":not(.unstackable)"));
+
+@notToggle: if(@variationCheckboxToggle, e(":not(.toggle)"));
+@notSlider: if(@variationCheckboxSlider, e(":not(.slider)"));
+@notCompact: if(@variationDropdownCompact, e(":not(.compact)"));
+@notIcon: if(@variationInputIcon, e(":not(.compact)"));
+@notCorner: if(@variationLabelCorner, e(":not(.corner)"));
+
 /*******************************
             Elements
 *******************************/
@@ -183,16 +196,16 @@
     Checkbox margin
 --------------------- */
 
-.ui.form .fields:not(.grouped):not(.inline) .field:not(:only-child) label + .ui.ui.checkbox {
+.ui.form .fields@{notGrouped}@{notInline} .field:not(:only-child) label + .ui.ui.checkbox {
     margin-top: @checkboxLabelFieldTopMargin;
 }
-.ui.form .fields:not(.grouped):not(.inline) .field:not(:only-child) .ui.checkbox {
+.ui.form .fields@{notGrouped}@{notInline} .field:not(:only-child) .ui.checkbox {
     margin-top: @inputLineHeight + @checkboxFieldTopMargin;
 }
-.ui.form .fields:not(.grouped):not(.inline) .field:not(:only-child) .ui.toggle.checkbox {
+.ui.form .fields@{notGrouped}@{notInline} .field:not(:only-child) .ui.toggle.checkbox {
     margin-top: @inputLineHeight + @checkboxToggleFieldTopMargin;
 }
-.ui.form .fields:not(.grouped):not(.inline) .field:not(:only-child) .ui.slider.checkbox {
+.ui.form .fields@{notGrouped}@{notInline} .field:not(:only-child) .ui.slider.checkbox {
     margin-top: @inputLineHeight + @checkboxSliderFieldTopMargin;
 }
 .ui.ui.form .field .fields .field:not(:only-child) .ui.checkbox {
@@ -210,7 +223,7 @@
           Transparent
     --------------------- */
 
-    .ui.form .field .transparent.input:not(.icon) input,
+    .ui.form .field .transparent.input@{notIcon} input,
     .ui.form .field input.transparent,
     .ui.form .field textarea.transparent {
         padding: @transparentPadding;
@@ -254,7 +267,7 @@
 --------------------- */
 
 /* Block */
-.ui.form .field > .selection.dropdown:not(.compact) {
+.ui.form .field > .selection.dropdown@{notCompact} {
     min-width: auto;
     width: 100%;
 }
@@ -287,8 +300,8 @@
 
 & when (@variationFormInline) {
     /* Inline */
-    .ui.form .inline.fields .field:not(.wide) .ui.input,
-    .ui.form .inline.field:not(.wide) .ui.input {
+    .ui.form .inline.fields .field@{notWide} .ui.input,
+    .ui.form .inline.field@{notWide} .ui.input {
         width: auto;
         vertical-align: middle;
     }
@@ -528,9 +541,9 @@
         }
 
         .ui.ui.form .fields.@{state} .field label,
-        .ui.ui.form .fields.@{state} .field .ui.label:not(.corner),
+        .ui.ui.form .fields.@{state} .field .ui.label@{notCorner},
         .ui.ui.form .field.@{state} label,
-        .ui.ui.form .field.@{state} .ui.label:not(.corner),
+        .ui.ui.form .field.@{state} .ui.label@{notCorner},
         .ui.ui.form .fields.@{state} .field .input,
         .ui.ui.form .field.@{state} .input {
             color: @c;
@@ -720,12 +733,12 @@
         /*--------------------
             Checkbox State
         ---------------------*/
-        .ui.form .fields.@{state} .field .checkbox:not(.toggle):not(.slider) label,
-        .ui.form .field.@{state} .checkbox:not(.toggle):not(.slider) label {
+        .ui.form .fields.@{state} .field .checkbox@{notToggle}@{notSlider} label,
+        .ui.form .field.@{state} .checkbox@{notToggle}@{notSlider} label {
             color: @c;
         }
-        .ui.form .fields.@{state} .field .checkbox:not(.toggle):not(.slider) label::before,
-        .ui.form .field.@{state} .checkbox:not(.toggle):not(.slider) label::before {
+        .ui.form .fields.@{state} .field .checkbox@{notToggle}@{notSlider} label::before,
+        .ui.form .field.@{state} .checkbox@{notToggle}@{notSlider} label::before {
             background: @bg;
             border-color: @bdc;
         }
@@ -820,11 +833,11 @@
          Required Field
     --------------------- */
 
-    .ui.form .required.fields:not(.grouped):not(.inline) > .field > label::after,
+    .ui.form .required.fields@{notGrouped}@{notInline} > .field > label::after,
     .ui.form .required.fields.inline > label::after,
     .ui.form .required.fields.grouped > label::after,
     .ui.form .required.field > label::after,
-    .ui.form .required.fields:not(.grouped):not(.inline) > .field > .checkbox::after,
+    .ui.form .required.fields@{notGrouped}@{notInline} > .field > .checkbox::after,
     .ui.form .required.field > .checkbox::after,
     .ui.form label.required::after {
         margin: @requiredMargin;
@@ -832,7 +845,7 @@
         color: @requiredColor;
     }
 
-    .ui.form .required.fields:not(.grouped):not(.inline) > .field > label::after,
+    .ui.form .required.fields@{notGrouped}@{notInline} > .field > label::after,
     .ui.form .required.fields.inline > label::after,
     .ui.form .required.fields.grouped > label::after,
     .ui.form .required.field > label::after,
@@ -841,7 +854,7 @@
         vertical-align: top;
     }
 
-    .ui.form .required.fields:not(.grouped):not(.inline) > .field > .checkbox::after,
+    .ui.form .required.fields@{notGrouped}@{notInline} > .field > .checkbox::after,
     .ui.form .required.field > .checkbox::after {
         position: absolute;
         top: 0;
@@ -849,13 +862,13 @@
     }
 }
 
-.ui.ui.ui.ui.form .fields:not(.required) > label:empty::after,
-.ui.ui.ui.ui.form .fields:not(.grouped):not(.inline) > .field:not(.required) > label:empty::after {
+.ui.ui.ui.ui.form .fields@{notRequired} > label:empty::after,
+.ui.ui.ui.ui.form .fields@{notGrouped}@{notInline} > .field@{notRequired} > label:empty::after {
     content: " ";
     display: inline-block;
 }
 
-.ui.ui.ui.ui.form .inline.fields .field:not(.required) > label:empty {
+.ui.ui.ui.ui.form .inline.fields .field@{notRequired} > label:empty {
     display: none;
 }
 
@@ -1012,8 +1025,8 @@
         margin-bottom: 0;
     }
 
-    .ui.form:not(.unstackable) .fields:not(.unstackable) > .fields,
-    .ui.form:not(.unstackable) .fields:not(.unstackable) > .field {
+    .ui.form@{notUnstackable} .fields@{notUnstackable} > .fields,
+    .ui.form@{notUnstackable} .fields@{notUnstackable} > .field {
         width: @oneColumn;
         margin: 0 0 @rowDistance;
     }

--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -27,7 +27,7 @@
 @notToggle: if(@variationCheckboxToggle, e(":not(.toggle)"));
 @notSlider: if(@variationCheckboxSlider, e(":not(.slider)"));
 @notCompact: if(@variationDropdownCompact, e(":not(.compact)"));
-@notIcon: if(@variationInputIcon, e(":not(.compact)"));
+@notIcon: if(@variationInputIcon, e(":not(.icon)"));
 @notCorner: if(@variationLabelCorner, e(":not(.corner)"));
 
 /*******************************

--- a/src/definitions/collections/grid.less
+++ b/src/definitions/collections/grid.less
@@ -17,6 +17,17 @@
 
 @import (multiple) "../../theme.config";
 
+@notAligned: if(@variationGridAligned, e(":not(.aligned)"));
+@notJustified: if(@variationGridJustified, e(":not(.justified)"));
+@notStretched: if(@variationGridStretched, e(":not(.stretched)"));
+@notStackable: if(@variationGridStackable, e(":not(.stackable)"));
+@notHorizontally: if(@variationGridHorizontal, e(":not(.horizontally)"));
+@notVertically: if(@variationGridVertical, e(":not(.vertically)"));
+
+@notAttached: if(@variationSegmentAttached, e(":not(.attached)"));
+@notCompact: if(@variationSegmentCompact, e(":not(.compact)"));
+@notVertical: if(@variationSegmentVertical, e(":not(.vertical)"));
+
 /*******************************
             Standard
 *******************************/
@@ -125,8 +136,8 @@
 }
 
 /* Segment inside Aligned Grid */
-.ui.grid .aligned.row > .column > .segment:not(.compact):not(.attached),
-.ui.aligned.grid .column > .segment:not(.compact):not(.attached) {
+.ui.grid .aligned.row > .column > .segment@{notCompact}@{notAttached},
+.ui.aligned.grid .column > .segment@{notCompact}@{notAttached} {
     width: 100%;
 }
 
@@ -953,9 +964,9 @@
         text-align: center;
         justify-content: center;
     }
-    .ui.centered.grid > .column:not(.aligned):not(.justified):not(.row),
-    .ui.centered.grid > .row > .column:not(.aligned):not(.justified),
-    .ui.grid .centered.row > .column:not(.aligned):not(.justified) {
+    .ui.centered.grid > .column@{notAligned}@{notJustified}:not(.row),
+    .ui.centered.grid > .row > .column@{notAligned}@{notJustified},
+    .ui.grid .centered.row > .column@{notAligned}@{notJustified} {
         text-align: left;
     }
 
@@ -1008,16 +1019,20 @@
             Padded
     ----------------------- */
 
-    .ui.padded.grid:not(.vertically):not(.horizontally) {
+    .ui.padded.grid@{notVertically}@{notHorizontally} {
         margin: 0;
     }
-    [class*="horizontally padded"].ui.grid {
-        margin-left: 0;
-        margin-right: 0;
+    & when (@variationGridHorizontal) {
+        [class*="horizontally padded"].ui.grid {
+            margin-left: 0;
+            margin-right: 0;
+        }
     }
-    [class*="vertically padded"].ui.grid {
-        margin-top: 0;
-        margin-bottom: 0;
+    & when (@variationGridVertical) {
+        [class*="vertically padded"].ui.grid {
+            margin-top: 0;
+            margin-bottom: 0;
+        }
     }
 }
 
@@ -1100,7 +1115,7 @@
     & when (@variationGridPadded) {
         /* Padded Horizontally Divided */
         [class*="horizontally padded"].ui.divided.grid,
-        .ui.padded.divided.grid:not(.vertically):not(.horizontally) {
+        .ui.padded.divided.grid@{notVertically}@{notHorizontally} {
             width: 100%;
         }
     }
@@ -1499,8 +1514,8 @@
             box-shadow: none !important;
             margin: 0;
         }
-        .ui.grid:not(.stretched) > .doubling.row:not(.stretched) > .column:not(.stretched),
-        .ui.doubling.grid:not(.stretched) > .row:not(.stretched) > .column:not(.stretched) {
+        .ui.grid@{notStretched} > .doubling.row@{notStretched} > .column@{notStretched},
+        .ui.doubling.grid@{notStretched} > .row@{notStretched} > .column@{notStretched} {
             display: inline-block !important;
         }
         .ui[class*="two column"].doubling.grid > .row > .column,
@@ -1594,79 +1609,79 @@
             margin: 0 !important;
             box-shadow: none !important;
         }
-        .ui[class*="two column"].doubling:not(.stackable).grid > .row > .column,
-        .ui[class*="two column"].doubling:not(.stackable).grid > .column:not(.row),
-        .ui.ui.grid > [class*="two column"].doubling:not(.stackable).row > .column {
+        .ui[class*="two column"].doubling@{notStackable}.grid > .row > .column,
+        .ui[class*="two column"].doubling@{notStackable}.grid > .column:not(.row),
+        .ui.ui.grid > [class*="two column"].doubling@{notStackable}.row > .column {
             width: @oneColumn !important;
         }
-        .ui[class*="three column"].doubling:not(.stackable).grid > .row > .column,
-        .ui[class*="three column"].doubling:not(.stackable).grid > .column:not(.row),
-        .ui.ui.grid > [class*="three column"].doubling:not(.stackable).row > .column {
+        .ui[class*="three column"].doubling@{notStackable}.grid > .row > .column,
+        .ui[class*="three column"].doubling@{notStackable}.grid > .column:not(.row),
+        .ui.ui.grid > [class*="three column"].doubling@{notStackable}.row > .column {
             width: @twoColumn !important;
         }
-        .ui[class*="four column"].doubling:not(.stackable).grid > .row > .column,
-        .ui[class*="four column"].doubling:not(.stackable).grid > .column:not(.row),
-        .ui.ui.grid > [class*="four column"].doubling:not(.stackable).row > .column {
+        .ui[class*="four column"].doubling@{notStackable}.grid > .row > .column,
+        .ui[class*="four column"].doubling@{notStackable}.grid > .column:not(.row),
+        .ui.ui.grid > [class*="four column"].doubling@{notStackable}.row > .column {
             width: @twoColumn !important;
         }
-        .ui[class*="five column"].doubling:not(.stackable).grid > .row > .column,
-        .ui[class*="five column"].doubling:not(.stackable).grid > .column:not(.row),
-        .ui.ui.grid > [class*="five column"].doubling:not(.stackable).row > .column {
+        .ui[class*="five column"].doubling@{notStackable}.grid > .row > .column,
+        .ui[class*="five column"].doubling@{notStackable}.grid > .column:not(.row),
+        .ui.ui.grid > [class*="five column"].doubling@{notStackable}.row > .column {
             width: @twoColumn !important;
         }
-        .ui[class*="six column"].doubling:not(.stackable).grid > .row > .column,
-        .ui[class*="six column"].doubling:not(.stackable).grid > .column:not(.row),
-        .ui.ui.grid > [class*="six column"].doubling:not(.stackable).row > .column {
+        .ui[class*="six column"].doubling@{notStackable}.grid > .row > .column,
+        .ui[class*="six column"].doubling@{notStackable}.grid > .column:not(.row),
+        .ui.ui.grid > [class*="six column"].doubling@{notStackable}.row > .column {
             width: @twoColumn !important;
         }
-        .ui[class*="seven column"].doubling:not(.stackable).grid > .row > .column,
-        .ui[class*="seven column"].doubling:not(.stackable).grid > .column:not(.row),
-        .ui.ui.grid > [class*="seven column"].doubling:not(.stackable).row > .column {
+        .ui[class*="seven column"].doubling@{notStackable}.grid > .row > .column,
+        .ui[class*="seven column"].doubling@{notStackable}.grid > .column:not(.row),
+        .ui.ui.grid > [class*="seven column"].doubling@{notStackable}.row > .column {
             width: @twoColumn !important;
         }
-        .ui[class*="eight column"].doubling:not(.stackable).grid > .row > .column,
-        .ui[class*="eight column"].doubling:not(.stackable).grid > .column:not(.row),
-        .ui.ui.grid > [class*="eight column"].doubling:not(.stackable).row > .column {
+        .ui[class*="eight column"].doubling@{notStackable}.grid > .row > .column,
+        .ui[class*="eight column"].doubling@{notStackable}.grid > .column:not(.row),
+        .ui.ui.grid > [class*="eight column"].doubling@{notStackable}.row > .column {
             width: @twoColumn !important;
         }
-        .ui[class*="nine column"].doubling:not(.stackable).grid > .row > .column,
-        .ui[class*="nine column"].doubling:not(.stackable).grid > .column:not(.row),
-        .ui.ui.grid > [class*="nine column"].doubling:not(.stackable).row > .column {
+        .ui[class*="nine column"].doubling@{notStackable}.grid > .row > .column,
+        .ui[class*="nine column"].doubling@{notStackable}.grid > .column:not(.row),
+        .ui.ui.grid > [class*="nine column"].doubling@{notStackable}.row > .column {
             width: @threeColumn !important;
         }
-        .ui[class*="ten column"].doubling:not(.stackable).grid > .row > .column,
-        .ui[class*="ten column"].doubling:not(.stackable).grid > .column:not(.row),
-        .ui.ui.grid > [class*="ten column"].doubling:not(.stackable).row > .column {
+        .ui[class*="ten column"].doubling@{notStackable}.grid > .row > .column,
+        .ui[class*="ten column"].doubling@{notStackable}.grid > .column:not(.row),
+        .ui.ui.grid > [class*="ten column"].doubling@{notStackable}.row > .column {
             width: @threeColumn !important;
         }
-        .ui[class*="eleven column"].doubling:not(.stackable).grid > .row > .column,
-        .ui[class*="eleven column"].doubling:not(.stackable).grid > .column:not(.row),
-        .ui.ui.grid > [class*="eleven column"].doubling:not(.stackable).row > .column {
+        .ui[class*="eleven column"].doubling@{notStackable}.grid > .row > .column,
+        .ui[class*="eleven column"].doubling@{notStackable}.grid > .column:not(.row),
+        .ui.ui.grid > [class*="eleven column"].doubling@{notStackable}.row > .column {
             width: @threeColumn !important;
         }
-        .ui[class*="twelve column"].doubling:not(.stackable).grid > .row > .column,
-        .ui[class*="twelve column"].doubling:not(.stackable).grid > .column:not(.row),
-        .ui.ui.grid > [class*="twelve column"].doubling:not(.stackable).row > .column {
+        .ui[class*="twelve column"].doubling@{notStackable}.grid > .row > .column,
+        .ui[class*="twelve column"].doubling@{notStackable}.grid > .column:not(.row),
+        .ui.ui.grid > [class*="twelve column"].doubling@{notStackable}.row > .column {
             width: @threeColumn !important;
         }
-        .ui[class*="thirteen column"].doubling:not(.stackable).grid > .row > .column,
-        .ui[class*="thirteen column"].doubling:not(.stackable).grid > .column:not(.row),
-        .ui.ui.grid > [class*="thirteen column"].doubling:not(.stackable).row > .column {
+        .ui[class*="thirteen column"].doubling@{notStackable}.grid > .row > .column,
+        .ui[class*="thirteen column"].doubling@{notStackable}.grid > .column:not(.row),
+        .ui.ui.grid > [class*="thirteen column"].doubling@{notStackable}.row > .column {
             width: @threeColumn !important;
         }
-        .ui[class*="fourteen column"].doubling:not(.stackable).grid > .row > .column,
-        .ui[class*="fourteen column"].doubling:not(.stackable).grid > .column:not(.row),
-        .ui.ui.grid > [class*="fourteen column"].doubling:not(.stackable).row > .column {
+        .ui[class*="fourteen column"].doubling@{notStackable}.grid > .row > .column,
+        .ui[class*="fourteen column"].doubling@{notStackable}.grid > .column:not(.row),
+        .ui.ui.grid > [class*="fourteen column"].doubling@{notStackable}.row > .column {
             width: @fourColumn !important;
         }
-        .ui[class*="fifteen column"].doubling:not(.stackable).grid > .row > .column,
-        .ui[class*="fifteen column"].doubling:not(.stackable).grid > .column:not(.row),
-        .ui.ui.grid > [class*="fifteen column"].doubling:not(.stackable).row > .column {
+        .ui[class*="fifteen column"].doubling@{notStackable}.grid > .row > .column,
+        .ui[class*="fifteen column"].doubling@{notStackable}.grid > .column:not(.row),
+        .ui.ui.grid > [class*="fifteen column"].doubling@{notStackable}.row > .column {
             width: @fourColumn !important;
         }
-        .ui[class*="sixteen column"].doubling:not(.stackable).grid > .row > .column,
-        .ui[class*="sixteen column"].doubling:not(.stackable).grid > .column:not(.row),
-        .ui.ui.grid > [class*="sixteen column"].doubling:not(.stackable).row > .column {
+        .ui[class*="sixteen column"].doubling@{notStackable}.grid > .row > .column,
+        .ui[class*="sixteen column"].doubling@{notStackable}.grid > .column:not(.row),
+        .ui.ui.grid > [class*="sixteen column"].doubling@{notStackable}.row > .column {
             width: @fourColumn !important;
         }
     }
@@ -1696,7 +1711,7 @@
             box-shadow: none !important;
             padding: (@stackableRowSpacing / 2) (@stackableGutter / 2);
         }
-        .ui.stackable.grid:not(.vertically) > .row {
+        .ui.stackable.grid@{notVertically} > .row {
             margin: 0;
             padding: 0;
         }
@@ -1710,7 +1725,7 @@
 
         /* Don't pad inside segment or nested grid */
         .ui.grid .ui.stackable.grid,
-        .ui.segment:not(.vertical) .ui.stackable.page.grid {
+        .ui.segment@{notVertical} .ui.stackable.page.grid {
             margin-left: -(@stackableGutter / 2);
             margin-right: -(@stackableGutter / 2);
         }
@@ -1731,9 +1746,9 @@
             }
         }
         .ui.stackable.celled.grid > .column:not(.row),
-        .ui.stackable.divided:not(.vertically).grid > .column:not(.row),
+        .ui.stackable.divided@{notVertically}.grid > .column:not(.row),
         .ui.stackable.celled.grid > .row > .column,
-        .ui.stackable.divided:not(.vertically).grid > .row > .column {
+        .ui.stackable.divided@{notVertically}.grid > .row > .column {
             border-top: @stackableMobileBorder;
             box-shadow: none !important;
             padding-top: @stackableRowSpacing !important;
@@ -1745,8 +1760,8 @@
             }
         }
         & when (@variationGridDivided) {
-            .ui.stackable.divided:not(.vertically).grid > .column:not(.row),
-            .ui.stackable.divided:not(.vertically).grid > .row > .column {
+            .ui.stackable.divided@{notVertically}.grid > .column:not(.row),
+            .ui.stackable.divided@{notVertically}.grid > .row > .column {
                 padding-left: 0 !important;
                 padding-right: 0 !important;
             }

--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -17,6 +17,17 @@
 
 @import (multiple) "../../theme.config";
 
+@notSecondary: if(@variationMenuSecondary, e(":not(.secondary)"));
+@notText: if(@variationMenuText, e(":not(.text)"));
+@notTabular: if(@variationMenuTabular, e(":not(.tabular)"));
+@notVertical: if(@variationMenuVertical, e(":not(.vertical)"));
+@notBorderless: if(@variationMenuBorderless, e(":not(.borderless)"));
+@notFluid: if(@variationMenuFluid, e(":not(.fluid)"));
+@notWrapping: if(@variationMenuWrapping, e(":not(.wrapping)"));
+
+@notUpward: if(@variationDropdownUpward, e(":not(.upward)"));
+@notFloating: if(@variationLabelFloating, e(":not(.floating)"));
+
 /*******************************
             Standard
 *******************************/
@@ -60,7 +71,7 @@
     margin: 0;
 }
 
-.ui.menu:not(.vertical) > .menu {
+.ui.menu@{notVertical} > .menu {
     display: flex;
 }
 
@@ -68,7 +79,7 @@
       Item
 --------------- */
 
-.ui.menu:not(.vertical) .item {
+.ui.menu@{notVertical} .item {
     display: flex;
     align-items: center;
 }
@@ -135,7 +146,7 @@
      Button
 --------------- */
 
-.ui.menu:not(.vertical) .item > .button {
+.ui.menu@{notVertical} .item > .button {
     position: relative;
     top: @buttonOffset;
     margin: @buttonMargin;
@@ -162,7 +173,7 @@
 .ui.menu .item > .input {
     width: 100%;
 }
-.ui.menu:not(.vertical) .item > .input {
+.ui.menu@{notVertical} .item > .input {
     position: relative;
     top: @inputOffset;
     margin: @inputVerticalMargin 0;
@@ -298,7 +309,7 @@
     .ui.vertical.menu .dropdown.item.upward .menu {
         bottom: 0;
     }
-    .ui.vertical.menu .dropdown.item:not(.upward) .menu {
+    .ui.vertical.menu .dropdown.item@{notUpward} .menu {
         top: 0;
     }
     .ui.vertical.menu .active.dropdown.item {
@@ -319,7 +330,7 @@
      Labels
 --------------- */
 
-.ui.menu .item > .label:not(.floating) {
+.ui.menu .item > .label@{notFloating} {
     margin-left: @labelTextMargin;
     padding: @labelVerticalPadding @labelHorizontalPadding;
 }
@@ -401,11 +412,11 @@
     }
 }
 @media only screen and (min-width: @tabletBreakpoint) {
-    .ui.menu:not(.secondary):not(.text):not(.tabular):not(.borderless) > .container > .item:not(.right):not(.borderless):first-child {
+    .ui.menu@{notSecondary}@{notText}@{notTabular}@{notBorderless} > .container > .item:not(.right)@{notBorderless}:first-child {
         border-left: @dividerSize solid @dividerBackground;
     }
-    .ui.menu:not(.secondary):not(.text):not(.tabular):not(.borderless) > .container > .right.item:not(.borderless):last-child,
-    .ui.menu:not(.secondary):not(.text):not(.tabular):not(.borderless) > .container > .right.menu > .item:not(.borderless):last-child {
+    .ui.menu@{notSecondary}@{notText}@{notTabular}@{notBorderless} > .container > .right.item@{notBorderless}:last-child,
+    .ui.menu@{notSecondary}@{notText}@{notTabular}@{notBorderless} > .container > .right.menu > .item@{notBorderless}:last-child {
         border-right: @dividerSize solid @dividerBackground;
     }
 }
@@ -482,27 +493,27 @@ Floated Menu / Item
 ------------------- */
 
 /* Left Floated */
-.ui.menu:not(.vertical) .left.item,
-.ui.menu:not(.vertical) .left.menu {
+.ui.menu@{notVertical} .left.item,
+.ui.menu@{notVertical} .left.menu {
     display: flex;
     margin-right: auto !important;
 }
 
 /* Right Floated */
-.ui.menu:not(.vertical) .right.item,
-.ui.menu:not(.vertical) .right.menu {
+.ui.menu@{notVertical} .right.item,
+.ui.menu@{notVertical} .right.menu {
     display: flex;
     margin-left: auto !important;
 }
 
-.ui.menu:not(.vertical) :not(.dropdown) > .left.menu,
-.ui.menu:not(.vertical) :not(.dropdown) > .right.menu {
+.ui.menu@{notVertical} :not(.dropdown) > .left.menu,
+.ui.menu@{notVertical} :not(.dropdown) > .right.menu {
     display: inherit;
 }
 
 /* Center */
-.ui.menu:not(.vertical) .center.item,
-.ui.menu:not(.vertical) .center.menu {
+.ui.menu@{notVertical} .center.item,
+.ui.menu@{notVertical} .center.menu {
     display: flex;
     margin-left: auto !important;
     margin-right: auto !important;
@@ -795,7 +806,7 @@ Floated Menu / Item
     .ui.compact.menu .item:last-child {
         border-radius: 0 @borderRadius @borderRadius 0;
     }
-    .ui.pagination.menu:not(.wrapping) .item:last-child::before {
+    .ui.pagination.menu@{notWrapping} .item:last-child::before {
         display: none;
     }
 
@@ -972,7 +983,7 @@ Floated Menu / Item
             border-bottom-width: 0;
         }
 
-        .ui.secondary.pointing.menu .item > .label:not(.floating) {
+        .ui.secondary.pointing.menu .item > .label@{notFloating} {
             margin-top: -@labelVerticalPadding;
             margin-bottom: -@labelVerticalPadding;
         }
@@ -1489,8 +1500,8 @@ Floated Menu / Item
 }
 
 & when (@variationMenuCentered) {
-    .ui.center.aligned.menu:not(.fluid),
-    .ui.centered.menu:not(.fluid) {
+    .ui.center.aligned.menu@{notFluid},
+    .ui.centered.menu@{notFluid} {
         display: inline-flex;
         transform: translateX(-50%);
         margin-left: 50%;
@@ -1596,7 +1607,7 @@ Floated Menu / Item
             display: inline-block;
         }
     }
-    .ui.compact.menu:not(.secondary) .item:last-child {
+    .ui.compact.menu@{notSecondary} .item:last-child {
         border-radius: 0 @borderRadius @borderRadius 0;
     }
     .ui.compact.menu .item:last-child::before {
@@ -1643,8 +1654,8 @@ Floated Menu / Item
         text-align: center;
         justify-content: center;
     }
-    .ui.attached[class*="equal width"].menu:not(.tabular),
-    .ui.attached.item.menu:not(.tabular) {
+    .ui.attached[class*="equal width"].menu@{notTabular},
+    .ui.attached.item.menu@{notTabular} {
         margin: 0 @attachedHorizontalOffset !important;
     }
 
@@ -1904,7 +1915,7 @@ Floated Menu / Item
     }
 
     /* Tabular Attached */
-    .ui.attached.menu:not(.tabular):not(.text) {
+    .ui.attached.menu@{notTabular}@{notText} {
         border: @attachedBorder;
     }
     & when (@variationMenuInverted) {
@@ -1936,7 +1947,7 @@ Floated Menu / Item
         & .item:first-child::before {
             display: none;
         }
-        &:not(.secondary):not(.text):not(.tabular):not(.borderless) .item {
+        &@{notSecondary}@{notText}@{notTabular}@{notBorderless} .item {
             &:last-of-type,
             &:last-child {
                 border-right: @dividerSize solid @dividerBackground;
@@ -1944,7 +1955,7 @@ Floated Menu / Item
         }
     }
     & when (@variationMenuWrapped) {
-        .ui.wrapped.menu:not(.secondary):not(.text):not(.tabular):not(.borderless) .item {
+        .ui.wrapped.menu@{notSecondary}@{notText}@{notTabular}@{notBorderless} .item {
             &:first-child {
                 border-bottom-left-radius: 0;
             }

--- a/src/definitions/collections/table.less
+++ b/src/definitions/collections/table.less
@@ -17,6 +17,15 @@
 
 @import (multiple) "../../theme.config";
 
+@notUnstackable: if(@variationTableUnstackable, e(":not(.unstackable)"));
+@notRowSpanned: if(@variationTableRowSpanned, e(":not(.rowspanned)"));
+@notFullWidth: if(@variationTableFullWidth, e(":not(.full-width)"));
+@notMarked: if(@variationTableMarked, e(":not(.marked)"));
+@notSortable: if(@variationTableSortable, e(":not(.sortable)"));
+@notStriped: if(@variationTableStriped, e(":not(.striped)"));
+@notInverted: if(@variationTableInverted, e(":not(.inverted)"));
+@notBasic: if(@variationTableBasic, e(":not(.basic)"));
+
 /*******************************
              Table
 *******************************/
@@ -58,10 +67,12 @@
     transition: @transition;
 }
 
-/* Rowspan helper class */
-.ui.table th.rowspanned,
-.ui.table td.rowspanned {
-    display: none;
+& when (@variationTableRowSpanned) {
+    /* Rowspan helper class */
+    .ui.table th.rowspanned,
+    .ui.table td.rowspanned {
+        display: none;
+    }
 }
 
 /* Headers */
@@ -173,67 +184,67 @@
 
 /* Responsive */
 @media only screen and (max-width: @largestMobileScreen) {
-    .ui.table:not(.unstackable) {
+    .ui.table@{notUnstackable} {
         width: 100%;
         padding: 0;
     }
-    .ui.table:not(.unstackable) > thead,
-    .ui.table:not(.unstackable) > thead > tr,
-    .ui.table:not(.unstackable) > tfoot,
-    .ui.table:not(.unstackable) > tfoot > tr,
-    .ui.table:not(.unstackable) > tbody,
-    .ui.table:not(.unstackable) > tr,
-    .ui.table:not(.unstackable) > tbody > tr,
-    .ui.table:not(.unstackable) > tr > th:not(.rowspanned),
-    .ui.table:not(.unstackable) > thead > tr > th:not(.rowspanned),
-    .ui.table:not(.unstackable) > tbody > tr > th:not(.rowspanned),
-    .ui.table:not(.unstackable) > tfoot > tr > th:not(.rowspanned),
-    .ui.table:not(.unstackable) > tr > td:not(.rowspanned),
-    .ui.table:not(.unstackable) > tbody > tr > td:not(.rowspanned),
-    .ui.table:not(.unstackable) > tfoot > tr > td:not(.rowspanned) {
+    .ui.table@{notUnstackable} > thead,
+    .ui.table@{notUnstackable} > thead > tr,
+    .ui.table@{notUnstackable} > tfoot,
+    .ui.table@{notUnstackable} > tfoot > tr,
+    .ui.table@{notUnstackable} > tbody,
+    .ui.table@{notUnstackable} > tr,
+    .ui.table@{notUnstackable} > tbody > tr,
+    .ui.table@{notUnstackable} > tr > th@{notRowSpanned},
+    .ui.table@{notUnstackable} > thead > tr > th@{notRowSpanned},
+    .ui.table@{notUnstackable} > tbody > tr > th@{notRowSpanned},
+    .ui.table@{notUnstackable} > tfoot > tr > th@{notRowSpanned},
+    .ui.table@{notUnstackable} > tr > td@{notRowSpanned},
+    .ui.table@{notUnstackable} > tbody > tr > td@{notRowSpanned},
+    .ui.table@{notUnstackable} > tfoot > tr > td@{notRowSpanned} {
         display: block !important;
         width: auto !important;
     }
 
-    .ui.table:not(.unstackable) > thead {
+    .ui.table@{notUnstackable} > thead {
         display: @responsiveHeaderDisplay;
     }
-    .ui.table:not(.unstackable) > tfoot {
+    .ui.table@{notUnstackable} > tfoot {
         display: @responsiveFooterDisplay;
     }
-    .ui.ui.ui.ui.table:not(.unstackable) > tr,
-    .ui.ui.ui.ui.table:not(.unstackable) > thead > tr,
-    .ui.ui.ui.ui.table:not(.unstackable) > tbody > tr,
-    .ui.ui.ui.ui.table:not(.unstackable) > tfoot > tr {
+    .ui.ui.ui.ui.table@{notUnstackable} > tr,
+    .ui.ui.ui.ui.table@{notUnstackable} > thead > tr,
+    .ui.ui.ui.ui.table@{notUnstackable} > tbody > tr,
+    .ui.ui.ui.ui.table@{notUnstackable} > tfoot > tr {
         padding-top: @responsiveRowVerticalPadding;
         padding-bottom: @responsiveRowVerticalPadding;
         box-shadow: @responsiveRowBoxShadow;
     }
 
-    .ui.ui.ui.ui.table:not(.unstackable) > tr > th,
-    .ui.ui.ui.ui.table:not(.unstackable) > thead > tr > th,
-    .ui.ui.ui.ui.table:not(.unstackable) > tbody > tr > th,
-    .ui.ui.ui.ui.table:not(.unstackable) > tfoot > tr > th,
-    .ui.ui.ui.ui.table:not(.unstackable) > tr > td,
-    .ui.ui.ui.ui.table:not(.unstackable) > tbody > tr > td,
-    .ui.ui.ui.ui.table:not(.unstackable) > tfoot > tr > td {
+    .ui.ui.ui.ui.table@{notUnstackable} > tr > th,
+    .ui.ui.ui.ui.table@{notUnstackable} > thead > tr > th,
+    .ui.ui.ui.ui.table@{notUnstackable} > tbody > tr > th,
+    .ui.ui.ui.ui.table@{notUnstackable} > tfoot > tr > th,
+    .ui.ui.ui.ui.table@{notUnstackable} > tr > td,
+    .ui.ui.ui.ui.table@{notUnstackable} > tbody > tr > td,
+    .ui.ui.ui.ui.table@{notUnstackable} > tfoot > tr > td {
         background: none;
         border: none;
         padding: @responsiveCellVerticalPadding @responsiveCellHorizontalPadding;
         box-shadow: @responsiveCellBoxShadow;
     }
-    .ui.table:not(.unstackable) > tr > th:first-child,
-    .ui.table:not(.unstackable) > thead > tr > th:first-child,
-    .ui.table:not(.unstackable) > tbody > tr > th:first-child,
-    .ui.table:not(.unstackable) > tfoot > tr > th:first-child,
-    .ui.table:not(.unstackable) > tr > td:first-child,
-    .ui.table:not(.unstackable) > tbody > tr > td:first-child,
-    .ui.table:not(.unstackable) > tfoot > tr > td:first-child {
+    .ui.table@{notUnstackable} > tr > th:first-child,
+    .ui.table@{notUnstackable} > thead > tr > th:first-child,
+    .ui.table@{notUnstackable} > tbody > tr > th:first-child,
+    .ui.table@{notUnstackable} > tfoot > tr > th:first-child,
+    .ui.table@{notUnstackable} > tr > td:first-child,
+    .ui.table@{notUnstackable} > tbody > tr > td:first-child,
+    .ui.table@{notUnstackable} > tfoot > tr > td:first-child {
         font-weight: @responsiveCellHeaderFontWeight;
     }
 
     /* Definition Table */
-    .ui.definition.table:not(.unstackable) > thead > tr > th:first-child {
+    .ui.definition.table@{notUnstackable} > thead > tr > th:first-child {
         box-shadow: none !important;
     }
     & when (@variationTableMarked) and not (@variationTableColors = false) {
@@ -241,7 +252,7 @@
             @color: @value;
             @c: @colors[@@color][color];
             @l: @colors[@@color][light];
-            .ui.ui.ui.ui.table:not(.unstackable) tr[class*="@{color} marked"] {
+            .ui.ui.ui.ui.table@{notUnstackable} tr[class*="@{color} marked"] {
                 &.left {
                     box-shadow: @responsiveRowBoxShadow, @coloredBorderSize 0 0 0 @c inset;
                 }
@@ -250,7 +261,7 @@
                 }
             }
             & when (@variationTableInverted) {
-                .ui.ui.ui.ui.inverted.table:not(.unstackable) tr[class*="@{color} marked"] {
+                .ui.ui.ui.ui.inverted.table@{notUnstackable} tr[class*="@{color} marked"] {
                     &.left {
                         box-shadow: @responsiveRowBoxShadow, @coloredBorderSize 0 0 0 @l inset;
                     }
@@ -716,7 +727,7 @@
        Definition
     --------------- */
 
-    .ui.definition.table > thead:not(.full-width) > tr > th:first-child {
+    .ui.definition.table > thead@{notFullWidth} > tr > th:first-child {
         pointer-events: none;
         background: @definitionHeaderBackground;
         font-weight: @definitionHeaderFontWeight;
@@ -727,11 +738,11 @@
         -moz-transform: scale(1);
     }
 
-    .ui.definition.table > thead:not(.full-width) > tr > th:first-child:not(:empty) {
+    .ui.definition.table > thead@{notFullWidth} > tr > th:first-child:not(:empty) {
         pointer-events: auto;
     }
 
-    .ui.definition.table > tfoot:not(.full-width) > tr > th:first-child {
+    .ui.definition.table > tfoot@{notFullWidth} > tr > th:first-child {
         pointer-events: none;
         background: @definitionFooterBackground;
         font-weight: @definitionFooterFontWeight;
@@ -759,11 +770,11 @@
     }
 
     /* Fix 2nd Column */
-    .ui.definition.table > thead:not(.full-width) > tr > th:nth-child(2) {
+    .ui.definition.table > thead@{notFullWidth} > tr > th:nth-child(2) {
         border-left: @borderWidth solid @borderColor;
     }
-    .ui.definition.table > tfoot:not(.full-width) > tr > th:nth-child(2),
-    .ui.definition.table > tfoot:not(.full-width) > tr > td:nth-child(2) {
+    .ui.definition.table > tfoot@{notFullWidth} > tr > th:nth-child(2),
+    .ui.definition.table > tfoot@{notFullWidth} > tr > td:nth-child(2) {
         border-left: @borderWidth solid @borderColor;
     }
     .ui.definition.table > tr > td:nth-child(2),
@@ -907,13 +918,13 @@
         .ui[class*="tablet stackable"].table > tbody,
         .ui[class*="tablet stackable"].table > tbody > tr,
         .ui[class*="tablet stackable"].table > tr,
-        .ui[class*="tablet stackable"].table > thead > tr > th:not(.rowspanned),
-        .ui[class*="tablet stackable"].table > tbody > tr > th:not(.rowspanned),
-        .ui[class*="tablet stackable"].table > tfoot > tr > th:not(.rowspanned),
-        .ui[class*="tablet stackable"].table > tr > th:not(.rowspanned),
-        .ui[class*="tablet stackable"].table > tbody > tr > td:not(.rowspanned),
-        .ui[class*="tablet stackable"].table > tfoot > tr > td:not(.rowspanned),
-        .ui[class*="tablet stackable"].table > tr > td:not(.rowspanned) {
+        .ui[class*="tablet stackable"].table > thead > tr > th@{notRowSpanned},
+        .ui[class*="tablet stackable"].table > tbody > tr > th@{notRowSpanned},
+        .ui[class*="tablet stackable"].table > tfoot > tr > th@{notRowSpanned},
+        .ui[class*="tablet stackable"].table > tr > th@{notRowSpanned},
+        .ui[class*="tablet stackable"].table > tbody > tr > td@{notRowSpanned},
+        .ui[class*="tablet stackable"].table > tfoot > tr > td@{notRowSpanned},
+        .ui[class*="tablet stackable"].table > tr > td@{notRowSpanned} {
             display: block !important;
             width: 100% !important;
         }
@@ -1269,9 +1280,9 @@
         .ui.ui.ui.ui.table tr[class*="@{color} colored"],
         .ui.ui.table th[class*="@{color} colored"],
         .ui.ui.table td[class*="@{color} colored"],
-        .ui.ui.ui.ui.table tr.@{color}:not(.marked),
-        .ui.ui.table th.@{color}:not(.marked),
-        .ui.ui.table td.@{color}:not(.marked) {
+        .ui.ui.ui.ui.table tr.@{color}@{notMarked},
+        .ui.ui.table th.@{color}@{notMarked},
+        .ui.ui.table td.@{color}@{notMarked} {
             & when (@stateMarkerWidth > 0) {
                 box-shadow: @stateMarkerWidth 0 0 @r inset;
             }
@@ -1291,9 +1302,9 @@
         .ui.table > thead > tr[class*="@{color} colored"] > th,
         .ui.table > tfoot > tr[class*="@{color} colored"] > th,
         .ui.table > tfoot > tr[class*="@{color} colored"] > td,
-        .ui.table > thead > tr.@{color}:not(.marked) > th,
-        .ui.table > tfoot > tr.@{color}:not(.marked) > th,
-        .ui.table > tfoot > tr.@{color}:not(.marked) > td {
+        .ui.table > thead > tr.@{color}@{notMarked} > th,
+        .ui.table > tfoot > tr.@{color}@{notMarked} > th,
+        .ui.table > tfoot > tr.@{color}@{notMarked} > td {
             background: inherit;
             & when (@isVeryDark) {
                 color: @white;
@@ -1307,18 +1318,18 @@
             .ui.ui.ui.ui.inverted.table tr[class*="@{color} colored"],
             .ui.ui.inverted.table th[class*="@{color} colored"],
             .ui.ui.inverted.table td[class*="@{color} colored"],
-            .ui.ui.ui.ui.inverted.table tr.@{color}:not(.marked),
-            .ui.ui.inverted.table th.@{color}:not(.marked),
-            .ui.ui.inverted.table td.@{color}:not(.marked) {
+            .ui.ui.ui.ui.inverted.table tr.@{color}@{notMarked},
+            .ui.ui.inverted.table th.@{color}@{notMarked},
+            .ui.ui.inverted.table td.@{color}@{notMarked} {
                 background: @c;
                 color: @white;
             }
             .ui.inverted.table > thead > tr[class*="@{color} colored"] > th,
             .ui.inverted.table > tfoot > tr[class*="@{color} colored"] > th,
             .ui.inverted.table > tfoot > tr[class*="@{color} colored"] > td,
-            .ui.inverted.table > thead > tr.@{color}:not(.marked) > th,
-            .ui.inverted.table > tfoot > tr.@{color}:not(.marked) > th,
-            .ui.inverted.table > tfoot > tr.@{color}:not(.marked) > td {
+            .ui.inverted.table > thead > tr.@{color}@{notMarked} > th,
+            .ui.inverted.table > tfoot > tr.@{color}@{notMarked} > th,
+            .ui.inverted.table > tfoot > tr.@{color}@{notMarked} > td {
                 background: inherit;
                 color: @white;
             }
@@ -1327,9 +1338,9 @@
             .ui.ui.selectable.table tr[class*="@{color} colored"]:hover,
             .ui.table tr td.selectable[class*="@{color} colored"]:hover,
             .ui.selectable.table tr:hover td[class*="@{color} colored"],
-            .ui.ui.selectable.table tr.@{color}:not(.marked):hover,
-            .ui.table tr td.selectable.@{color}:not(.marked):hover,
-            .ui.selectable.table tr:hover td.@{color}:not(.marked) {
+            .ui.ui.selectable.table tr.@{color}@{notMarked}:hover,
+            .ui.table tr td.selectable.@{color}@{notMarked}:hover,
+            .ui.selectable.table tr:hover td.@{color}@{notMarked} {
                 & when (@isDark) {
                     background: @lh;
                 }
@@ -1347,9 +1358,9 @@
                 .ui.ui.inverted.selectable.table tr[class*="@{color} colored"]:hover,
                 .ui.inverted.table tr td.selectable[class*="@{color} colored"]:hover,
                 .ui.inverted.selectable.table tr:hover td[class*="@{color} colored"],
-                .ui.ui.inverted.selectable.table tr.@{color}:not(.marked):hover,
-                .ui.inverted.table tr td.selectable.@{color}:not(.marked):hover,
-                .ui.inverted.selectable.table tr:hover td.@{color}:not(.marked) {
+                .ui.ui.inverted.selectable.table tr.@{color}@{notMarked}:hover,
+                .ui.inverted.table tr td.selectable.@{color}@{notMarked}:hover,
+                .ui.inverted.selectable.table tr:hover td.@{color}@{notMarked} {
                     & when (@isDark) {
                         background: @bh;
                     }
@@ -1564,7 +1575,7 @@
     .ui.sortable.table > thead > tr > th:hover {
         color: @sortableHoverColor;
     }
-    .ui.sortable.table:not(.basic) > thead > tr > th:hover {
+    .ui.sortable.table@{notBasic} > thead > tr > th:hover {
         background: @sortableHoverBackground;
     }
 
@@ -1572,7 +1583,7 @@
     .ui.sortable.table thead th.sorted {
         color: @sortableActiveColor;
     }
-    .ui.sortable.table:not(.basic) thead th.sorted {
+    .ui.sortable.table@{notBasic} thead th.sorted {
         background: @sortableActiveBackground;
     }
     .ui.sortable.table thead th.sorted::after {
@@ -1583,7 +1594,7 @@
     .ui.sortable.table thead th.sorted:hover {
         color: @sortableActiveHoverColor;
     }
-    .ui.sortable.table:not(.basic) thead th.sorted:hover {
+    .ui.sortable.table@{notBasic} thead th.sorted:hover {
         background: @sortableActiveHoverBackground;
     }
     & when (@variationTableInverted) {
@@ -1591,16 +1602,16 @@
         .ui.inverted.sortable.table thead th.sorted {
             color: @sortableInvertedActiveColor;
         }
-        .ui.inverted.sortable.table:not(.basic) thead th.sorted {
+        .ui.inverted.sortable.table@{notBasic} thead th.sorted {
             background: @sortableInvertedActiveBackground;
         }
         .ui.inverted.sortable.table > thead > tr > th:hover {
             color: @sortableInvertedHoverColor;
         }
-        .ui.inverted.sortable.table:not(.basic) > thead > tr > th:hover {
+        .ui.inverted.sortable.table@{notBasic} > thead > tr > th:hover {
             background: @sortableInvertedHoverBackground;
         }
-        .ui.inverted.sortable.table:not(.basic) > thead > tr > th {
+        .ui.inverted.sortable.table@{notBasic} > thead > tr > th {
             border-left-color: @sortableInvertedBorderColor;
             border-right-color: @sortableInvertedBorderColor;
         }
@@ -1653,8 +1664,8 @@
     }
     & when (@variationTableDefinition) {
         /* Definition */
-        .ui.inverted.definition.table > tfoot:not(.full-width) > tr > th:first-child,
-        .ui.inverted.definition.table > thead:not(.full-width) > tr > th:first-child {
+        .ui.inverted.definition.table > tfoot@{notFullWidth} > tr > th:first-child,
+        .ui.inverted.definition.table > thead@{notFullWidth} > tr > th:first-child {
             background: @definitionPageBackground;
         }
         .ui.inverted.definition.table > tbody > tr > td:first-child,
@@ -1715,33 +1726,33 @@
         .ui[class*="very basic"].table {
             border: none;
         }
-        .ui[class*="very basic"].table:not(.sortable):not(.striped) > tr > th,
-        .ui[class*="very basic"].table:not(.sortable):not(.striped) > thead > tr > th,
-        .ui[class*="very basic"].table:not(.sortable):not(.striped) > tbody > tr > th,
-        .ui[class*="very basic"].table:not(.sortable):not(.striped) > tfoot > tr > th,
-        .ui[class*="very basic"].table:not(.sortable):not(.striped) > tr > td,
-        .ui[class*="very basic"].table:not(.sortable):not(.striped) > tbody > tr > td {
+        .ui[class*="very basic"].table@{notSortable}@{notStriped} > tr > th,
+        .ui[class*="very basic"].table@{notSortable}@{notStriped} > thead > tr > th,
+        .ui[class*="very basic"].table@{notSortable}@{notStriped} > tbody > tr > th,
+        .ui[class*="very basic"].table@{notSortable}@{notStriped} > tfoot > tr > th,
+        .ui[class*="very basic"].table@{notSortable}@{notStriped} > tr > td,
+        .ui[class*="very basic"].table@{notSortable}@{notStriped} > tbody > tr > td {
             padding: @basicTableCellPadding;
         }
-        .ui[class*="very basic"].table:not(.sortable):not(.striped) > tr > th:first-child,
-        .ui[class*="very basic"].table:not(.sortable):not(.striped) > thead > tr > th:first-child,
-        .ui[class*="very basic"].table:not(.sortable):not(.striped) > tbody > tr > th:first-child,
-        .ui[class*="very basic"].table:not(.sortable):not(.striped) > tfoot > tr > th:first-child,
-        .ui[class*="very basic"].table:not(.sortable):not(.striped) > tr > td:first-child,
-        .ui[class*="very basic"].table:not(.sortable):not(.striped) > tbody > tr > td:first-child,
-        .ui[class*="very basic"].table:not(.sortable):not(.striped) > tfoot > tr > td:first-child {
+        .ui[class*="very basic"].table@{notSortable}@{notStriped} > tr > th:first-child,
+        .ui[class*="very basic"].table@{notSortable}@{notStriped} > thead > tr > th:first-child,
+        .ui[class*="very basic"].table@{notSortable}@{notStriped} > tbody > tr > th:first-child,
+        .ui[class*="very basic"].table@{notSortable}@{notStriped} > tfoot > tr > th:first-child,
+        .ui[class*="very basic"].table@{notSortable}@{notStriped} > tr > td:first-child,
+        .ui[class*="very basic"].table@{notSortable}@{notStriped} > tbody > tr > td:first-child,
+        .ui[class*="very basic"].table@{notSortable}@{notStriped} > tfoot > tr > td:first-child {
             padding-left: 0;
         }
-        .ui[class*="very basic"].table:not(.sortable):not(.striped) > tr > th:last-child,
-        .ui[class*="very basic"].table:not(.sortable):not(.striped) > thead > tr > th:last-child,
-        .ui[class*="very basic"].table:not(.sortable):not(.striped) > tbody > tr > th:last-child,
-        .ui[class*="very basic"].table:not(.sortable):not(.striped) > tfoot > tr > th:last-child,
-        .ui[class*="very basic"].table:not(.sortable):not(.striped) > tr > td:last-child,
-        .ui[class*="very basic"].table:not(.sortable):not(.striped) > tbody > tr > td:last-child,
-        .ui[class*="very basic"].table:not(.sortable):not(.striped) > tfoot > tr > td:last-child {
+        .ui[class*="very basic"].table@{notSortable}@{notStriped} > tr > th:last-child,
+        .ui[class*="very basic"].table@{notSortable}@{notStriped} > thead > tr > th:last-child,
+        .ui[class*="very basic"].table@{notSortable}@{notStriped} > tbody > tr > th:last-child,
+        .ui[class*="very basic"].table@{notSortable}@{notStriped} > tfoot > tr > th:last-child,
+        .ui[class*="very basic"].table@{notSortable}@{notStriped} > tr > td:last-child,
+        .ui[class*="very basic"].table@{notSortable}@{notStriped} > tbody > tr > td:last-child,
+        .ui[class*="very basic"].table@{notSortable}@{notStriped} > tfoot > tr > td:last-child {
             padding-right: 0;
         }
-        .ui[class*="very basic"].table:not(.sortable):not(.striped) > thead > tr:first-child > th {
+        .ui[class*="very basic"].table@{notSortable}@{notStriped} > thead > tr:first-child > th {
             padding-top: 0;
         }
     }
@@ -1857,7 +1868,7 @@
          Stuck
     --------------- */
 
-    .ui.stuck.table:not(.inverted) {
+    .ui.stuck.table@{notInverted} {
         background: @stuckBackground;
         & > thead > tr {
             background: @stuckHeaderBackground;

--- a/src/definitions/elements/button.less
+++ b/src/definitions/elements/button.less
@@ -17,6 +17,18 @@
 
 @import (multiple) "../../theme.config";
 
+@notIcon: if(@variationButtonIcon, e(":not(.icon)"));
+@notAnimated: if(@variationButtonAnimated, e(":not(.animated)"));
+@notLabeled: if(@variationButtonLabeled, e(":not(.labeled)"));
+@notCompact: if(@variationButtonCompact, e(":not(.compact)"));
+@notSpaced: if(@variationButtonSpaced, e(":not(.spaced)"));
+@notCircular: if(@variationButtonCircular, e(":not(.circular)"));
+@notVertical: if(@variationButtonVertical, e(":not(.vertical)"));
+@notInverted: if(@variationButtonInverted, e(":not(.inverted)"));
+@notBasic: if(@variationButtonBasic, e(":not(.basic)"));
+@notAttached: if(@variationButtonAttached, e(":not(.attached)"));
+@notWrapping: if(@variationButtonWrapping, e(":not(.wrapping)"));
+
 /*******************************
             Button
 *******************************/
@@ -166,10 +178,10 @@
         }
     }
     & when (@variationButtonBasic) {
-        .ui.basic.loading.button:not(.inverted)::before {
+        .ui.basic.loading.button@{notInverted}::before {
             border-color: @loaderFillColor;
         }
-        .ui.basic.loading.button:not(.inverted)::after {
+        .ui.basic.loading.button@{notInverted}::after {
             border-color: @loaderLineColor;
         }
     }
@@ -179,7 +191,7 @@
           Disabled
     -------------------- */
 
-    .ui.buttons .disabled.button:not(.basic),
+    .ui.buttons .disabled.button@{notBasic},
     .ui.disabled.button,
     .ui.button:disabled,
     .ui.disabled.button:hover,
@@ -377,7 +389,7 @@
         Labeled Button
     -------------------- */
 
-    .ui.labeled.button:not(.icon) {
+    .ui.labeled.button@{notIcon} {
         display: inline-flex;
         flex-direction: row;
         background: none;
@@ -621,15 +633,15 @@
     color: @iconColor;
 }
 
-.ui.button:not(.icon) > .icon:not(.button):not(.dropdown),
-.ui.button:not(.icon) > .icons:not(.button):not(.dropdown) {
+.ui.button@{notIcon} > .icon:not(.button):not(.dropdown),
+.ui.button@{notIcon} > .icons:not(.button):not(.dropdown) {
     margin: @iconMargin;
     vertical-align: @iconVerticalAlign;
 }
-.ui.button:not(.icon) > .icons:not(.button):not(.dropdown) > .icon {
+.ui.button@{notIcon} > .icons:not(.button):not(.dropdown) > .icon {
     vertical-align: @iconVerticalAlign;
 }
-.ui.button:not(.icon) > .right.icon:not(.button):not(.dropdown) {
+.ui.button@{notIcon} > .right.icon:not(.button):not(.dropdown) {
     margin: @rightIconMargin;
 }
 
@@ -737,7 +749,7 @@
     --------------- */
 
     .ui.icon.buttons .button,
-    .ui.icon.button:not(.animated):not(.compact):not(.labeled) {
+    .ui.icon.button@{notAnimated}@{notCompact}@{notLabeled} {
         padding: @verticalPadding @verticalPadding (@verticalPadding + @shadowOffset);
     }
     .ui.animated.icon.button > .content > .icon,
@@ -873,7 +885,7 @@
 
     & when (@variationButtonGroups) {
         /* Basic Group */
-        .ui.basic.buttons:not(.inverted) .button:not(.basic) {
+        .ui.basic.buttons@{notInverted} .button@{notBasic} {
             border-right: @basicGroupBorder;
             box-shadow: none;
         }
@@ -885,7 +897,7 @@
                 border-top: @basicGroupBorder;
             }
 
-            .ui.basic.vertical.buttons:not(.spaced):not(.circular) .button:first-child {
+            .ui.basic.vertical.buttons@{notSpaced}@{notCircular} .button:first-child {
                 border-top: none;
             }
         }
@@ -1107,7 +1119,7 @@
         vertical-align: baseline;
     }
 
-    .ui.circular.buttons:not(.vertical):not(.spaced) .button {
+    .ui.circular.buttons@{notVertical}@{notSpaced} .button {
         margin-right: @circularGroupMargin;
     }
 
@@ -1827,7 +1839,7 @@
                 box-shadow: 0 0 0 @basicColoredBorderSize @@_backgroundColorDown inset;
                 color: @@_backgroundColorDown;
             }
-            .ui.buttons:not(.vertical) > .basic.@{consequence}.button:not(:first-child) {
+            .ui.buttons@{notVertical} > .basic.@{consequence}.button:not(:first-child) {
                 margin-left: -@basicColoredBorderSize;
             }
         }
@@ -1847,7 +1859,7 @@
         margin: @verticalMargin @horizontalMargin 0 0;
     }
 
-    .ui.buttons:not(.basic):not(.inverted) {
+    .ui.buttons@{notBasic}@{notInverted} {
         box-shadow: @groupBoxShadow;
     }
 
@@ -1867,7 +1879,7 @@
         margin: @groupButtonOffset;
     }
 
-    .ui.buttons:not(.basic):not(.inverted) > .button:not(.basic):not(.inverted) {
+    .ui.buttons@{notBasic}@{notInverted} > .button@{notBasic}@{notInverted} {
         box-shadow: @groupButtonBoxShadow;
     }
 
@@ -1895,7 +1907,7 @@
             width: 100%;
             margin: @verticalGroupOffset;
             border-radius: 0;
-            &:not(.basic) {
+            &@{notBasic} {
                 box-shadow: @verticalBoxShadow;
             }
         }
@@ -1943,7 +1955,7 @@
         }
     }
     & when (@variationButtonWrapped) {
-        .ui.wrapped.buttons:not(.spaced) {
+        .ui.wrapped.buttons@{notSpaced} {
             border-top-right-radius: 0;
             & .button {
                 &:first-child {
@@ -1991,7 +2003,7 @@
                 }
             }
             & when (@variationButtonWrapping) {
-                .ui.spaced.basic.wrapping.buttons .button:not(.basic) {
+                .ui.spaced.basic.wrapping.buttons .button@{notBasic} {
                     border-top: @basicGroupBorder;
                     border-right: @basicGroupBorder;
                     &:first-child {
@@ -2009,22 +2021,22 @@
     }
 
     & when (@variationButtonBasic) {
-        .ui.basic.buttons:not(.vertical).inverted .button,
-        .ui.basic.buttons:not(.vertical) .basic.button {
+        .ui.basic.buttons@{notVertical}.inverted .button,
+        .ui.basic.buttons@{notVertical} .basic.button {
             margin-left: -@basicColoredBorderSize;
             border-right: none;
         }
-        .ui.basic.buttons:not(.vertical):not(.spaced):not(.inverted) .basic.button {
+        .ui.basic.buttons@{notVertical}@{notSpaced}@{notInverted} .basic.button {
             margin-top: -@basicColoredBorderSize;
             border-bottom: none;
         }
         & when (@variationButtonAttached) or (@variationButtonInverted) {
-            .ui.inverted.basic.buttons:not(.spaced) .button,
-            .ui.attached.basic.buttons:not(.wrapping):not(.inverted) .basic.button {
+            .ui.inverted.basic.buttons@{notSpaced} .button,
+            .ui.attached.basic.buttons@{notWrapping}@{notInverted} .basic.button {
                 margin-bottom: @attachedOffset;
             }
         }
-        .ui.basic.buttons:not(.vertical):not(.attached):not(.spaced):not(.wrapping):not(.inverted) .basic.button {
+        .ui.basic.buttons@{notVertical}@{notAttached}@{notSpaced}@{notWrapping}@{notInverted} .basic.button {
             margin-bottom: -@basicColoredBorderSize;
         }
     }

--- a/src/definitions/elements/container.less
+++ b/src/definitions/elements/container.less
@@ -17,6 +17,8 @@
 
 @import (multiple) "../../theme.config";
 
+@notFluid: if(@variationContainerFluid, e(":not(.fluid)"));
+
 /*******************************
             Container
 *******************************/
@@ -29,7 +31,7 @@
 
 /* Mobile */
 @media only screen and (max-width: @largestMobileScreen) {
-    .ui.ui.ui.container:not(.fluid) {
+    .ui.ui.ui.container@{notFluid} {
         width: @mobileWidth;
         margin-left: @mobileGutter;
         margin-right: @mobileGutter;
@@ -53,7 +55,7 @@
 
 /* Tablet */
 @media only screen and (min-width: @tabletBreakpoint) and (max-width: @largestTabletScreen) {
-    .ui.ui.ui.container:not(.fluid) {
+    .ui.ui.ui.container@{notFluid} {
         width: @tabletWidth;
         margin-left: @tabletGutter;
         margin-right: @tabletGutter;
@@ -77,7 +79,7 @@
 
 /* Small Monitor */
 @media only screen and (min-width: @computerBreakpoint) and (max-width: @largestSmallMonitor) {
-    .ui.ui.ui.container:not(.fluid) {
+    .ui.ui.ui.container@{notFluid} {
         width: @computerWidth;
         margin-left: @computerGutter;
         margin-right: @computerGutter;
@@ -101,7 +103,7 @@
 
 /* Large Monitor */
 @media only screen and (min-width: @largeMonitorBreakpoint) {
-    .ui.ui.ui.container:not(.fluid) {
+    .ui.ui.ui.container@{notFluid} {
         width: @largeMonitorWidth;
         margin-left: @largeMonitorGutter;
         margin-right: @largeMonitorGutter;

--- a/src/definitions/elements/divider.less
+++ b/src/definitions/elements/divider.less
@@ -17,6 +17,9 @@
 
 @import (multiple) "../../theme.config";
 
+@notHorizontal: if(@variationDividerHorizontal, e(":not(.horizontal)"));
+@notVertical: if(@variationDividerVertical, e(":not(.vertical)"));
+
 /*******************************
             Divider
 *******************************/
@@ -37,7 +40,7 @@
       Basic
 --------------- */
 
-.ui.divider:not(.vertical):not(.horizontal) {
+.ui.divider@{notVertical}@{notHorizontal} {
     border-top: @shadowWidth @borderStyle @shadowColor;
     border-bottom: @highlightWidth @borderStyle @highlightColor;
 }

--- a/src/definitions/elements/emoji.less
+++ b/src/definitions/elements/emoji.less
@@ -17,6 +17,8 @@
 
 @import (multiple) "../../theme.config";
 
+@notDisabled: if(@variationEmojiDisabled, e(":not(.disabled)"));
+
 /*******************************
              Emoji
 *******************************/
@@ -63,7 +65,7 @@ em[data-emoji]::before {
              Link
     -------------------- */
 
-    em[data-emoji].link:not(.disabled) {
+    em[data-emoji].link@{notDisabled} {
         cursor: pointer;
     }
 }

--- a/src/definitions/elements/header.less
+++ b/src/definitions/elements/header.less
@@ -18,6 +18,7 @@
 @import (multiple) "../../theme.config";
 
 @notCenteredAligned: if(@variationHeaderAligned, e(":not(.centered):not(.aligned)"));
+@notIcon: if(@variationHeaderIcon, e(":not(.icon)"));
 
 /*******************************
             Header
@@ -72,8 +73,8 @@
 }
 
 /* With Text Node */
-.ui.header:not(.icon) > .icons:only-child,
-.ui.header:not(.icon) > i.icon:only-child {
+.ui.header@{notIcon} > .icons:only-child,
+.ui.header@{notIcon} > i.icon:only-child {
     display: inline-block;
     padding: 0;
     margin-right: @iconMargin;
@@ -113,8 +114,8 @@
 }
 
 /* After Icon */
-.ui.header:not(.icon)@{notCenteredAligned} > .icons + .content,
-.ui.header:not(.icon)@{notCenteredAligned} > i.icon + .content {
+.ui.header@{notIcon}@{notCenteredAligned} > .icons + .content,
+.ui.header@{notIcon}@{notCenteredAligned} > i.icon + .content {
     padding-left: @iconMargin;
     display: table-cell;
     vertical-align: @contentIconAlignment;

--- a/src/definitions/elements/header.less
+++ b/src/definitions/elements/header.less
@@ -17,6 +17,8 @@
 
 @import (multiple) "../../theme.config";
 
+@notCenteredAligned: if(@variationHeaderAligned, e(":not(.centered):not(.aligned)"));
+
 /*******************************
             Header
 *******************************/
@@ -111,8 +113,8 @@
 }
 
 /* After Icon */
-.ui.header:not(.icon):not(.centered):not(.aligned) > .icons + .content,
-.ui.header:not(.icon):not(.centered):not(.aligned) > i.icon + .content {
+.ui.header:not(.icon)@{notCenteredAligned} > .icons + .content,
+.ui.header:not(.icon)@{notCenteredAligned} > i.icon + .content {
     padding-left: @iconMargin;
     display: table-cell;
     vertical-align: @contentIconAlignment;

--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -17,6 +17,13 @@
 
 @import (multiple) "../../theme.config";
 
+@notDisabled: if(@variationIconDisabled, e(":not(.disabled)"));
+@notCorner: if(@variationIconCorner, e(":not(.corner)"));
+@notRotated: if(@variationIconRotated, e(":not(.rotated)"));
+@notFlipped: if(@variationIconFlipped, e(":not(.flipped)"));
+@notBordered: if(@variationIconBordered, e(":not(.bordered)"));
+@notCircular: if(@variationIconCircular, e(":not(.circular)"));
+
 /*******************************
              Icon
 *******************************/
@@ -78,8 +85,8 @@ i.icon:hover,
 i.icons:hover,
 i.icon:active,
 i.icons:active,
-i.emphasized.icon:not(.disabled),
-i.emphasized.icons:not(.disabled) {
+i.emphasized.icon@{notDisabled},
+i.emphasized.icons@{notDisabled} {
     opacity: 1;
 }
 
@@ -113,8 +120,8 @@ i.emphasized.icons:not(.disabled) {
              Link
     -------------------- */
 
-    i.link.icon:not(.disabled),
-    i.link.icons:not(.disabled) {
+    i.link.icon@{notDisabled},
+    i.link.icons@{notDisabled} {
         cursor: pointer;
         opacity: @linkOpacity;
         transition: opacity @defaultDuration @defaultEasing;
@@ -163,11 +170,11 @@ i.emphasized.icons:not(.disabled) {
     }
 
     & when (@variationIconGroups) {
-        .icons i.flipped.icon:not(.corner):not(:first-child),
-        .icons i.horizontally.flipped.icon:not(.corner):not(:first-child) {
+        .icons i.flipped.icon@{notCorner}:not(:first-child),
+        .icons i.horizontally.flipped.icon@{notCorner}:not(:first-child) {
             transform: translateX(-50%) translateY(-50%) scale(-1, 1);
         }
-        .icons i.vertically.flipped.icon:not(.corner):not(:first-child) {
+        .icons i.vertically.flipped.icon@{notCorner}:not(:first-child) {
             transform: translateX(-50%) translateY(-50%) scale(1, -1);
         }
     }
@@ -194,16 +201,16 @@ i.emphasized.icons:not(.disabled) {
     }
 
     & when (@variationIconGroups) {
-        .icons i.rotated.rotated.icon:not(.corner):not(:first-child),
-        .icons i.right.rotated.icon:not(.corner):not(:first-child),
-        .icons i.clockwise.rotated.icon:not(.corner):not(:first-child) {
+        .icons i.rotated.rotated.icon@{notCorner}:not(:first-child),
+        .icons i.right.rotated.icon@{notCorner}:not(:first-child),
+        .icons i.clockwise.rotated.icon@{notCorner}:not(:first-child) {
             transform: translateX(-50%) translateY(-50%) rotate(90deg);
         }
-        .icons i.left.rotated.icon:not(.corner):not(:first-child),
-        .icons i.counterclockwise.rotated.icon:not(.corner):not(:first-child) {
+        .icons i.left.rotated.icon@{notCorner}:not(:first-child),
+        .icons i.counterclockwise.rotated.icon@{notCorner}:not(:first-child) {
             transform: translateX(-50%) translateY(-50%) rotate(-90deg);
         }
-        .icons i.halfway.rotated.icon:not(.corner):not(:first-child) {
+        .icons i.halfway.rotated.icon@{notCorner}:not(:first-child) {
             transform: translateX(-50%) translateY(-50%) rotate(180deg);
         }
     }
@@ -245,28 +252,28 @@ i.emphasized.icons:not(.disabled) {
     }
 
     & when (@variationIconGroups) {
-        .icons i.rotated.flipped.icon:not(.corner):not(:first-child),
-        .icons i.right.rotated.flipped.icon:not(.corner):not(:first-child),
-        .icons i.clockwise.rotated.flipped.icon:not(.corner):not(:first-child) {
+        .icons i.rotated.flipped.icon@{notCorner}:not(:first-child),
+        .icons i.right.rotated.flipped.icon@{notCorner}:not(:first-child),
+        .icons i.clockwise.rotated.flipped.icon@{notCorner}:not(:first-child) {
             transform: translateX(-50%) translateY(-50%) scale(-1, 1) rotate(90deg);
         }
-        .icons i.left.rotated.flipped.icon:not(.corner):not(:first-child),
-        .icons i.counterclockwise.rotated.flipped.icon:not(.corner):not(:first-child) {
+        .icons i.left.rotated.flipped.icon@{notCorner}:not(:first-child),
+        .icons i.counterclockwise.rotated.flipped.icon@{notCorner}:not(:first-child) {
             transform: translateX(-50%) translateY(-50%) scale(-1, 1) rotate(-90deg);
         }
-        .icons i.halfway.rotated.flipped.icon:not(.corner):not(:first-child) {
+        .icons i.halfway.rotated.flipped.icon@{notCorner}:not(:first-child) {
             transform: translateX(-50%) translateY(-50%) scale(-1, 1) rotate(180deg);
         }
-        .icons i.rotated.vertically.flipped.icon:not(.corner):not(:first-child),
-        .icons i.right.rotated.vertically.flipped.icon:not(.corner):not(:first-child),
-        .icons i.clockwise.rotated.vertically.flipped.icon:not(.corner):not(:first-child) {
+        .icons i.rotated.vertically.flipped.icon@{notCorner}:not(:first-child),
+        .icons i.right.rotated.vertically.flipped.icon@{notCorner}:not(:first-child),
+        .icons i.clockwise.rotated.vertically.flipped.icon@{notCorner}:not(:first-child) {
             transform: translateX(-50%) translateY(-50%) scale(1, -1) rotate(90deg);
         }
-        .icons i.left.rotated.vertically.flipped.icon:not(.corner):not(:first-child),
-        .icons i.counterclockwise.rotated.vertically.flipped.icon:not(.corner):not(:first-child) {
+        .icons i.left.rotated.vertically.flipped.icon@{notCorner}:not(:first-child),
+        .icons i.counterclockwise.rotated.vertically.flipped.icon@{notCorner}:not(:first-child) {
             transform: translateX(-50%) translateY(-50%) scale(1, -1) rotate(-90deg);
         }
-        .icons i.halfway.rotated.vertically.flipped.icon:not(.corner):not(:first-child) {
+        .icons i.halfway.rotated.vertically.flipped.icon@{notCorner}:not(:first-child) {
             transform: translateX(-50%) translateY(-50%) scale(1, -1) rotate(180deg);
         }
     }
@@ -383,7 +390,7 @@ i.icons {
         top: 50%;
         left: 50%;
         margin: 0;
-        &:not(.corner):not(.rotated):not(.flipped) {
+        &@{notCorner}@{notRotated}@{notFlipped} {
             transform: translateX(-50%) translateY(-50%);
         }
     }
@@ -394,7 +401,7 @@ i.icons {
         height: auto;
         vertical-align: top;
     }
-    i.icons:not(.bordered):not(.circular) .icon:first-child:not(.rotated):not(.flipped) {
+    i.icons@{notBordered}@{notCircular} .icon:first-child@{notRotated}@{notFlipped} {
         transform: none;
     }
 
@@ -407,7 +414,7 @@ i.icons {
             bottom: @cornerOffset;
             font-size: @cornerIconSize;
             text-shadow: @cornerIconShadow;
-            &:not(.rotated):not(.flipped) {
+            &@{notRotated}@{notFlipped} {
                 transform: none;
             }
         }

--- a/src/definitions/elements/input.less
+++ b/src/definitions/elements/input.less
@@ -19,6 +19,7 @@
 
 @notCorner: if(@variationInputCorner, e(":not(.corner)"));
 @notAction: if(@variationInputAction, e(":not(.action)"));
+@notDisabled: if(@variationInputDisabled, e(":not(.disabled)"));
 
 @notBasic: if(@variationButtonBasic, e(":not(.basic)"));
 @notTertiary: if(@variationButtonTertiary, e(":not(.tertiary)"));

--- a/src/definitions/elements/input.less
+++ b/src/definitions/elements/input.less
@@ -17,6 +17,13 @@
 
 @import (multiple) "../../theme.config";
 
+@notCorner: if(@variationInputCorner, e(":not(.corner)"));
+@notAction: if(@variationInputAction, e(":not(.action)"));
+
+@notBasic: if(@variationButtonBasic, e(":not(.basic)"));
+@notTertiary: if(@variationButtonTertiary, e(":not(.tertiary)"));
+@notLink: if(@variationIconLink, e(":not(.link)"));
+
 /*******************************
            Standard
 *******************************/
@@ -83,12 +90,12 @@
     --------------------- */
 
     .ui.disabled.input,
-    .ui.input:not(.disabled) input[disabled] {
+    .ui.input@{notDisabled} input[disabled] {
         opacity: @disabledOpacity;
     }
 
     .ui.disabled.input > input,
-    .ui.input:not(.disabled) input[disabled] {
+    .ui.input@{notDisabled} input[disabled] {
         pointer-events: @disabledPointerEvents;
     }
 }
@@ -275,11 +282,11 @@
         border-radius: 0 @borderRadius @borderRadius 0;
         transition: @iconTransition;
     }
-    .ui.icon.input > i.icon:not(.link) {
+    .ui.icon.input > i.icon@{notLink} {
         pointer-events: none;
     }
-    .ui.ui.ui.ui.icon.input:not(.corner) > textarea,
-    .ui.ui.ui.ui.icon.input:not(.corner) > input {
+    .ui.ui.ui.ui.icon.input@{notCorner} > textarea,
+    .ui.ui.ui.ui.icon.input@{notCorner} > input {
         padding-right: @iconMargin;
     }
 
@@ -314,8 +321,8 @@
     .ui.ui.ui.ui[class*="left icon"]:not([class*="left corner"]).input > input {
         padding-left: @iconMargin;
     }
-    .ui.ui.ui.ui[class*="left icon"]:not(.corner).input > textarea,
-    .ui.ui.ui.ui[class*="left icon"]:not(.corner).input > input {
+    .ui.ui.ui.ui[class*="left icon"]@{notCorner}.input > textarea,
+    .ui.ui.ui.ui[class*="left icon"]@{notCorner}.input > input {
         padding-right: @horizontalPadding;
     }
 
@@ -338,7 +345,7 @@
         margin: 0;
         font-size: @relativeMedium;
     }
-    .ui.labeled.input > .label:not(.corner) {
+    .ui.labeled.input > .label@{notCorner} {
         padding-top: @verticalPadding;
         padding-bottom: @verticalPadding;
     }
@@ -639,7 +646,7 @@
     }
 
     .ui.form .field > input[type="file"],
-    .ui.file.input:not(.action) input[type="file"] {
+    .ui.file.input@{notAction} input[type="file"] {
         padding: 0;
     }
 
@@ -720,8 +727,8 @@
         position: absolute;
     }
 
-    input[type="file"].ui.file.input:focus + label.ui.button:not(.basic):not(.tertiary),
-    .ui.file.input input[type="file"]:focus + label.ui.button:not(.basic):not(.tertiary) {
+    input[type="file"].ui.file.input:focus + label.ui.button@{notBasic}@{notTertiary},
+    .ui.file.input input[type="file"]:focus + label.ui.button@{notBasic}@{notTertiary} {
         background: @fileButtonBackgroundHover;
         color: @hoveredTextColor;
         &.inverted {
@@ -736,8 +743,8 @@
             @h: @colors[@@color][hover];
             @lh: @colors[@@color][lightHover];
 
-            input[type="file"].ui.file.input:focus + label.ui.@{color}.button:not(.basic):not(.tertiary),
-            .ui.file.input input[type="file"]:focus + label.ui.@{color}.button:not(.basic):not(.tertiary) {
+            input[type="file"].ui.file.input:focus + label.ui.@{color}.button@{notBasic}@{notTertiary},
+            .ui.file.input input[type="file"]:focus + label.ui.@{color}.button@{notBasic}@{notTertiary} {
                 background-color: @h;
                 color: @white;
                 &.inverted when (@variationButtonInverted) {

--- a/src/definitions/elements/label.less
+++ b/src/definitions/elements/label.less
@@ -17,6 +17,12 @@
 
 @import (multiple) "../../theme.config";
 
+@notTag: if(@variationLabelTag, e(":not(.tag)"));
+@notImage: if(@variationLabelImage, e(":not(.image)"));
+@notRibbon: if(@variationLabelRibbon, e(":not(.ribbon)"));
+
+@notBasic: if(@variationSegmentBasic, e(":not(.basic)"));
+
 /*******************************
             Label
 *******************************/
@@ -164,19 +170,19 @@ a.ui.label {
     margin-bottom: @attachedSegmentPadding !important;
 }
 
-.ui.segment:not(.basic) > .ui.top.attached.label {
+.ui.segment@{notBasic} > .ui.top.attached.label {
     margin-top: @attachedOffset;
 }
-.ui.segment:not(.basic) > .ui.bottom.attached.label {
+.ui.segment@{notBasic} > .ui.bottom.attached.label {
     margin-bottom: @attachedOffset;
 }
-.ui.segment:not(.basic) > .ui.attached.label:not(.right) {
+.ui.segment@{notBasic} > .ui.attached.label:not(.right) {
     margin-left: @attachedOffset;
 }
-.ui.segment:not(.basic) > .ui.right.attached.label {
+.ui.segment@{notBasic} > .ui.right.attached.label {
     margin-right: @attachedOffset;
 }
-.ui.segment:not(.basic) > .ui.attached.label:not(.left):not(.right) {
+.ui.segment@{notBasic} > .ui.attached.label:not(.left):not(.right) {
     width: @attachedWidthOffset;
 }
 
@@ -196,7 +202,7 @@ a.ui.label {
         padding: @imageLabelPadding;
         border-radius: @imageLabelBorderRadius;
         box-shadow: @imageLabelBoxShadow;
-        &.attached:not(.basic) when (@variationLabelAttached) {
+        &.attached@{notBasic} when (@variationLabelAttached) {
             padding: @imageLabelPadding;
         }
     }
@@ -642,8 +648,8 @@ a.ui.active.label:hover::before {
         padding-bottom: @basicVerticalPadding;
         padding-right: @basicHorizontalPadding;
     }
-    .ui.basic.labels:not(.tag):not(.image):not(.ribbon) .label,
-    .ui.basic.label:not(.tag):not(.image):not(.ribbon) {
+    .ui.basic.labels@{notTag}@{notImage}@{notRibbon} .label,
+    .ui.basic.label@{notTag}@{notImage}@{notRibbon} {
         padding-left: @basicHorizontalPadding;
     }
     & when (@variationLabelImage) {

--- a/src/definitions/elements/list.less
+++ b/src/definitions/elements/list.less
@@ -17,6 +17,13 @@
 
 @import (multiple) "../../theme.config";
 
+@notSelection: if(@variationListSelection, e(":not(.selection)"));
+@notIcon: if(@variationListIcon, e(":not(.icon)"));
+@notHorizontal: if(@variationListHorizontal, e(":not(.horizontal)"));
+@notCelled: if(@variationListCelled, e(":not(.celled)"));
+
+@notLoading: if(@variationIconLoading, e(":not(.loading)"));
+
 /*******************************
             List
 *******************************/
@@ -87,7 +94,7 @@ ol.ui.list li:last-child,
 /* Child List */
 ul.ui.list ul,
 ol.ui.list ol,
-.ui.list .list:not(.icon) {
+.ui.list .list@{notIcon} {
     clear: both;
     margin: 0;
     padding: @childListPadding;
@@ -110,7 +117,7 @@ ol.ui.list ol li,
         margin: 0;
         padding-top: @iconOffset;
         transition: @iconTransition;
-        &:not(.loading) {
+        &@{notLoading} {
             padding-right: @iconDistance;
             vertical-align: @iconContentVerticalAlign;
         }
@@ -312,11 +319,11 @@ ol.ui.list ol li,
         margin-right: @horizontalSpacing;
         font-size: 1rem;
     }
-    .ui.horizontal.list:not(.celled) > .item:last-child {
+    .ui.horizontal.list@{notCelled} > .item:last-child {
         margin-right: 0;
         padding-right: 0;
     }
-    .ui.horizontal.list .list:not(.icon) {
+    .ui.horizontal.list .list@{notIcon} {
         padding-left: 0;
         padding-bottom: 0;
     }
@@ -585,7 +592,7 @@ ol.ui.list ol li,
     .ui.animated.list > .item {
         transition: @animatedListTransition;
     }
-    .ui.animated.list:not(.horizontal) > .item:hover {
+    .ui.animated.list@{notHorizontal} > .item:hover {
         padding-left: @animatedListIndent;
     }
 }
@@ -594,8 +601,8 @@ ol.ui.list ol li,
     /* -------------------
            Fitted
     -------------------- */
-    .ui.fitted.list:not(.selection) .list > .item,
-    .ui.fitted.list:not(.selection) > .item {
+    .ui.fitted.list@{notSelection} .list > .item,
+    .ui.fitted.list@{notSelection} > .item {
         padding-left: 0;
         padding-right: 0;
     }
@@ -643,7 +650,7 @@ ol.ui.list ol li,
     }
 
     ul.ui.list ul,
-    .ui.bulleted.list .list:not(.icon) {
+    .ui.bulleted.list .list@{notIcon} {
         padding-left: @bulletChildDistance;
     }
 
@@ -679,7 +686,7 @@ ol.ui.list ol li,
 
     ol.ui.list,
     .ui.ordered.list,
-    .ui.ordered.list .list:not(.icon),
+    .ui.ordered.list .list@{notIcon},
     ol.ui.list ol {
         counter-reset: @orderedCountName;
         margin-left: @orderedCountDistance;
@@ -727,7 +734,7 @@ ol.ui.list ol li,
 
     /* Child Lists */
     ol.ui.list ol,
-    .ui.ordered.list .list:not(.icon) {
+    .ui.ordered.list .list@{notIcon} {
         margin-left: @orderedChildCountDistance;
     }
     ol.ui.list ol li::before,
@@ -779,18 +786,18 @@ ol.ui.list ol li,
     }
 
     /* Sub Menu */
-    .ui.divided.list:not(.horizontal) .list > .item:first-child {
+    .ui.divided.list@{notHorizontal} .list > .item:first-child {
         border-top-width: @dividedBorderWidth;
     }
 
     & when (@variationListBulleted) {
         /* Divided bulleted */
-        .ui.divided.bulleted.list:not(.horizontal),
-        .ui.divided.bulleted.list .list:not(.icon) {
+        .ui.divided.bulleted.list@{notHorizontal},
+        .ui.divided.bulleted.list .list@{notIcon} {
             margin-left: 0;
             padding-left: 0;
         }
-        .ui.divided.bulleted.list > .item:not(.horizontal) {
+        .ui.divided.bulleted.list > .item@{notHorizontal} {
             padding-left: @bulletDistance;
         }
     }
@@ -804,7 +811,7 @@ ol.ui.list ol li,
         .ui.divided.ordered.list > .item {
             padding-left: @orderedCountDistance;
         }
-        .ui.divided.ordered.list .item .list:not(.icon) {
+        .ui.divided.ordered.list .item .list@{notIcon} {
             margin-left: 0;
             margin-right: 0;
             padding-bottom: @itemVerticalPadding;
@@ -896,7 +903,7 @@ ol.ui.list ol li,
         .ui.celled.bulleted.list > .item {
             padding-left: (@bulletDistance);
         }
-        .ui.celled.bulleted.list .item .list:not(.icon) {
+        .ui.celled.bulleted.list .item .list@{notIcon} {
             margin-left: -(@bulletDistance);
             margin-right: -(@bulletDistance);
             padding-bottom: @itemVerticalPadding;
@@ -912,7 +919,7 @@ ol.ui.list ol li,
         .ui.celled.ordered.list > .item {
             padding-left: @orderedCountDistance;
         }
-        .ui.celled.ordered.list .item .list:not(.icon) {
+        .ui.celled.ordered.list .item .list@{notIcon} {
             margin-left: 0;
             margin-right: 0;
             padding-bottom: @itemVerticalPadding;
@@ -961,10 +968,10 @@ ol.ui.list ol li,
            Relaxed
     -------------------- */
 
-    .ui.relaxed.list:not(.horizontal) > .item:not(:first-child) {
+    .ui.relaxed.list@{notHorizontal} > .item:not(:first-child) {
         padding-top: @relaxedItemVerticalPadding;
     }
-    .ui.relaxed.list:not(.horizontal) > .item:not(:last-child) {
+    .ui.relaxed.list@{notHorizontal} > .item:not(:last-child) {
         padding-bottom: @relaxedItemVerticalPadding;
     }
 
@@ -980,10 +987,10 @@ ol.ui.list ol li,
     }
     & when (@variationListVeryRelaxed) {
         /* Very Relaxed */
-        .ui[class*="very relaxed"].list:not(.horizontal) > .item:not(:first-child) {
+        .ui[class*="very relaxed"].list@{notHorizontal} > .item:not(:first-child) {
             padding-top: @veryRelaxedItemVerticalPadding;
         }
-        .ui[class*="very relaxed"].list:not(.horizontal) > .item:not(:last-child) {
+        .ui[class*="very relaxed"].list@{notHorizontal} > .item:not(:last-child) {
             padding-bottom: @veryRelaxedItemVerticalPadding;
         }
 

--- a/src/definitions/elements/loader.less
+++ b/src/definitions/elements/loader.less
@@ -17,6 +17,9 @@
 
 @import (multiple) "../../theme.config";
 
+@notElastic: if(@variationLoaderElastic, e(":not(.elastic)"));
+@notDouble: if(@variationLoaderDouble, e(":not(.double)"));
+
 /*******************************
             Loader
 *******************************/
@@ -97,7 +100,7 @@
 .ui.dimmer > .ui.loader {
     color: @invertedLoaderTextColor;
 }
-.ui.dimmer > .ui.loader:not(.elastic)::before {
+.ui.dimmer > .ui.loader@{notElastic}::before {
     border-color: @invertedLoaderFillColor;
 }
 
@@ -105,7 +108,7 @@
 .ui.inverted.dimmer > .ui.loader {
     color: @loaderTextColor;
 }
-.ui.inverted.dimmer > .ui.loader:not(.elastic)::before {
+.ui.inverted.dimmer > .ui.loader@{notElastic}::before {
     border-color: @loaderFillColor;
 }
 
@@ -246,8 +249,10 @@
 .ui.elastic.basic.loading.button::after {
     color: @loaderLineColor;
 }
-.ui.ui.ui.ui.double.loading.button::after {
-    border-bottom-color: currentColor;
+& when (@variationLoaderDouble) {
+    .ui.ui.ui.ui.double.loading.button::after {
+        border-bottom-color: currentColor;
+    }
 }
 
 & when (@variationLoaderInline) {
@@ -285,10 +290,10 @@
     border-left-color: transparent;
     border-right-color: transparent;
 }
-.ui.ui.ui.ui.ui.ui.ui.loading:not(.double)::after,
-.ui.ui.ui.ui.ui.ui.ui.loading:not(.double) .input > i.icon::after,
-.ui.ui.ui.ui.ui.ui.ui.loading:not(.double) > i.icon::after,
-.ui.ui.ui.ui.ui.ui.loader:not(.double)::after {
+.ui.ui.ui.ui.ui.ui.ui.loading@{notDouble}::after,
+.ui.ui.ui.ui.ui.ui.ui.loading@{notDouble} .input > i.icon::after,
+.ui.ui.ui.ui.ui.ui.ui.loading@{notDouble} > i.icon::after,
+.ui.ui.ui.ui.ui.ui.loader@{notDouble}::after {
     border-bottom-color: transparent;
 }
 .ui.ui.ui.ui.ui.ui.loading.card::after,
@@ -298,10 +303,10 @@
     border-left-color: @loaderFillColor;
     border-right-color: @loaderFillColor;
 }
-.ui.ui.ui.ui.ui.ui.loading.card:not(.double)::after,
-.ui.ui.ui.ui.ui.ui.loading.segments:not(.double)::after,
-.ui.ui.ui.ui.ui.ui.loading.segment:not(.double)::after,
-.ui.ui.ui.ui.ui.ui.loading.form:not(.double)::after {
+.ui.ui.ui.ui.ui.ui.loading.card@{notDouble}::after,
+.ui.ui.ui.ui.ui.ui.loading.segments@{notDouble}::after,
+.ui.ui.ui.ui.ui.ui.loading.segment@{notDouble}::after,
+.ui.ui.ui.ui.ui.ui.loading.form@{notDouble}::after {
     border-bottom-color: @loaderFillColor;
 }
 

--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -17,6 +17,11 @@
 
 @import (multiple) "../../theme.config";
 
+@notHorizontal: if(@variationSegmentHorizontal, e(":not(.horizontal)"));
+@notCompact: if(@variationSegmentCompact, e(":not(.compact)"));
+@notInverted: if(@variationSegmentInverted, e(":not(.inverted)"));
+@notBasic: if(@variationSegmentBasic, e(":not(.basic)"));
+
 /*******************************
             Segment
 *******************************/
@@ -413,7 +418,7 @@
         border-top: @groupedSegmentDivider;
     }
 
-    .ui.segments:not(.horizontal) > .segment:first-child {
+    .ui.segments@{notHorizontal} > .segment:first-child {
         top: @attachedTopOffset;
         bottom: 0;
         border-top: none;
@@ -423,7 +428,7 @@
     }
 
     /* Bottom */
-    .ui.segments:not(.horizontal) > .segment:last-child {
+    .ui.segments@{notHorizontal} > .segment:last-child {
         top: @attachedBottomOffset;
         bottom: 0;
         margin-top: 0;
@@ -433,7 +438,7 @@
     }
 
     /* Only */
-    .ui.segments:not(.horizontal) > .segment:only-child {
+    .ui.segments@{notHorizontal} > .segment:only-child {
         border-radius: @borderRadius;
     }
 
@@ -445,7 +450,7 @@
     .ui.segments > .segments:first-child {
         border-top: none;
     }
-    .ui.segments > .segment + .segments:not(.horizontal) {
+    .ui.segments > .segment + .segments@{notHorizontal} {
         margin-top: 0;
     }
 
@@ -477,7 +482,7 @@
         }
 
         /* Horizontal Segment */
-        .ui.horizontal.segments:not(.compact) > .segment:not(.compact) {
+        .ui.horizontal.segments@{notCompact} > .segment@{notCompact} {
             flex: 1 1 auto;
             & when (@supportIE) {
                 // https://github.com/Semantic-Org/Semantic-UI/issues/2550
@@ -616,7 +621,7 @@
         @color: @value;
         @c: @colors[@@color][color];
         & when not (@color=primary) and not (@color=secondary) {
-            .ui.ui.ui.ui.ui.@{color}.segment:not(.inverted) {
+            .ui.ui.ui.ui.ui.@{color}.segment@{notInverted} {
                 border-top: @coloredBorderSize solid @c;
             }
             & when (@variationSegmentInverted) {
@@ -755,7 +760,7 @@
         width: @attachedWidth;
         max-width: @attachedWidth;
         box-shadow: @attachedBoxShadow;
-        &:not(.basic) {
+        &@{notBasic} {
             border: @attachedBorder;
         }
     }

--- a/src/definitions/elements/step.less
+++ b/src/definitions/elements/step.less
@@ -21,9 +21,9 @@
 
 @import (multiple) "../../theme.config";
 
-@notCircular: if(@variationStepCircular, e("@{notCircular}"));
-@notVertical: if(@variationStepVertical, e("@{notVertical}"));
-@notUnstackable: if(@variationStepUnstackable, e("@{notUnstackable}"));
+@notCircular: if(@variationStepCircular, e(":not(.circular)"));
+@notVertical: if(@variationStepVertical, e(":not(.vertical)"));
+@notUnstackable: if(@variationStepUnstackable, e(":not(.unstackable)"));
 
 /*******************************
             Plural

--- a/src/definitions/elements/step.less
+++ b/src/definitions/elements/step.less
@@ -21,11 +21,15 @@
 
 @import (multiple) "../../theme.config";
 
+@notCircular: if(@variationStepCircular, e("@{notCircular}"));
+@notVertical: if(@variationStepVertical, e("@{notVertical}"));
+@notUnstackable: if(@variationStepUnstackable, e("@{notUnstackable}"));
+
 /*******************************
             Plural
 *******************************/
 
-.ui.steps:not(.circular) {
+.ui.steps@{notCircular} {
     display: inline-flex;
     flex-direction: row;
     align-items: stretch;
@@ -36,7 +40,7 @@
     border-radius: @stepsBorderRadius;
     border: @stepsBorder;
 }
-.ui.steps:not(.unstackable) {
+.ui.steps@{notUnstackable} {
     flex-wrap: wrap;
 }
 
@@ -54,7 +58,7 @@
            Singular
 *******************************/
 
-.ui.steps:not(.circular) .step {
+.ui.steps@{notCircular} .step {
     position: relative;
     display: flex;
     flex: 1 0 auto;
@@ -74,7 +78,7 @@
 }
 
 /* Arrow */
-.ui.steps:not(.circular) .step::after {
+.ui.steps@{notCircular} .step::after {
     display: none;
     position: absolute;
     z-index: 2;
@@ -92,20 +96,20 @@
 }
 
 /* First Step */
-.ui.steps:not(.circular) .step:first-child {
+.ui.steps@{notCircular} .step:first-child {
     padding-left: @horizontalPadding;
     border-radius: @stepsBorderRadius 0 0 @stepsBorderRadius;
 }
 
 /* Last Step */
-.ui.steps:not(.circular) .step:last-child {
+.ui.steps@{notCircular} .step:last-child {
     border-radius: 0 @stepsBorderRadius @stepsBorderRadius 0;
     border-right: none;
     margin-right: 0;
 }
 
 /* Only Step */
-.ui.steps:not(.circular) .step:only-child {
+.ui.steps@{notCircular} .step:only-child {
     border-radius: @stepsBorderRadius;
 }
 
@@ -152,7 +156,7 @@
 }
 
 /* Horizontal Icon */
-.ui.steps:not(.vertical) .step > i.icon {
+.ui.steps@{notVertical} .step > i.icon {
     width: auto;
 }
 
@@ -172,7 +176,7 @@
         border-radius: 0;
         box-shadow: none;
 
-        &:not(.vertical) {
+        &@{notVertical} {
             background: transparent;
             border: 0;
             border-radius: 0;
@@ -284,10 +288,10 @@
         }
     }
     @supports selector(:has(.f)) {
-        .ui.circular.steps:not(.vertical) .step:last-child:has(.content) {
+        .ui.circular.steps@{notVertical} .step:last-child:has(.content) {
             flex: 1;
         }
-        .ui.circular.steps:not(.vertical) .step:last-child:has(.center.aligned.content) {
+        .ui.circular.steps@{notVertical} .step:last-child:has(.center.aligned.content) {
             background: none;
         }
     }
@@ -309,7 +313,7 @@
         font-family: @orderedFontFamily;
         font-weight: @orderedFontWeight;
     }
-    .ui.ordered.steps:not(.circular) .step::before {
+    .ui.ordered.steps@{notCircular} .step::before {
         display: block;
         position: static;
         font-size: @iconSize;
@@ -344,51 +348,51 @@
         Vertical
     --------------- */
 
-    .ui.vertical.steps:not(.circular) {
+    .ui.vertical.steps@{notCircular} {
         display: inline-flex;
         flex-direction: column;
         overflow: visible;
     }
-    .ui.vertical.steps:not(.circular) .step {
+    .ui.vertical.steps@{notCircular} .step {
         justify-content: flex-start;
         border-radius: @borderRadius;
         padding: @verticalPadding @horizontalPadding;
         border-right: none;
         border-bottom: @verticalDivider;
     }
-    .ui.vertical.steps:not(.circular) .step:first-child {
+    .ui.vertical.steps@{notCircular} .step:first-child {
         padding: @verticalPadding @horizontalPadding;
         border-radius: @stepsBorderRadius @stepsBorderRadius 0 0;
     }
-    .ui.vertical.steps:not(.circular) .step:last-child {
+    .ui.vertical.steps@{notCircular} .step:last-child {
         border-bottom: none;
         border-radius: 0 0 @stepsBorderRadius @stepsBorderRadius;
     }
-    .ui.vertical.steps:not(.circular) .step:only-child {
+    .ui.vertical.steps@{notCircular} .step:only-child {
         border-radius: @stepsBorderRadius;
     }
 
     /* Arrow */
-    .ui.vertical.steps:not(.circular) .step::after {
+    .ui.vertical.steps@{notCircular} .step::after {
         top: @verticalArrowTopOffset;
         right: @verticalArrowRightOffset;
         border-width: @verticalArrowBorderWidth;
         display: @verticalArrowDisplay;
     }
-    .ui.right.vertical.steps:not(.circular) .step::after {
+    .ui.right.vertical.steps@{notCircular} .step::after {
         border-width: @verticalLeftArrowBorderWidth;
         left: @verticalLeftArrowLeftOffset;
         right: @verticalLeftArrowRightOffset;
         transform: translateY(-50%) translateX(-50%) rotate(-45deg);
     }
 
-    .ui.vertical.steps:not(.circular) .active.step::after {
+    .ui.vertical.steps@{notCircular} .active.step::after {
         display: @verticalActiveArrowDisplay;
     }
-    .ui.vertical.steps:not(.circular) .step:last-child::after {
+    .ui.vertical.steps@{notCircular} .step:last-child::after {
         display: @verticalLastArrowDisplay;
     }
-    .ui.vertical.steps:not(.circular) .active.step:last-child::after {
+    .ui.vertical.steps@{notCircular} .active.step:last-child::after {
         display: @verticalActiveLastArrowDisplay;
     }
 
@@ -452,12 +456,12 @@
 
 /* Mobile (Default) */
 @media only screen and (max-width: (@largestMobileScreen)) {
-    .ui.steps:not(.unstackable):not(.circular) {
+    .ui.steps@{notUnstackable}@{notCircular} {
         display: inline-flex;
         overflow: visible;
         flex-direction: column;
     }
-    .ui.steps:not(.unstackable):not(.circular) .step {
+    .ui.steps@{notUnstackable}@{notCircular} .step {
         width: 100% !important;
         flex-direction: column;
         border-radius: @borderRadius;
@@ -465,36 +469,36 @@
         border-right: none;
         border-bottom: @stepsBorder;
     }
-    .ui.steps:not(.unstackable):not(.circular) .step:first-child {
+    .ui.steps@{notUnstackable}@{notCircular} .step:first-child {
         padding: @verticalPadding @horizontalPadding;
         border-radius: @stepsBorderRadius @stepsBorderRadius 0 0;
     }
-    .ui.steps:not(.unstackable):not(.circular) .step:last-child {
+    .ui.steps@{notUnstackable}@{notCircular} .step:last-child {
         border-radius: 0 0 @stepsBorderRadius @stepsBorderRadius;
         border-bottom: none;
     }
 
     /* Arrow */
-    .ui.steps:not(.unstackable):not(.circular) .step::after {
+    .ui.steps@{notUnstackable}@{notCircular} .step::after {
         top: unset;
         bottom: -@arrowSize;
         right: 50%;
         transform: translateY(-50%) translateX(50%) rotate(45deg);
     }
     & when (@variationStepVertical) {
-        .ui.vertical.steps:not(.circular) .active.step:last-child::after {
+        .ui.vertical.steps@{notCircular} .active.step:last-child::after {
             display: none;
         }
     }
 
     /* Content */
-    .ui.steps:not(.unstackable):not(.circular) .step .content {
+    .ui.steps@{notUnstackable}@{notCircular} .step .content {
         text-align: center;
     }
 
     /* Icon */
-    .ui.steps:not(.unstackable):not(.circular) .step > i.icon,
-    .ui.ordered.steps:not(.unstackable):not(.circular) .step::before {
+    .ui.steps@{notUnstackable}@{notCircular} .step > i.icon,
+    .ui.ordered.steps@{notUnstackable}@{notCircular} .step::before {
         margin: 0 0 @mobileIconDistance 0;
     }
 }
@@ -504,32 +508,32 @@
 *******************************/
 
 /* Link Hover */
-.ui.steps:not(.circular) .link.step:hover::after,
-.ui.steps:not(.circular) .link.step:hover,
-.ui.steps:not(.circular) a.step:hover::after,
-.ui.steps:not(.circular) a.step:hover {
+.ui.steps@{notCircular} .link.step:hover::after,
+.ui.steps@{notCircular} .link.step:hover,
+.ui.steps@{notCircular} a.step:hover::after,
+.ui.steps@{notCircular} a.step:hover {
     background: @hoverBackground;
     color: @hoverColor;
 }
 
 /* Link Down */
-.ui.steps:not(.circular) .link.step:active::after,
-.ui.steps:not(.circular) .link.step:active,
-.ui.steps:not(.circular) a.step:active::after,
-.ui.steps:not(.circular) a.step:active {
+.ui.steps@{notCircular} .link.step:active::after,
+.ui.steps@{notCircular} .link.step:active,
+.ui.steps@{notCircular} a.step:active::after,
+.ui.steps@{notCircular} a.step:active {
     background: @downBackground;
     color: @downColor;
 }
 
 /* Active */
-.ui.steps:not(.circular) .step.active {
+.ui.steps@{notCircular} .step.active {
     cursor: auto;
     background: @activeBackground;
 }
-.ui.steps:not(.circular) .step.active::after {
+.ui.steps@{notCircular} .step.active::after {
     background: @activeBackground;
 }
-.ui.steps:not(.circular) .step.active .title {
+.ui.steps@{notCircular} .step.active .title {
     color: @activeColor;
 }
 .ui.ordered.steps .step.active::before,
@@ -538,24 +542,24 @@
 }
 
 /* Active Arrow */
-.ui.steps:not(.circular) .step::after {
+.ui.steps@{notCircular} .step::after {
     display: @arrowDisplay;
 }
-.ui.steps:not(.circular) .active.step::after {
+.ui.steps@{notCircular} .active.step::after {
     display: @activeArrowDisplay;
 }
-.ui.steps:not(.circular) .step:last-child::after {
+.ui.steps@{notCircular} .step:last-child::after {
     display: @lastArrowDisplay;
 }
-.ui.steps:not(.circular) .active.step:last-child::after {
+.ui.steps@{notCircular} .active.step:last-child::after {
     display: @activeLastArrowDisplay;
 }
 
 /* Active Hover */
-.ui.steps:not(.circular) .link.active.step:hover::after,
-.ui.steps:not(.circular) .link.active.step:hover,
-.ui.steps:not(.circular) a.active.step:hover::after,
-.ui.steps:not(.circular) a.active.step:hover {
+.ui.steps@{notCircular} .link.active.step:hover::after,
+.ui.steps@{notCircular} .link.active.step:hover,
+.ui.steps@{notCircular} a.active.step:hover::after,
+.ui.steps@{notCircular} a.active.step:hover {
     cursor: pointer;
     background: @activeHoverBackground;
     color: @activeHoverColor;
@@ -569,17 +573,17 @@
 
 & when (@variationStepDisabled) {
     /* Disabled */
-    .ui.steps:not(.circular) .disabled.step {
+    .ui.steps@{notCircular} .disabled.step {
         cursor: auto;
         background: @disabledBackground;
         pointer-events: none;
     }
-    .ui.steps:not(.circular) .disabled.step,
-    .ui.steps:not(.circular) .disabled.step .title,
-    .ui.steps:not(.circular) .disabled.step .description {
+    .ui.steps@{notCircular} .disabled.step,
+    .ui.steps@{notCircular} .disabled.step .title,
+    .ui.steps@{notCircular} .disabled.step .description {
         color: @disabledColor;
     }
-    .ui.steps:not(.circular) .disabled.step::after {
+    .ui.steps@{notCircular} .disabled.step::after {
         background: @disabledBackground;
     }
     & when (@variationStepCircular) {
@@ -606,31 +610,31 @@
 
     /* Tablet Or Below */
     @media only screen and (max-width: @largestTabletScreen) {
-        .ui[class*="tablet stackable"].steps:not(.circular) {
+        .ui[class*="tablet stackable"].steps@{notCircular} {
             display: inline-flex;
             overflow: visible;
             flex-direction: column;
         }
 
         /* Steps */
-        .ui[class*="tablet stackable"].steps:not(.circular) .step {
+        .ui[class*="tablet stackable"].steps@{notCircular} .step {
             flex-direction: column;
             border-radius: @borderRadius;
             padding: @verticalPadding @horizontalPadding;
             border-right: none;
             border-bottom: @stepsBorder;
         }
-        .ui[class*="tablet stackable"].steps:not(.circular) .step:first-child {
+        .ui[class*="tablet stackable"].steps@{notCircular} .step:first-child {
             padding: @verticalPadding @horizontalPadding;
             border-radius: @stepsBorderRadius @stepsBorderRadius 0 0;
         }
-        .ui[class*="tablet stackable"].steps:not(.circular) .step:last-child {
+        .ui[class*="tablet stackable"].steps@{notCircular} .step:last-child {
             border-radius: 0 0 @stepsBorderRadius @stepsBorderRadius;
             border-bottom: none;
         }
 
         /* Arrow */
-        .ui[class*="tablet stackable"].steps:not(.circular) .step::after {
+        .ui[class*="tablet stackable"].steps@{notCircular} .step::after {
             top: unset;
             bottom: -@arrowSize;
             right: 50%;
@@ -638,7 +642,7 @@
         }
 
         /* Content */
-        .ui[class*="tablet stackable"].steps:not(.circular) .step .content {
+        .ui[class*="tablet stackable"].steps@{notCircular} .step .content {
             text-align: center;
         }
 
@@ -668,28 +672,28 @@
     --------------- */
 
     /* Top */
-    .ui.attached.steps:not(.circular) {
+    .ui.attached.steps@{notCircular} {
         width: @attachedWidth !important;
         margin: 0 @attachedHorizontalOffset @attachedVerticalOffset;
         max-width: @attachedWidth;
         border-radius: @stepsBorderRadius @stepsBorderRadius 0 0;
     }
-    .ui.attached.steps:not(.circular) .step:first-child {
+    .ui.attached.steps@{notCircular} .step:first-child {
         border-radius: @stepsBorderRadius 0 0 0;
     }
-    .ui.attached.steps:not(.circular) .step:last-child {
+    .ui.attached.steps@{notCircular} .step:last-child {
         border-radius: 0 @stepsBorderRadius 0 0;
     }
 
     /* Bottom */
-    .ui.bottom.attached.steps:not(.circular) {
+    .ui.bottom.attached.steps@{notCircular} {
         margin: @attachedVerticalOffset @attachedHorizontalOffset 0;
         border-radius: 0 0 @stepsBorderRadius @stepsBorderRadius;
     }
-    .ui.bottom.attached.steps:not(.circular) .step:first-child {
+    .ui.bottom.attached.steps@{notCircular} .step:first-child {
         border-radius: 0 0 0 @stepsBorderRadius;
     }
-    .ui.bottom.attached.steps:not(.circular) .step:last-child {
+    .ui.bottom.attached.steps@{notCircular} .step:last-child {
         border-radius: 0 0 @stepsBorderRadius 0;
     }
 }
@@ -761,7 +765,7 @@
             font-size: @s;
         }
         & when (@variationStepCircular) {
-            .ui.@{value}.circular.steps:not(.vertical) {
+            .ui.@{value}.circular.steps@{notVertical} {
                 margin: @s 0;
                 padding: @s 0;
             }
@@ -774,17 +778,17 @@
         Inverted
     --------------- */
 
-    .ui.inverted.steps:not(.circular) {
+    .ui.inverted.steps@{notCircular} {
         border: 1px solid @solidWhiteBorderColor;
     }
 
-    .ui.inverted.steps:not(.circular) .step {
+    .ui.inverted.steps@{notCircular} .step {
         color: @invertedTextColor;
         background: @black;
         border-color: @solidWhiteBorderColor;
     }
 
-    .ui.inverted.steps:not(.circular) .step::after {
+    .ui.inverted.steps@{notCircular} .step::after {
         background-color: @black;
         border-color: @solidWhiteBorderColor;
     }
@@ -794,42 +798,42 @@
     }
 
     /* Active */
-    .ui.inverted.steps:not(.circular) .step.active,
-    .ui.inverted.steps:not(.circular) .step.active::after {
+    .ui.inverted.steps@{notCircular} .step.active,
+    .ui.inverted.steps@{notCircular} .step.active::after {
         background: @invertedActiveBackground;
     }
-    .ui.inverted.ordered.steps:not(.circular) .step.active::before,
-    .ui.inverted.steps:not(.circular) .active.step i.icon {
+    .ui.inverted.ordered.steps@{notCircular} .step.active::before,
+    .ui.inverted.steps@{notCircular} .active.step i.icon {
         color: @invertedSelectedTextColor;
     }
 
     & when (@variationStepDisabled) {
         /* Disabled */
-        .ui.inverted.steps:not(.circular) .disabled.step,
-        .ui.inverted.steps:not(.circular) .disabled.step::after {
+        .ui.inverted.steps@{notCircular} .disabled.step,
+        .ui.inverted.steps@{notCircular} .disabled.step::after {
             background: @invertedDisabledBackground;
         }
-        .ui.inverted.steps:not(.circular) .disabled.step,
-        .ui.inverted.steps:not(.circular) .disabled.step .title,
-        .ui.inverted.steps:not(.circular) .disabled.step .description {
+        .ui.inverted.steps@{notCircular} .disabled.step,
+        .ui.inverted.steps@{notCircular} .disabled.step .title,
+        .ui.inverted.steps@{notCircular} .disabled.step .description {
             color: @invertedDisabledTextColor;
         }
     }
 
     /* Link Hover */
-    .ui.inverted.steps:not(.circular) .link.step:hover::after,
-    .ui.inverted.steps:not(.circular) .link.step:hover,
-    .ui.inverted.steps:not(.circular) a.step:hover::after,
-    .ui.inverted.steps:not(.circular) a.step:hover {
+    .ui.inverted.steps@{notCircular} .link.step:hover::after,
+    .ui.inverted.steps@{notCircular} .link.step:hover,
+    .ui.inverted.steps@{notCircular} a.step:hover::after,
+    .ui.inverted.steps@{notCircular} a.step:hover {
         background: @invertedHoverBackground;
         color: @invertedHoveredTextColor;
     }
 
     /* Link Down */
-    .ui.inverted.steps:not(.circular) .link.step:active::after,
-    .ui.inverted.steps:not(.circular) .link.step:active,
-    .ui.inverted.steps:not(.circular) a.step:active::after,
-    .ui.inverted.steps:not(.circular) a.step:active {
+    .ui.inverted.steps@{notCircular} .link.step:active::after,
+    .ui.inverted.steps@{notCircular} .link.step:active,
+    .ui.inverted.steps@{notCircular} a.step:active::after,
+    .ui.inverted.steps@{notCircular} a.step:active {
         background: @invertedActiveHoverBackground;
         color: @invertedPressedTextColor;
     }
@@ -840,7 +844,7 @@
                 color: @invertedTextColor;
             }
 
-            &:not(.vertical) {
+            &@{notVertical} {
                 & .step:not(.completed) {
                     background: @invertedTextColor;
                 }
@@ -894,12 +898,12 @@
                 border-color: @color;
             }
         }
-        .ui.ui.@{variation}.circular.steps:not(.vertical) .step, .ui.ui.ui.circular.steps:not(.vertical) .step.@{variation} {
+        .ui.ui.@{variation}.circular.steps@{notVertical} .step, .ui.ui.ui.circular.steps@{notVertical} .step.@{variation} {
             &.completed {
                 background: @color;
             }
         }
-        .ui.ui.circular.steps:not(.vertical) .step.@{variation} {
+        .ui.ui.circular.steps@{notVertical} .step.@{variation} {
             background: @color;
         }
         .ui.ui.@{variation}.circular.steps .step, .ui.ui.ui.circular.steps .step.@{variation} {

--- a/src/definitions/modules/accordion.less
+++ b/src/definitions/modules/accordion.less
@@ -17,6 +17,8 @@
 
 @import (multiple) "../../theme.config";
 
+@notStyled: if(@variationAccordionStyled, e(":not(.styled)"));
+
 /*******************************
             Accordion
 *******************************/
@@ -44,12 +46,12 @@
 }
 
 /* Default Styling */
-.ui.accordion:not(.styled) .title ~ .content,
-.ui.accordion:not(.styled) .accordion .title ~ .content {
+.ui.accordion@{notStyled} .title ~ .content,
+.ui.accordion@{notStyled} .accordion .title ~ .content {
     margin: @contentMargin;
     padding: @contentPadding;
 }
-.ui.accordion:not(.styled) .title ~ .content:last-child {
+.ui.accordion@{notStyled} .title ~ .content:last-child {
     padding-bottom: 0;
 }
 
@@ -183,13 +185,13 @@
 
     /* Default Styling */
 
-    .ui.compact.accordion:not(.styled) > .title,
-    .ui.compact.accordion:not(.styled) .accordion > .title {
+    .ui.compact.accordion@{notStyled} > .title,
+    .ui.compact.accordion@{notStyled} .accordion > .title {
         padding: @titlePaddingCompact;
     }
 
-    .ui.compact.accordion:not(.styled) .title ~ .content,
-    .ui.compact.accordion:not(.styled) .accordion .title ~ .content {
+    .ui.compact.accordion@{notStyled} .title ~ .content,
+    .ui.compact.accordion@{notStyled} .accordion .title ~ .content {
         padding: @contentPaddingCompact;
     }
 
@@ -211,13 +213,13 @@
   --------------- */
 
 & when (@variationAccordionVeryCompact) {
-    .ui[class*="very compact"].accordion:not(.styled) > .title,
-    .ui[class*="very compact"].accordion:not(.styled) .accordion > .title {
+    .ui[class*="very compact"].accordion@{notStyled} > .title,
+    .ui[class*="very compact"].accordion@{notStyled} .accordion > .title {
         padding: @titlePaddingVeryCompact;
     }
 
-    .ui[class*="very compact"].accordion:not(.styled) .title ~ .content,
-    .ui[class*="very compact"].accordion:not(.styled) .accordion .title ~ .content {
+    .ui[class*="very compact"].accordion@{notStyled} .title ~ .content,
+    .ui[class*="very compact"].accordion@{notStyled} .accordion .title ~ .content {
         padding: @contentPaddingVeryCompact;
     }
 
@@ -351,8 +353,8 @@
 }
 
 & when (@variationAccordionTree) {
-    .ui.tree.accordion:not(.styled) .title ~ .content,
-    .ui.tree.accordion:not(.styled) .accordion .title ~ .content {
+    .ui.tree.accordion@{notStyled} .title ~ .content,
+    .ui.tree.accordion@{notStyled} .accordion .title ~ .content {
         padding: @treeContentPadding;
     }
     .ui.tree.accordion > .content,

--- a/src/definitions/modules/calendar.less
+++ b/src/definitions/modules/calendar.less
@@ -17,6 +17,8 @@
 
 @import (multiple) "../../theme.config";
 
+@notDisabled: if(@variationCalendarDisabled, e(":not(.disabled)"));
+
 /*******************************
             Popup
 *******************************/
@@ -150,8 +152,8 @@
     box-shadow: @rangeBoxShadow;
 }
 
-.ui.calendar:not(.disabled):focus .ui.table tbody tr td.focus,
-.ui.calendar:not(.disabled).popup.active .ui.table tbody tr td.focus {
+.ui.calendar@{notDisabled}:focus .ui.table tbody tr td.focus,
+.ui.calendar@{notDisabled}.popup.active .ui.table tbody tr td.focus {
     box-shadow: @focusBoxShadow;
 }
 
@@ -162,8 +164,8 @@
         box-shadow: @rangeInvertedBoxShadow;
     }
 
-    .ui.inverted.calendar:not(.disabled) .calendar:focus .ui.table.inverted tbody tr td.focus,
-    .ui.inverted.calendar:not(.disabled).popup.active .ui.table.inverted tbody tr td.focus {
+    .ui.inverted.calendar@{notDisabled} .calendar:focus .ui.table.inverted tbody tr td.focus,
+    .ui.inverted.calendar@{notDisabled}.popup.active .ui.table.inverted tbody tr td.focus {
         box-shadow: @focusInvertedBoxShadow;
     }
     .ui.inverted.calendar .ui.ui.ui.inverted.table tr .disabled {

--- a/src/definitions/modules/checkbox.less
+++ b/src/definitions/modules/checkbox.less
@@ -22,7 +22,6 @@
 @notRadio: if(@variationCheckboxRadio, e(":not(.radio)"));
 @notInvisible: if(@variationCheckboxInvisible, e(":not(.invisible)"));
 
-
 /*******************************
            Checkbox
 *******************************/

--- a/src/definitions/modules/checkbox.less
+++ b/src/definitions/modules/checkbox.less
@@ -17,6 +17,12 @@
 
 @import (multiple) "../../theme.config";
 
+@notToggle: if(@variationCheckboxToggle, e(":not(.toggle)"));
+@notSlider: if(@variationCheckboxSlider, e(":not(.slider)"));
+@notRadio: if(@variationCheckboxRadio, e(":not(.radio)"));
+@notInvisible: if(@variationCheckboxInvisible, e(":not(.invisible)"));
+
+
 /*******************************
            Checkbox
 *******************************/
@@ -60,7 +66,7 @@
     font-size: @labelFontSize;
 }
 
-.ui.checkbox:not(.invisible) label {
+.ui.checkbox@{notInvisible} label {
     padding-left: @labelDistance;
 }
 
@@ -133,8 +139,8 @@
     background: @checkboxHoverBackground;
     border-color: @checkboxHoverBorderColor;
 }
-.ui.checkbox:not(.invisible) label:hover,
-.ui.checkbox:not(.invisible) + label:hover {
+.ui.checkbox@{notInvisible} label:hover,
+.ui.checkbox@{notInvisible} + label:hover {
     color: @labelHoverColor;
 }
 
@@ -149,7 +155,7 @@
 .ui.checkbox label:active::after {
     color: @checkboxPressedColor;
 }
-.ui.checkbox:not(.invisible) input:active ~ label {
+.ui.checkbox@{notInvisible} input:active ~ label {
     color: @labelPressedColor;
 }
 
@@ -164,7 +170,7 @@
 .ui.checkbox input:focus ~ label::after {
     color: @checkboxFocusCheckColor;
 }
-.ui.checkbox:not(.invisible) input:focus ~ label {
+.ui.checkbox@{notInvisible} input:focus ~ label {
     color: @labelFocusColor;
 }
 
@@ -726,7 +732,7 @@
         & when (@@raw > 1) {
             .ui.@{value}.form .checkbox,
             .ui.@{value}.checkbox {
-                &:not(.slider):not(.toggle):not(.radio) {
+                &@{notSlider}@{notToggle}@{notRadio} {
                     &
                     label::after,
                     label::before {

--- a/src/definitions/modules/checkbox.less
+++ b/src/definitions/modules/checkbox.less
@@ -21,6 +21,7 @@
 @notSlider: if(@variationCheckboxSlider, e(":not(.slider)"));
 @notRadio: if(@variationCheckboxRadio, e(":not(.radio)"));
 @notInvisible: if(@variationCheckboxInvisible, e(":not(.invisible)"));
+@notCompact: if(@variationCheckboxCompact, e(":not(.compact)"));
 
 /*******************************
            Checkbox

--- a/src/definitions/modules/dimmer.less
+++ b/src/definitions/modules/dimmer.less
@@ -17,6 +17,9 @@
 
 @import (multiple) "../../theme.config";
 
+@notInverted: if(@variationDimmerInverted, e(":not(.inverted)"));
+@notPage: if(@variationDimmerPage, e(":not(.page)"));
+
 /*******************************
             Dimmer
 *******************************/
@@ -56,26 +59,26 @@
 }
 
 /* Loose Coupling */
-.ui.segment > .ui.dimmer:not(.page) {
+.ui.segment > .ui.dimmer:@{notPage} {
     border-radius: inherit;
 }
 
 /* Scrollbars */
 & when (@useCustomScrollbars) {
-    .ui.dimmer:not(.inverted)::-webkit-scrollbar-track {
+    .ui.dimmer:@{notInverted}::-webkit-scrollbar-track {
         background: @trackInvertedBackground;
     }
-    .ui.dimmer:not(.inverted)::-webkit-scrollbar-thumb {
+    .ui.dimmer:@{notInverted}::-webkit-scrollbar-thumb {
         background: @thumbInvertedBackground;
     }
-    .ui.dimmer:not(.inverted)::-webkit-scrollbar-thumb:window-inactive {
+    .ui.dimmer:@{notInverted}::-webkit-scrollbar-thumb:window-inactive {
         background: @thumbInvertedInactiveBackground;
     }
-    .ui.dimmer:not(.inverted)::-webkit-scrollbar-thumb:hover {
+    .ui.dimmer:@{notInverted}::-webkit-scrollbar-thumb:hover {
         background: @thumbInvertedHoverBackground;
     }
     & when (@supportIE) {
-        .ui.dimmer:not(.inverted) {
+        .ui.dimmer:@{notInverted} {
             /* IE11 */
             scrollbar-face-color: @thumbInvertedBackgroundHex;
             scrollbar-shadow-color: @thumbInvertedBackgroundHex;
@@ -84,7 +87,7 @@
         }
     }
     @supports (-moz-appearance: none) {
-        .ui.dimmer:not(.inverted) {
+        .ui.dimmer:@{notInverted} {
             /* firefox: first color thumb, second track */
             scrollbar-color: @thumbInvertedBackground @trackInvertedBackground;
         }

--- a/src/definitions/modules/dimmer.less
+++ b/src/definitions/modules/dimmer.less
@@ -59,26 +59,26 @@
 }
 
 /* Loose Coupling */
-.ui.segment > .ui.dimmer:@{notPage} {
+.ui.segment > .ui.dimmer@{notPage} {
     border-radius: inherit;
 }
 
 /* Scrollbars */
 & when (@useCustomScrollbars) {
-    .ui.dimmer:@{notInverted}::-webkit-scrollbar-track {
+    .ui.dimmer@{notInverted}::-webkit-scrollbar-track {
         background: @trackInvertedBackground;
     }
-    .ui.dimmer:@{notInverted}::-webkit-scrollbar-thumb {
+    .ui.dimmer@{notInverted}::-webkit-scrollbar-thumb {
         background: @thumbInvertedBackground;
     }
-    .ui.dimmer:@{notInverted}::-webkit-scrollbar-thumb:window-inactive {
+    .ui.dimmer@{notInverted}::-webkit-scrollbar-thumb:window-inactive {
         background: @thumbInvertedInactiveBackground;
     }
-    .ui.dimmer:@{notInverted}::-webkit-scrollbar-thumb:hover {
+    .ui.dimmer@{notInverted}::-webkit-scrollbar-thumb:hover {
         background: @thumbInvertedHoverBackground;
     }
     & when (@supportIE) {
-        .ui.dimmer:@{notInverted} {
+        .ui.dimmer@{notInverted} {
             /* IE11 */
             scrollbar-face-color: @thumbInvertedBackgroundHex;
             scrollbar-shadow-color: @thumbInvertedBackgroundHex;
@@ -87,7 +87,7 @@
         }
     }
     @supports (-moz-appearance: none) {
-        .ui.dimmer:@{notInverted} {
+        .ui.dimmer@{notInverted} {
             /* firefox: first color thumb, second track */
             scrollbar-color: @thumbInvertedBackground @trackInvertedBackground;
         }

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -26,6 +26,7 @@
 @notSelection: if(@variationDropdownSelection, e(":not(.selection)"));
 @notButton: if(@variationDropdownButton, e(":not(.button)"));
 @notSimple: if(@variationDropdownSimple, e(":not(.simple)"));
+@notUpward: if(@variationDropdownUpward, e(":not(.upward)"));
 
 @notTransparent: if(@variationInputTransparent, e(":not(.transparent)"));
 @notVertical: if(@variationMenuVertical, e(":not(.vertical)"));

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -17,6 +17,22 @@
 
 @import (multiple) "../../theme.config";
 
+@notPointing: if(@variationDropdownPointing, e(":not(.pointing)"));
+@notFloating: if(@variationDropdownFloating, e(":not(.floating)"));
+@notLabeled: if(@variationDropdownLabel, e(":not(.labeled)"));
+@notSearch: if(@variationDropdownSearch, e(":not(.search)"));
+@notUnlimited: if(@variationDropdownUnlimited, e(":not(.unlimited)"));
+@notMultiple: if(@variationDropdownMultiple, e(":not(.multiple)"));
+@notSelection: if(@variationDropdownSelection, e(":not(.selection)"));
+@notButton: if(@variationDropdownButton, e(":not(.button)"));
+@notSimple: if(@variationDropdownSimple, e(":not(.simple)"));
+
+@notTransparent: if(@variationInputTransparent, e(":not(.transparent)"));
+@notVertical: if(@variationMenuVertical, e(":not(.vertical)"));
+@notImage: if(@variationLabelImage, e(":not(.image)"));
+@notCentered: if(@variationImageCentered, e(":not(.centered)"));
+@notAvatar: if(@variationImageAvatar, e(":not(.avatar)"));
+
 /*******************************
             Dropdown
 *******************************/
@@ -69,7 +85,7 @@
   Hidden Input
 --------------- */
 
-.ui.dropdown > input:not(.search):first-child,
+.ui.dropdown > input@{notSearch}:first-child,
 .ui.dropdown > select {
     display: none !important;
 }
@@ -78,7 +94,7 @@
  Dropdown Icon
 --------------- */
 
-.ui.dropdown:not(.labeled) > .dropdown.icon {
+.ui.dropdown@{notLabeled} > .dropdown.icon {
     position: relative;
     width: auto;
     min-width: @dropdownIconMinWidth;
@@ -190,12 +206,12 @@
 .ui.dropdown .menu > .header + .input {
     margin-top: 0;
 }
-.ui.dropdown .menu > .input:not(.transparent) input {
+.ui.dropdown .menu > .input@{notTransparent} input {
     padding: @menuInputPadding;
 }
-.ui.dropdown .menu > .input:not(.transparent) .button,
-.ui.dropdown .menu > .input:not(.transparent) i.icon,
-.ui.dropdown .menu > .input:not(.transparent) .label {
+.ui.dropdown .menu > .input@{notTransparent} .button,
+.ui.dropdown .menu > .input@{notTransparent} i.icon,
+.ui.dropdown .menu > .input@{notTransparent} .label {
     padding-top: @menuInputVerticalPadding;
     padding-bottom: @menuInputVerticalPadding;
 }
@@ -358,10 +374,10 @@
     .ui.dropdown.button .menu {
         min-width: 100%;
     }
-    .ui.dropdown.button:not(.pointing):not(.floating).active {
+    .ui.dropdown.button@{notPointing}@{notFloating}.active {
         border-radius: @borderRadius @borderRadius 0 0;
     }
-    .ui.dropdown.button:not(.pointing):not(.floating) > .menu {
+    .ui.dropdown.button@{notPointing}@{notFloating} > .menu {
         border-radius: 0 0 @borderRadius @borderRadius;
     }
 }
@@ -435,7 +451,7 @@ select.ui.dropdown {
     }
 
     /* Selection Menu */
-    .ui.selection.dropdown:not(.unlimited) .menu {
+    .ui.selection.dropdown@{notUnlimited} .menu {
         overflow-x: hidden;
         overflow-y: auto;
         overscroll-behavior: @overscrollBehavior;
@@ -449,7 +465,7 @@ select.ui.dropdown {
         box-shadow: @selectionMenuBoxShadow;
         transition: @selectionMenuTransition;
     }
-    .ui.selection.dropdown:not(.pointing):not(.floating) .menu {
+    .ui.selection.dropdown@{notPointing}@{notFloating} .menu {
         border-top-width: 0;
         border-radius: @selectionMenuBorderRadius;
     }
@@ -475,7 +491,7 @@ select.ui.dropdown {
                 max-height: @selectionMobileMaxMenuHeight * 0.5;
             }
         }
-        .ui.selection.dropdown:not(.unlimited) .menu {
+        .ui.selection.dropdown@{notUnlimited} .menu {
             max-height: @selectionMobileMaxMenuHeight;
         }
         & when (@variationDropdownLong) {
@@ -496,7 +512,7 @@ select.ui.dropdown {
                 max-height: @selectionTabletMaxMenuHeight * 0.5;
             }
         }
-        .ui.selection.dropdown:not(.unlimited) .menu {
+        .ui.selection.dropdown@{notUnlimited} .menu {
             max-height: @selectionTabletMaxMenuHeight;
         }
         & when (@variationDropdownLong) {
@@ -517,7 +533,7 @@ select.ui.dropdown {
                 max-height: @selectionComputerMaxMenuHeight * 0.5;
             }
         }
-        .ui.selection.dropdown:not(.unlimited) .menu {
+        .ui.selection.dropdown@{notUnlimited} .menu {
             max-height: @selectionComputerMaxMenuHeight;
         }
         & when (@variationDropdownLong) {
@@ -538,7 +554,7 @@ select.ui.dropdown {
                 max-height: @selectionWidescreenMaxMenuHeight * 0.5;
             }
         }
-        .ui.selection.dropdown:not(.unlimited) .menu {
+        .ui.selection.dropdown@{notUnlimited} .menu {
             max-height: @selectionWidescreenMaxMenuHeight;
         }
         & when (@variationDropdownLong) {
@@ -631,7 +647,7 @@ select.ui.dropdown {
     }
 
     /* Connecting Border */
-    .ui.active.selection.dropdown:not(.pointing):not(.floating) {
+    .ui.active.selection.dropdown@{notPointing}@{notFloating} {
         border-bottom-left-radius: @selectionVisibleConnectingBorder !important;
         border-bottom-right-radius: @selectionVisibleConnectingBorder !important;
     }
@@ -759,29 +775,29 @@ select.ui.dropdown {
     }
 
     /* Search Menu */
-    .ui.search.dropdown:not(.unlimited) .menu {
+    .ui.search.dropdown@{notUnlimited} .menu {
         overflow-x: hidden;
         overflow-y: auto;
         overscroll-behavior: @overscrollBehavior;
         backface-visibility: hidden;
     }
     @media only screen and (max-width: @largestMobileScreen) {
-        .ui.search.dropdown:not(.unlimited) .menu {
+        .ui.search.dropdown@{notUnlimited} .menu {
             max-height: @searchMobileMaxMenuHeight;
         }
     }
     @media only screen and (min-width: @tabletBreakpoint) {
-        .ui.search.dropdown:not(.unlimited) .menu {
+        .ui.search.dropdown@{notUnlimited} .menu {
             max-height: @searchTabletMaxMenuHeight;
         }
     }
     @media only screen and (min-width: @computerBreakpoint) {
-        .ui.search.dropdown:not(.unlimited) .menu {
+        .ui.search.dropdown@{notUnlimited} .menu {
             max-height: @searchComputerMaxMenuHeight;
         }
     }
     @media only screen and (min-width: @widescreenMonitorBreakpoint) {
-        .ui.search.dropdown:not(.unlimited) .menu {
+        .ui.search.dropdown@{notUnlimited} .menu {
             max-height: @searchWidescreenMaxMenuHeight;
         }
     }
@@ -812,21 +828,21 @@ select.ui.dropdown {
     }
 
     .ui.clearable.dropdown .text:not(.default),
-    .ui.clearable.dropdown:not(.search) > .ui.label:last-of-type {
+    .ui.clearable.dropdown@{notSearch} > .ui.label:last-of-type {
         margin-right: @clearableTextMargin;
     }
 
     .ui.dropdown select.noselection ~ .remove.icon,
     .ui.dropdown input[value=""] ~ .remove.icon,
-    .ui.dropdown input:not([value]):not(.search) ~ .remove.icon,
+    .ui.dropdown input:not([value])@{notSearch} ~ .remove.icon,
     .ui.dropdown.loading > .remove.icon {
         display: none;
     }
 
-    .ui.dropdown:not(.selection) > .remove.icon ~ .dropdown.icon {
+    .ui.dropdown@{notSelection} > .remove.icon ~ .dropdown.icon {
         margin-left: @clearableIconMargin;
     }
-    .ui.dropdown:not(.selection):not(.multiple) > .remove.icon {
+    .ui.dropdown@{notSelection}@{notMultiple} > .remove.icon {
         margin-top: -@clearableIconMarginTop;
     }
 }
@@ -879,24 +895,24 @@ select.ui.dropdown {
     .ui.multiple.dropdown > .label ~ .text {
         display: none;
     }
-    .ui.multiple.dropdown > .label:not(.image) > img:not(.centered) {
+    .ui.multiple.dropdown > .label@{notImage} > img@{notCentered} {
         margin-right: @itemElementDistance;
     }
-    .ui.multiple.dropdown > .label:not(.image) > img.ui:not(.avatar) {
+    .ui.multiple.dropdown > .label@{notImage} > img.ui@{notAvatar} {
         margin-bottom: @itemElementBottomDistance;
     }
     .ui.multiple.dropdown > .image.label img {
         margin: @imageLabelImageMargin;
         height: @imageLabelHeight;
     }
-    .ui.multiple.dropdown:not(.selection):not(.labeled) {
+    .ui.multiple.dropdown@{notSelection}@{notLabeled} {
         & > .dropdown.icon {
             right: @dropdownIconMultipleRight;
         }
         & > .remove.icon {
             margin-right: @dropdownIconMultipleRight;
         }
-        &:not(.search) > .remove.icon ~ .text.default,
+        &@{notSearch} > .remove.icon ~ .text.default,
         > .text.default:first-child {
             overflow: inherit;
         }
@@ -947,8 +963,8 @@ select.ui.dropdown {
         .ui.multiple.search.dropdown > span.sizer {
             display: none;
         }
-        .ui.multiple.search.dropdown:not(.selection) > .remove.icon + input.search,
-        .ui.multiple.search.dropdown:not(.selection) > input.search:first-child {
+        .ui.multiple.search.dropdown@{notSelection} > .remove.icon + input.search,
+        .ui.multiple.search.dropdown@{notSelection} > input.search:first-child {
             min-width: @multipleSearchMinWidth;
         }
     }
@@ -1010,12 +1026,12 @@ select.ui.dropdown {
      Default Text
 ---------------------- */
 
-.ui.dropdown:not(.button) > .default.text,
-.ui.default.dropdown:not(.button) > .text {
+.ui.dropdown@{notButton} > .default.text,
+.ui.default.dropdown@{notButton} > .text {
     color: @defaultTextColor;
 }
-.ui.dropdown:not(.button) > input:focus ~ .default.text,
-.ui.default.dropdown:not(.button) > input:focus ~ .text {
+.ui.dropdown@{notButton} > input:focus ~ .default.text,
+.ui.default.dropdown@{notButton} > input:focus ~ .text {
     color: @defaultTextFocusColor;
 }
 
@@ -1286,17 +1302,17 @@ select.ui.dropdown {
 
     & when (@variationDropdownButton) {
         /* Button */
-        .ui.upward.dropdown.button:not(.pointing):not(.floating).active {
+        .ui.upward.dropdown.button@{notPointing}@{notFloating}.active {
             border-radius: 0 0 @borderRadius @borderRadius;
         }
-        .ui.upward.dropdown.button:not(.pointing):not(.floating) > .menu {
+        .ui.upward.dropdown.button@{notPointing}@{notFloating} > .menu {
             border-radius: @borderRadius @borderRadius 0 0;
         }
     }
 
     & when (@variationDropdownSelection) {
         /* Selection */
-        .ui.ui.upward.selection.dropdown:not(.pointing):not(.floating) .menu {
+        .ui.ui.upward.selection.dropdown@{notPointing}@{notFloating} .menu {
             border-top-width: @menuBorderWidth;
             border-bottom-width: 0;
             box-shadow: @upwardSelectionMenuBoxShadow;
@@ -1307,14 +1323,14 @@ select.ui.dropdown {
         }
 
         /* Active Upward */
-        .ui.active.upward.selection.dropdown:not(.pointing):not(.floating) {
+        .ui.active.upward.selection.dropdown@{notPointing}@{notFloating} {
             border-radius: @upwardSelectionVisibleBorderRadius !important;
         }
 
         /* Visible Upward */
         .ui.upward.selection.dropdown.visible {
             box-shadow: @upwardSelectionVisibleBoxShadow;
-            &:not(.pointing):not(.floating) {
+            &@{notPointing}@{notFloating} {
                 border-radius: @upwardSelectionVisibleBorderRadius !important;
             }
         }
@@ -1323,7 +1339,7 @@ select.ui.dropdown {
         .ui.upward.active.selection.dropdown:hover {
             box-shadow: @upwardSelectionActiveHoverBoxShadow;
         }
-        .ui.upward.active.selection.dropdown:hover:not(.pointing):not(.floating) .menu {
+        .ui.upward.active.selection.dropdown:hover@{notPointing}@{notFloating} .menu {
             box-shadow: @upwardSelectionActiveHoverMenuBoxShadow;
         }
     }
@@ -1511,7 +1527,7 @@ select.ui.dropdown {
         .ui.simple.selection.dropdown .upward.menu {
             margin-bottom: @simpleUpwardSelectionMenuMargin;
         }
-        .ui.menu:not(.vertical) .ui.simple.dropdown.item .upward.menu {
+        .ui.menu@{notVertical} .ui.simple.dropdown.item .upward.menu {
             margin-bottom: @simpleUpwardItemMenuMargin;
         }
     }
@@ -1605,10 +1621,10 @@ select.ui.dropdown {
         box-shadow: @floatingMenuBoxShadow !important;
         border-radius: @floatingMenuBorderRadius !important;
     }
-    .ui:not(.upward).floating.dropdown > .menu {
+    .ui@{notUpward}.floating.dropdown > .menu {
         margin-top: @floatingMenuDistance;
     }
-    .ui.upward.floating.dropdown:not(.simple) > .menu {
+    .ui.upward.floating.dropdown@{notSimple} > .menu {
         margin-bottom: @floatingMenuDistance;
     }
 }
@@ -1639,11 +1655,11 @@ select.ui.dropdown {
     }
 
     @supports selector(:has(.f)) {
-        .ui.pointing.dropdown:not(.upward) .menu:has(:first-child:hover)::after,
+        .ui.pointing.dropdown@{notUpward} .menu:has(:first-child:hover)::after,
         .ui.upward.pointing.dropdown .menu:has(:last-child:hover)::after {
             background: @hoveredItemBackground;
         }
-        .ui.pointing.dropdown:not(.upward) .menu:has(.selected.item:first-child)::after,
+        .ui.pointing.dropdown@{notUpward} .menu:has(.selected.item:first-child)::after,
         .ui.upward.pointing.dropdown .menu:has(.selected.item:last-child)::after {
             background: @selectedBackground;
         }
@@ -1965,12 +1981,12 @@ select.ui.dropdown {
         }
     }
 
-    .ui.inverted.dropdown:not(.button) > .default.text,
-    .ui.inverted.default.dropdown:not(.button) > .text {
+    .ui.inverted.dropdown@{notButton} > .default.text,
+    .ui.inverted.default.dropdown@{notButton} > .text {
         color: @invertedDefaultTextColor;
     }
-    .ui.inverted.dropdown:not(.button) > input:focus ~ .default.text,
-    .ui.inverted.default.dropdown:not(.button) > input:focus ~ .text {
+    .ui.inverted.dropdown@{notButton} > input:focus ~ .default.text,
+    .ui.inverted.default.dropdown@{notButton} > input:focus ~ .text {
         color: @invertedDefaultTextFocusColor;
     }
 
@@ -2075,11 +2091,11 @@ select.ui.dropdown {
             }
         }
         @supports selector(:has(.f)) {
-            .ui.inverted.pointing.dropdown:not(.upward) .menu:has(:first-child:hover)::after,
+            .ui.inverted.pointing.dropdown@{notUpward} .menu:has(:first-child:hover)::after,
             .ui.inverted.upward.pointing.dropdown .menu:has(:last-child:hover)::after {
                 background: @invertedHoveredItemBackground;
             }
-            .ui.inverted.pointing.dropdown:not(.upward) .menu:has(.selected.item:first-child)::after,
+            .ui.inverted.pointing.dropdown@{notUpward} .menu:has(.selected.item:first-child)::after,
             .ui.inverted.upward.pointing.dropdown .menu:has(.selected.item:last-child)::after {
                 background: @invertedSelectedBackground;
             }

--- a/src/definitions/modules/flyout.less
+++ b/src/definitions/modules/flyout.less
@@ -17,6 +17,10 @@
 
 @import (multiple) "../../theme.config";
 
+@notFullscreen: if(@variationFlyoutFullscreen, e(":not(.fullscreen)"));
+
+@notFluid: if(@variationButtonFluid, e(":not(.fluid)"));
+
 /*******************************
              Flyout
 *******************************/
@@ -134,7 +138,7 @@
         border-top: @actionBorder;
         text-align: @actionAlign;
     }
-    .ui.flyout .actions > .button:not(.fluid) {
+    .ui.flyout .actions > .button@{notFluid} {
         margin-left: @buttonDistance;
     }
     & when (@variationFlyoutBasic) {
@@ -145,7 +149,7 @@
     & when (@variationFlyoutLeftActions) {
         .ui.flyout > .left.actions {
             text-align: left;
-            & > .button:not(.fluid) {
+            & > .button@{notFluid} {
                 margin-left: @buttonLeftDistance;
                 margin-right: @buttonLeftDistance;
             }
@@ -156,7 +160,7 @@
     .ui.flyout > .centered,
     .ui.flyout > .center.aligned {
         text-align: center;
-        &.actions > .button:not(.fluid) when (@variationFlyoutActions) {
+        &.actions > .button@{notFluid} when (@variationFlyoutActions) {
             margin-left: @buttonCenteredDistance;
             margin-right: @buttonCenteredDistance;
         }
@@ -525,67 +529,67 @@ body.pushable > .pusher {
     & when (@variationFlyoutColumnWidth) {
         /* Sizing Combinations */
 
-        .ui[class*="one wide"].flyout:not(.fullscreen) {
+        .ui[class*="one wide"].flyout@{notFullscreen} {
             width: @oneWide;
         }
 
-        .ui[class*="two wide"].flyout:not(.fullscreen) {
+        .ui[class*="two wide"].flyout@{notFullscreen} {
             width: @twoWide;
         }
 
-        .ui[class*="three wide"].flyout:not(.fullscreen) {
+        .ui[class*="three wide"].flyout@{notFullscreen} {
             width: @threeWide;
         }
 
-        .ui[class*="four wide"].flyout:not(.fullscreen) {
+        .ui[class*="four wide"].flyout@{notFullscreen} {
             width: @fourWide;
         }
 
-        .ui[class*="five wide"].flyout:not(.fullscreen) {
+        .ui[class*="five wide"].flyout@{notFullscreen} {
             width: @fiveWide;
         }
 
-        .ui[class*="six wide"].flyout:not(.fullscreen) {
+        .ui[class*="six wide"].flyout@{notFullscreen} {
             width: @sixWide;
         }
 
-        .ui[class*="seven wide"].flyout:not(.fullscreen) {
+        .ui[class*="seven wide"].flyout@{notFullscreen} {
             width: @sevenWide;
         }
 
-        .ui[class*="eight wide"].flyout:not(.fullscreen) {
+        .ui[class*="eight wide"].flyout@{notFullscreen} {
             width: @eightWide;
         }
 
-        .ui[class*="nine wide"].flyout:not(.fullscreen) {
+        .ui[class*="nine wide"].flyout@{notFullscreen} {
             width: @nineWide;
         }
 
-        .ui[class*="ten wide"].flyout:not(.fullscreen) {
+        .ui[class*="ten wide"].flyout@{notFullscreen} {
             width: @tenWide;
         }
 
-        .ui[class*="eleven wide"].flyout:not(.fullscreen) {
+        .ui[class*="eleven wide"].flyout@{notFullscreen} {
             width: @elevenWide;
         }
 
-        .ui[class*="twelve wide"].flyout:not(.fullscreen) {
+        .ui[class*="twelve wide"].flyout@{notFullscreen} {
             width: @twelveWide;
         }
 
-        .ui[class*="thirteen wide"].flyout:not(.fullscreen) {
+        .ui[class*="thirteen wide"].flyout@{notFullscreen} {
             width: @thirteenWide;
         }
 
-        .ui[class*="fourteen wide"].flyout:not(.fullscreen) {
+        .ui[class*="fourteen wide"].flyout@{notFullscreen} {
             width: @fourteenWide;
         }
 
-        .ui[class*="fifteen wide"].flyout:not(.fullscreen) {
+        .ui[class*="fifteen wide"].flyout@{notFullscreen} {
             width: @fifteenWide;
         }
 
-        .ui[class*="sixteen wide"].flyout:not(.fullscreen) {
+        .ui[class*="sixteen wide"].flyout@{notFullscreen} {
             width: @sixteenWide;
         }
     }

--- a/src/definitions/modules/flyout.less
+++ b/src/definitions/modules/flyout.less
@@ -50,30 +50,31 @@
 .ui.flyout > * {
     backface-visibility: hidden;
 }
+& when (@variationFlyoutClose) {
+    /* --------------
+       Close
+    --------------- */
 
-/* --------------
-   Close
---------------- */
-.ui.flyout > .close {
-    cursor: pointer;
-    position: absolute;
-    top: @closeTop;
-    right: @closeRight;
-    z-index: 1;
-    opacity: @closeOpacity;
-    font-size: @closeSize;
-    color: @closeColor;
-    width: @closeHitbox;
-    height: @closeHitbox;
-    padding: @closePadding;
-    margin: @closeMargin;
-    text-align: right;
-}
-
-.ui.flyout > .close:focus,
-.ui.flyout > .close:hover {
-    opacity: 1;
-    outline: none;
+    .ui.flyout > .close {
+        cursor: pointer;
+        position: absolute;
+        top: @closeTop;
+        right: @closeRight;
+        z-index: 1;
+        opacity: @closeOpacity;
+        font-size: @closeSize;
+        color: @closeColor;
+        width: @closeHitbox;
+        height: @closeHitbox;
+        padding: @closePadding;
+        margin: @closeMargin;
+        text-align: right;
+    }
+    .ui.flyout > .close:focus,
+    .ui.flyout > .close:hover {
+        opacity: 1;
+        outline: none;
+    }
 }
 
 /* --------------
@@ -406,9 +407,10 @@ body.pushable > .pusher {
     .ui.flyout.inverted {
         background: @invertedBackground;
     }
-
-    .ui.flyout.inverted > .close {
-        color: @invertedCloseColor;
+    & when (@variationFlyoutClose) {
+        .ui.flyout.inverted > .close {
+            color: @invertedCloseColor;
+        }
     }
 
     .ui.flyout.inverted > .header,

--- a/src/definitions/modules/modal.less
+++ b/src/definitions/modules/modal.less
@@ -17,6 +17,13 @@
 
 @import (multiple) "../../theme.config";
 
+@notFullscreen: if(@variationModalFullscreen, e(":not(.fullscreen)"));
+@notInside: if(@variationModalCloseInside, e(":not(.inside)"));
+@notAligned: if(@variationModalAligned, e(":not(.aligned)"));
+
+@notFluid: if(@variationButtonFluid, e(":not(.fluid)"));
+
+
 /*******************************
              Modal
 *******************************/
@@ -172,7 +179,7 @@
         border-top: @actionBorder;
         text-align: @actionAlign;
     }
-    .ui.modal .actions > .button:not(.fluid) {
+    .ui.modal .actions > .button@{notFluid} {
         margin-left: @buttonDistance;
     }
     .ui.ui.modal > .basic.actions,
@@ -182,7 +189,7 @@
     & when (@variationModalLeftActions) {
         .ui.modal > .left.actions {
             text-align: left;
-            & > .button:not(.fluid) {
+            & > .button@{notFluid} {
                 margin-left: @buttonLeftDistance;
                 margin-right: @buttonLeftDistance;
             }
@@ -194,7 +201,7 @@
     .ui.modal > .centered,
     .ui.modal > .center.aligned {
         text-align: center;
-        &.actions > .button:not(.fluid) when (@variationModalActions) {
+        &.actions > .button@{notFluid} when (@variationModalActions) {
             margin-left: @buttonCenteredDistance;
             margin-right: @buttonCenteredDistance;
         }
@@ -207,41 +214,41 @@
 
 /* Modal Width */
 @media only screen and (max-width: @largestMobileScreen) {
-    .ui.modal:not(.fullscreen) {
+    .ui.modal@{notFullscreen} {
         width: @mobileWidth;
         margin: @mobileMargin;
     }
 }
 @media only screen and (min-width: @tabletBreakpoint) {
-    .ui.modal:not(.fullscreen) {
+    .ui.modal@{notFullscreen} {
         width: @tabletWidth;
         margin: @tabletMargin;
     }
 }
 @media only screen and (min-width: @computerBreakpoint) {
-    .ui.modal:not(.fullscreen) {
+    .ui.modal@{notFullscreen} {
         width: @computerWidth;
         margin: @computerMargin;
-        & > .active.dimmer + .close:not(.inside) {
+        & > .active.dimmer + .close@{notInside} {
             pointer-events: none;
             opacity: @closeOpacityDimmed;
         }
     }
-    .ui.dimmer > .ui.modal:not(.fullscreen) > .close:not(.inside) {
+    .ui.dimmer > .ui.modal@{notFullscreen} > .close@{notInside} {
         text-shadow: @closeShadow;
     }
-    .ui.inverted.dimmer > .ui.modal:not(.fullscreen) > .close:not(.inside) {
+    .ui.inverted.dimmer > .ui.modal@{notFullscreen} > .close@{notInside} {
         text-shadow: @invertedCloseShadow;
     }
 }
 @media only screen and (min-width: @largeMonitorBreakpoint) {
-    .ui.modal:not(.fullscreen) {
+    .ui.modal@{notFullscreen} {
         width: @largeMonitorWidth;
         margin: @largeMonitorMargin;
     }
 }
 @media only screen and (min-width: @widescreenMonitorBreakpoint) {
-    .ui.modal:not(.fullscreen) {
+    .ui.modal@{notFullscreen} {
         width: @widescreenMonitorWidth;
         margin: @widescreenMonitorMargin;
     }
@@ -370,14 +377,14 @@
     .ui.legacy.legacy.page.dimmer > .ui.modal {
         left: 50% !important;
     }
-    .ui.legacy.legacy.modal:not(.aligned),
-    .ui.legacy.legacy.page.dimmer > .ui.modal:not(.aligned) {
+    .ui.legacy.legacy.modal@{notAligned},
+    .ui.legacy.legacy.page.dimmer > .ui.modal@{notAligned} {
         top: 50%;
     }
-    .ui.legacy.legacy.page.dimmer > .ui.scrolling.modal:not(.aligned),
-    .ui.page.dimmer > .ui.scrolling.legacy.legacy.modal:not(.aligned),
-    .ui.top.aligned.legacy.legacy.page.dimmer > .ui.modal:not(.aligned),
-    .ui.top.aligned.dimmer > .ui.legacy.legacy.modal:not(.aligned) {
+    .ui.legacy.legacy.page.dimmer > .ui.scrolling.modal@{notAligned},
+    .ui.page.dimmer > .ui.scrolling.legacy.legacy.modal@{notAligned},
+    .ui.top.aligned.legacy.legacy.page.dimmer > .ui.modal@{notAligned},
+    .ui.top.aligned.dimmer > .ui.legacy.legacy.modal@{notAligned} {
         top: auto;
     }
     & when (@variationModalOverlay) {
@@ -450,7 +457,7 @@
     .modals.dimmer .ui.scrolling.modal.fullscreen {
         top: 0;
     }
-    .modals.dimmer .ui.scrolling.modal:not(.fullscreen) {
+    .modals.dimmer .ui.scrolling.modal@{notFullscreen} {
         margin: @scrollingMargin auto;
         top: @scrollingTop;
     }
@@ -470,7 +477,7 @@
     .scrolling.undetached.dimmable.dimmed > .dimmer {
         overflow: hidden;
     }
-    .scrolling.undetached.dimmable .ui.scrolling.modal:not(.fullscreen) {
+    .scrolling.undetached.dimmable .ui.scrolling.modal@{notFullscreen} {
         position: absolute;
         left: 50%;
     }

--- a/src/definitions/modules/modal.less
+++ b/src/definitions/modules/modal.less
@@ -20,6 +20,7 @@
 @notFullscreen: if(@variationModalFullscreen, e(":not(.fullscreen)"));
 @notInside: if(@variationModalCloseInside, e(":not(.inside)"));
 @notAligned: if(@variationModalAligned, e(":not(.aligned)"));
+@notClose: if(@variationModalClose, e(":not(.close)"));
 
 @notFluid: if(@variationButtonFluid, e(":not(.fluid)"));
 
@@ -43,9 +44,9 @@
     outline: none;
 }
 
-.ui.modal > :first-child:not(.close):not(.dimmer),
+.ui.modal > :first-child@{notClose}:not(.dimmer),
 .ui.modal > i.icon:first-child + *,
-.ui.modal > .dimmer:first-child + *:not(.close),
+.ui.modal > .dimmer:first-child + *@{notClose},
 .ui.modal > .dimmer:first-child + i.icon + * {
     border-top-left-radius: @borderRadius;
     border-top-right-radius: @borderRadius;
@@ -64,27 +65,29 @@
             Content
 *******************************/
 
-/* --------------
-     Close
---------------- */
+& when (@variationModalClose) {
+    /* --------------
+         Close
+    --------------- */
 
-.ui.modal > .close {
-    cursor: pointer;
-    position: absolute;
-    top: @closeTop;
-    right: @closeRight;
-    z-index: 1;
-    opacity: @closeOpacity;
-    font-size: @closeSize;
-    color: @closeColor;
-    width: @closeHitbox;
-    height: @closeHitbox;
-    padding: @closePadding;
-}
-.ui.modal > .close:focus,
-.ui.modal > .close:hover {
-    opacity: 1;
-    outline: none;
+    .ui.modal > .close {
+        cursor: pointer;
+        position: absolute;
+        top: @closeTop;
+        right: @closeRight;
+        z-index: 1;
+        opacity: @closeOpacity;
+        font-size: @closeSize;
+        color: @closeColor;
+        width: @closeHitbox;
+        height: @closeHitbox;
+        padding: @closePadding;
+    }
+    .ui.modal > .close:focus,
+    .ui.modal > .close:hover {
+        opacity: 1;
+        outline: none;
+    }
 }
 
 /* --------------
@@ -228,16 +231,20 @@
     .ui.modal@{notFullscreen} {
         width: @computerWidth;
         margin: @computerMargin;
-        & > .active.dimmer + .close@{notInside} {
+        & > .active.dimmer + .close@{notInside} when (@variationModalClose) {
             pointer-events: none;
             opacity: @closeOpacityDimmed;
         }
     }
-    .ui.dimmer > .ui.modal@{notFullscreen} > .close@{notInside} {
-        text-shadow: @closeShadow;
-    }
-    .ui.inverted.dimmer > .ui.modal@{notFullscreen} > .close@{notInside} {
-        text-shadow: @invertedCloseShadow;
+    & when (@variationModalClose) {
+        .ui.dimmer > .ui.modal@{notFullscreen} > .close@{notInside} {
+            text-shadow: @closeShadow;
+        }
+        & when (@variationDimmerInverted) {
+            .ui.inverted.dimmer > .ui.modal@{notFullscreen} > .close@{notInside} {
+                text-shadow: @invertedCloseShadow;
+            }
+        }
     }
 }
 @media only screen and (min-width: @largeMonitorBreakpoint) {
@@ -253,15 +260,18 @@
     }
 }
 
-/* Tablet and Mobile */
-@media only screen and (max-width: @largestTabletScreen) {
-    .ui.modal > .close + .header {
-        padding-right: @closeHitbox;
-    }
-    .ui.modal > .close {
-        top: @innerCloseTop;
-        right: @innerCloseRight;
-        color: @innerCloseColor;
+& when (@variationModalClose) {
+    /* Tablet and Mobile */
+    @media only screen and (max-width: @largestTabletScreen) {
+        .ui.modal > .close + .header {
+            padding-right: @closeHitbox;
+        }
+
+        .ui.modal > .close {
+            top: @innerCloseTop;
+            right: @innerCloseRight;
+            color: @innerCloseColor;
+        }
     }
 }
 
@@ -270,8 +280,10 @@
     .ui.modal > .header {
         padding: @mobileHeaderPadding;
     }
-    .ui.modal > .close + .header {
-        padding-right: @closeHitbox;
+    & when (@variationModalClose) {
+        .ui.modal > .close + .header {
+            padding-right: @closeHitbox;
+        }
     }
     .ui.overlay.fullscreen.modal > .content.content.content {
         min-height: @overlayFullscreenScrollingContentMaxHeightMobile;
@@ -283,9 +295,11 @@
         display: block;
         padding: @mobileContentPadding !important;
     }
-    .ui.modal > .close {
-        top: @mobileCloseTop !important;
-        right: @mobileCloseRight !important;
+    & when (@variationModalClose) {
+        .ui.modal > .close {
+            top: @mobileCloseTop !important;
+            right: @mobileCloseRight !important;
+        }
     }
 
     /* rtl:ignore */
@@ -357,10 +371,12 @@
         color: @basicModalHeaderColor;
         border-bottom: none;
     }
-    .ui.basic.modal > .close {
-        top: @basicModalCloseTop;
-        right: @basicModalCloseRight;
-        color: @basicInnerCloseColor;
+    & when (@variationModalClose) {
+        .ui.basic.modal > .close {
+            top: @basicModalCloseTop;
+            right: @basicModalCloseRight;
+            color: @basicInnerCloseColor;
+        }
     }
     .ui.inverted.dimmer > .basic.modal {
         color: @basicInvertedModalColor;
@@ -523,19 +539,21 @@
             border-radius: 0;
         }
     }
-    .ui.modal > .close.inside + .header:not(.centered):not(.center):not(.icon),
-    .ui.fullscreen.modal > .close + .header:not(.centered):not(.center):not(.icon) {
-        padding-right: @closeHitbox;
-    }
-    .ui.modal > .close.inside,
-    .ui.fullscreen.modal > .close {
-        top: @innerCloseTop;
-        right: @innerCloseRight;
-        color: @innerCloseColor;
-    }
-    & when (@variationModalBasic) {
-        .ui.basic.fullscreen.modal > .close {
-            color: @basicInnerCloseColor;
+    & when (@variationModalClose) {
+        .ui.modal > .close.inside + .header:not(.centered):not(.center):not(.icon),
+        .ui.fullscreen.modal > .close + .header:not(.centered):not(.center):not(.icon) {
+            padding-right: @closeHitbox;
+        }
+        .ui.modal > .close.inside,
+        .ui.fullscreen.modal > .close {
+            top: @innerCloseTop;
+            right: @innerCloseRight;
+            color: @innerCloseColor;
+        }
+        & when (@variationModalBasic) {
+            .ui.basic.fullscreen.modal > .close {
+                color: @basicInnerCloseColor;
+            }
         }
     }
 }
@@ -617,14 +635,17 @@
             color: @invertedActionColor;
         }
     }
+    & when (@variationModalClose) {
+        & when (@variationDimmerInverted) {
+            .ui.inverted.dimmer > .modal > .close {
+                color: @invertedDimmerCloseColor;
+            }
+        }
 
-    .ui.inverted.dimmer > .modal > .close {
-        color: @invertedDimmerCloseColor;
-    }
-
-    @media only screen and (max-width: @largestTabletScreen) {
-        .ui.dimmer .inverted.modal > .close {
-            color: @invertedCloseColor;
+        @media only screen and (max-width: @largestTabletScreen) {
+            .ui.dimmer .inverted.modal > .close {
+                color: @invertedCloseColor;
+            }
         }
     }
     & when (@variationModalFullscreen) or (@variationModalCloseInside) {

--- a/src/definitions/modules/modal.less
+++ b/src/definitions/modules/modal.less
@@ -23,7 +23,6 @@
 
 @notFluid: if(@variationButtonFluid, e(":not(.fluid)"));
 
-
 /*******************************
              Modal
 *******************************/

--- a/src/definitions/modules/nag.less
+++ b/src/definitions/modules/nag.less
@@ -17,6 +17,10 @@
 
 @import (multiple) "../../theme.config";
 
+@notBottom: if(@variationNagBottom, e(":nxot(.bottom)"));
+@notFixed: if(@variationNagFixed, e(":nxot(.fixed)"));
+@notOverlay: if(@variationNagOverlay, e(":nxot(.overlay)"));
+
 /*******************************
              Nag
 *******************************/
@@ -63,7 +67,7 @@ a.ui.nag {
     transition: @closeTransition;
 }
 
-.ui.nag:not(.overlay):not(.fixed) {
+.ui.nag@{notOverlay}@{notFixed} {
     border-radius: @borderRadius;
 }
 
@@ -192,7 +196,7 @@ a.ui.nag {
     .ui.ui.nags .nag {
         border-radius: @groupedBorderRadius;
     }
-    .ui.nags:not(.bottom) .nag:last-child {
+    .ui.nags@{notBottom} .nag:last-child {
         border-radius: @topBorderRadius;
     }
     & when(@variationNagBottom) {
@@ -200,10 +204,10 @@ a.ui.nag {
             border-radius: @bottomBorderRadius;
         }
     }
-    .ui.nags:not(.fixed):not(.overlay) .nag:first-child {
+    .ui.nags@{notFixed}@{notOverlay} .nag:first-child {
         border-radius: @bottomBorderRadius;
     }
-    .ui.nags:not(.fixed):not(.overlay) .nag:only-child {
+    .ui.nags@{notFixed}@{notOverlay} .nag:only-child {
         border-radius: @borderRadius;
     }
 }

--- a/src/definitions/modules/nag.less
+++ b/src/definitions/modules/nag.less
@@ -17,9 +17,9 @@
 
 @import (multiple) "../../theme.config";
 
-@notBottom: if(@variationNagBottom, e(":nxot(.bottom)"));
-@notFixed: if(@variationNagFixed, e(":nxot(.fixed)"));
-@notOverlay: if(@variationNagOverlay, e(":nxot(.overlay)"));
+@notBottom: if(@variationNagBottom, e(":not(.bottom)"));
+@notFixed: if(@variationNagFixed, e(":not(.fixed)"));
+@notOverlay: if(@variationNagOverlay, e(":not(.overlay)"));
 
 /*******************************
              Nag

--- a/src/definitions/modules/popup.less
+++ b/src/definitions/modules/popup.less
@@ -17,6 +17,8 @@
 
 @import (multiple) "../../theme.config";
 
+@notPadded: if(@variationGridPadded, e(":not(.padded)"));
+
 /*******************************
             Popup
 *******************************/
@@ -696,7 +698,7 @@
 *******************************/
 
 /* Immediate Nested Grid */
-.ui.ui.ui.popup > .ui.grid:not(.padded) {
+.ui.ui.ui.popup > .ui.grid@{notPadded} {
     width: @nestedGridWidth;
     margin: @nestedGridMargin;
 }

--- a/src/definitions/modules/progress.less
+++ b/src/definitions/modules/progress.less
@@ -17,6 +17,12 @@
 
 @import (multiple) "../../theme.config";
 
+@notIndeterminate: if(@variationProgressIndeterminate, e(":not(.indeterminate)"));
+@notSliding: if(@variationProgressSliding, e(":not(.sliding)"));
+@notFilling: if(@variationProgressFilling, e(":not(.filling)"));
+@notSwinging: if(@variationProgressSwinging, e(":not(.swinging)"));
+@notBasic: if(@variationProgressBasic, e(":not(.basic)"));
+
 /*******************************
             Progress
 *******************************/
@@ -66,8 +72,8 @@
         min-width: @barMinWidth;
     }
 }
-.ui.ui.ui.progress:not([data-percent]):not(.indeterminate) .bar:not(:empty),
-.ui.ui.ui.progress[data-percent="0"]:not(.indeterminate) .bar:not(:empty) {
+.ui.ui.ui.progress:not([data-percent])@{notIndeterminate} .bar:not(:empty),
+.ui.ui.ui.progress[data-percent="0"]@{notIndeterminate} .bar:not(:empty) {
     background: transparent;
 }
 .ui.progress[data-percent="0"] .bar .progress {
@@ -396,7 +402,7 @@
         Inverted
     --------------- */
 
-    .ui.inverted.progress:not(.basic) {
+    .ui.inverted.progress@{notBasic} {
         background: @invertedBackground;
         border: @invertedBorder;
     }
@@ -573,7 +579,7 @@
             animation-name: progress-filling;
         }
     }
-    .ui.indeterminate.progress:not(.sliding):not(.filling):not(.swinging) .bar::before {
+    .ui.indeterminate.progress@{notSliding}@{notFilling}@{notSwinging} .bar::before {
         background: @indeterminatePulseColor;
     }
     & when (@variationProgressSliding) or (@variationProgressSwinging) or (@variationProgressFilling) {

--- a/src/definitions/modules/slider.less
+++ b/src/definitions/modules/slider.less
@@ -17,16 +17,23 @@
 
 @import (multiple) "../../theme.config";
 
-.ui.slider:not(.vertical):not(.checkbox) {
+@notVertical: if(@variationSliderVertical, e(":not(.vertical)"));
+@notDisabled: if(@variationSliderDisabled, e(":not(.disabled)"));
+@notBottom: if(@variationSliderBottomAligned, e(":not(.bottom)"));
+@notRight: if(@variationSliderRightAligned, e(":not(.right)"));
+
+@notCheckbox: if(@variationCheckboxSlider, e(":not(.checkbox)"));
+
+.ui.slider@{notVertical}@{notCheckbox} {
     width: 100%;
     padding: @padding;
 }
 
-.ui.slider:not(.checkbox) {
+.ui.slider@{notCheckbox} {
     position: relative;
 }
 
-.ui.slider:not(.checkbox):focus {
+.ui.slider@{notCheckbox}:focus {
     outline: 0;
 }
 
@@ -35,7 +42,7 @@
     z-index: 2;
 }
 
-.ui.slider:not(.vertical) .inner {
+.ui.slider@{notVertical} .inner {
     height: @height;
 }
 
@@ -49,7 +56,7 @@
     background-color: @trackColor;
 }
 
-.ui.slider:not(.vertical) .inner .track {
+.ui.slider@{notVertical} .inner .track {
     width: 100%;
     height: @trackHeight;
     top: @trackPositionTop;
@@ -62,7 +69,7 @@
     background-color: @trackFillColor;
 }
 
-.ui.slider:not(.vertical) .inner .track-fill {
+.ui.slider@{notVertical} .inner .track-fill {
     height: @trackFillHeight;
     top: @trackPositionTop;
     left: 0;
@@ -80,12 +87,12 @@
     transition: @thumbTransition;
 }
 
-.ui.slider:not(.disabled) .inner .thumb:hover {
+.ui.slider@{notDisabled} .inner .thumb:hover {
     cursor: @thumbHoverPointer;
     background: @thumbHoverBackground;
 }
 
-.ui.slider:not(.disabled):focus .inner .thumb {
+.ui.slider@{notDisabled}:focus .inner .thumb {
     background: @thumbHoverBackground;
 }
 
@@ -98,7 +105,7 @@
          Disabled
     --------------- */
 
-    .ui.disabled.slider:not(.checkbox) {
+    .ui.disabled.slider@{notCheckbox} {
         opacity: @disabledOpactiy;
     }
 
@@ -121,7 +128,7 @@
         right: 0;
     }
 
-    .ui.reversed.slider:not(.vertical) .inner .thumb {
+    .ui.reversed.slider@{notVertical} .inner .thumb {
         left: auto;
         right: 0;
     }
@@ -198,7 +205,7 @@
         right: 0;
     }
 
-    .ui.labeled.slider:not(.vertical) > .labels {
+    .ui.labeled.slider@{notVertical} > .labels {
         transform: translateY(-50%);
     }
 
@@ -251,13 +258,13 @@
         }
     }
     & when (@variationSliderUiLabel) {
-        .ui.labeled.slider:not(.vertical):not(.bottom) .labels .ui.label {
+        .ui.labeled.slider@{notVertical}@{notBottom} .labels .ui.label {
             margin-top: -@uiLabelMargin;
         }
-        .ui.labeled.ticked.slider:not(.vertical):not(.bottom) .labels .ui.label::after {
+        .ui.labeled.ticked.slider@{notVertical}@{notBottom} .labels .ui.label::after {
             margin-top: @uiLabelMargin;
         }
-        .ui.labeled.ticked.slider:not(.vertical) > .labels .ui.label::after {
+        .ui.labeled.ticked.slider@{notVertical} > .labels .ui.label::after {
             height: @uiLabelTickHeight;
         }
     }
@@ -288,7 +295,7 @@
             width: (@labelHeight / 2);
             height: @labelWidth;
         }
-        .ui.labeled.vertical.slider:not(.right) > .labels .halftick.label::after {
+        .ui.labeled.vertical.slider@{notRight} > .labels .halftick.label::after {
             margin-left: @verticalTickDistance;
         }
 
@@ -299,7 +306,7 @@
             }
         }
         & when (@variationSliderUiLabel) {
-            .ui.labeled.ticked.vertical.slider:not(.right) > .labels .ui.label::after {
+            .ui.labeled.ticked.vertical.slider@{notRight} > .labels .ui.label::after {
                 margin-left: @verticalUiLabelMargin;
             }
         }
@@ -343,8 +350,8 @@
     transition: @hoverOpacityTransition;
 }
 
-.ui.hover.slider:not(.disabled):hover .inner .thumb,
-.ui.hover.slider:not(.disabled):focus .inner .thumb {
+.ui.hover.slider@{notDisabled}:hover .inner .thumb,
+.ui.hover.slider@{notDisabled}:focus .inner .thumb {
     opacity: @hoverVarHoverOpacity;
 }
 
@@ -481,20 +488,20 @@
             height: @@h;
             width: @@h;
         }
-        .ui.slider.@{value}:not(.vertical) .inner {
+        .ui.slider.@{value}@{notVertical} .inner {
             height: @@h;
         }
-        .ui.slider.@{value}:not(.vertical) .inner .track,
-        .ui.slider.@{value}:not(.vertical) .inner .track-fill {
+        .ui.slider.@{value}@{notVertical} .inner .track,
+        .ui.slider.@{value}@{notVertical} .inner .track-fill {
             height: @@th;
             top: @@tp;
         }
         & when (@variationSliderLabeled) {
-            .ui.@{value}.labeled.slider:not(.vertical) > .labels,
-            .ui.@{value}.labeled.slider:not(.vertical) > .labels .label::after {
+            .ui.@{value}.labeled.slider@{notVertical} > .labels,
+            .ui.@{value}.labeled.slider@{notVertical} > .labels .label::after {
                 height: @@lh;
             }
-            .ui.@{value}.labeled.slider:not(.vertical) > .labels .halftick.label::after {
+            .ui.@{value}.labeled.slider@{notVertical} > .labels .halftick.label::after {
                 height: (@@lh / 2);
             }
         }

--- a/src/definitions/modules/toast.less
+++ b/src/definitions/modules/toast.less
@@ -17,6 +17,17 @@
 
 @import (multiple) "../../theme.config";
 
+@notActions: if(@variationToastActions, e(":not(.actions)"));
+@notAttached: if(@variationToastAttached, e(":not(.attached)"));
+@notVertical: if(@variationToastVertical, e(":not(.vertical)"));
+@notCenter: if(@variationToastCenter, e(":not(.center)"));
+@notCentered: if(@variationToastCentered, e(":not(.centered)"));
+@notBasic: if(@variationToastBasic, e(":not(.basic)"));
+@notClose: if(@variationToastClose, e(":not(.close)"));
+@notUnclickable: if(@variationToastUnclickable, e(":not(.unclickable)"));
+
+@notFluid: if(@variationButtonFluid, e(":not(.fluid)"));
+
 /*******************************
         Toast container
 *******************************/
@@ -56,7 +67,7 @@
             & > * {
                 width: 100%;
                 border-radius: 0;
-                & > .vertical:not(.actions) when (@variationToastVertical) {
+                & > .vertical@{notActions} when (@variationToastVertical) {
                     flex: 1;
                 }
             }
@@ -130,7 +141,7 @@
         &:hover {
             opacity: @toastOpacityOnHover;
         }
-        &:not(.unclickable):hover {
+        &@{notUnclickable}:hover {
             cursor: @toastCursorOnHover;
         }
         & when (@variationToastFloating) {
@@ -195,18 +206,18 @@
             }
             &.icon when (@variationToastIcon) {
                 align-items: inherit;
-                & > :not(.icon):not(.actions) {
+                & > :not(.icon)@{notActions} {
                     padding-left: @toastIconMessageContentPadding;
                 }
-                & > i.icon:not(.close) when (@variationToastIcon) {
+                & > i.icon@{notClose} when (@variationToastIcon) {
                     display: inline-block;
                     position: absolute;
                     width: @toastIconMessageWidth;
                     top: 50%;
                     transform: translateY(-50%);
                 }
-                &:not(.vertical) {
-                    &.actions > i.icon:not(.close) when (@variationToastActions) and (@variationToastIcon) {
+                &@{notVertical} {
+                    &.actions > i.icon@{notClose} when (@variationToastActions) and (@variationToastIcon) {
                         top: e(%("calc(50%% - %d)", @toastIconCenteredAdjustment));
                         transform: none;
                     }
@@ -230,7 +241,7 @@
                 margin-top: -@toastCloseTopDistance;
                 margin-right: -@toastCloseTopDistance;
             }
-            &:not(.vertical) > .close.icon when (@variationToastClose) {
+            &@{notVertical} > .close.icon when (@variationToastClose) {
                 position: absolute;
                 top: @toastCloseTopDistance;
                 &:not(.left) {
@@ -243,7 +254,7 @@
         }
         & .ui.card when (@variationToastCard) {
             margin: 0;
-            &.attached:not(.vertical) when (@variationToastAttached) {
+            &.attached@{notVertical} when (@variationToastAttached) {
                 &.bottom {
                     border-top-left-radius: 0;
                     border-top-right-radius: 0;
@@ -296,7 +307,7 @@
         &:hover .pausable.progressing {
             animation-play-state: paused;
         }
-        & .ui.toast:not(.vertical) {
+        & .ui.toast@{notVertical} {
             display: block;
         }
         & :not(.comment) {
@@ -306,10 +317,10 @@
             & .actions when (@variationToastActions) {
                 padding: @toastActionPadding @toastActionPadding @toastActionPaddingBottom @toastActionPadding;
                 text-align: right;
-                &.attached:not(.vertical) when (@variationToastAttached) {
+                &.attached@{notVertical} when (@variationToastAttached) {
                     margin-right: @toastLeftRightMargin;
                 }
-                &:not(.basic):not(.attached) {
+                &@{notBasic}@{notAttached} {
                     background: @toastActionBackground;
                     border-top: @toastActionBorder;
                 }
@@ -333,13 +344,13 @@
             &.attached > .button when (@variationToastAttached) {
                 align-items: center;
             }
-            &:not(.attached) {
+            &@{notAttached} {
                 border-top: 0;
                 margin-top: -@toastActionPaddingBottom;
                 margin-bottom: -@toastActionPaddingBottom;
                 margin-left: @toastActionMarginLeft;
                 justify-content: space-around;
-                &:not(.basic) {
+                &@{notBasic} {
                     border-left: @toastActionBorder;
                 }
                 & > .button:not(:last-child) {
@@ -417,7 +428,7 @@
     }
 }
 
-.ui.attached:not(.vertical) when (@variationToastAttached) {
+.ui.attached@{notVertical} when (@variationToastAttached) {
     &:not(.top) {
         &.actions when (@variationToastActions) {
             border-bottom-left-radius: @toastBorderRadius;
@@ -480,19 +491,19 @@
         background-color: @toastNeutralColor;
         color: @toastNeutralTextColor;
     }
-    & > i.icon:not(.close) when (@variationToastIcon) {
+    & > i.icon@{notClose} when (@variationToastIcon) {
         font-size: @toastIconFontSize;
     }
-    &:not(.vertical) {
-        &:not(.centered):not(.center) {
-            & > i.icon:not(.close) when (@variationToastIcon) {
+    &@{notVertical} {
+        &@{notCentered}@{notCenter} {
+            & > i.icon@{notClose} when (@variationToastIcon) {
                 position: absolute;
             }
             & > .ui.image when (@variationToastImage) {
                 position: absolute;
             }
         }
-        & > i.icon:not(.close) when (@variationToastIcon) {
+        & > i.icon@{notClose} when (@variationToastIcon) {
             & + .content {
                 padding-left: @toastIconContentPadding;
             }
@@ -518,7 +529,7 @@
                 min-height: @toastSmallImageHeight;
             }
         }
-        &:not(.centered):not(.center) when (@variationToastImage) or (@variationToastIcon) {
+        &@{notCentered}@{notCenter} when (@variationToastImage) or (@variationToastIcon) {
             & > .centered.image,
             > .centered.icon {
                 transform: translateY(-50%);
@@ -544,7 +555,7 @@
         }
         & when (@variationToastImage) or (@variationToastIcon) {
             & > .ui.image + .content,
-            > i.icon:not(.close) + .content {
+            > i.icon@{notClose} + .content {
                 padding-left: @toastImageContentPadding;
             }
         }
@@ -619,7 +630,7 @@
 
         & > .content,
         & > .ui.image,
-        & > i.icon:not(.close) {
+        & > i.icon@{notClose} {
             align-self: center;
         }
     }
@@ -633,7 +644,7 @@
     .ui.toast-container .toast-box .center.aligned.actions {
         text-align: center;
 
-        &:not(.attached) > .button:not(.fluid) {
+        &@{notAttached} > .button@{notFluid} {
             margin-left: @toastActionCenteredMargin;
             margin-right: @toastActionCenteredMargin;
         }
@@ -679,7 +690,7 @@
             width: auto;
             max-width: 100%;
         }
-        & > *:not(.vertical) {
+        & > *@{notVertical} {
             min-width: @mobileWidth;
         }
         & when (@variationToastCard) {

--- a/src/definitions/views/card.less
+++ b/src/definitions/views/card.less
@@ -17,6 +17,8 @@
 
 @import (multiple) "../../theme.config";
 
+@notRaised: if(@variationCardRaised, e(":not(.raised)"));
+
 /*******************************
             Standard
 *******************************/
@@ -358,9 +360,9 @@
     /* --------------
        Basic
     --------------- */
-    .ui.cards:not(.raised) > .basic.card:not(.raised),
-    .ui.ui.ui.basic.cards:not(.raised) > .card:not(.raised),
-    .ui.ui.ui.basic.card:not(.raised) {
+    .ui.cards@{notRaised} > .basic.card@{notRaised},
+    .ui.ui.ui.basic.cards@{notRaised} > .card@{notRaised},
+    .ui.ui.ui.basic.card@{notRaised} {
         box-shadow: none;
         & > .buttons,
         > .button {
@@ -369,8 +371,8 @@
         }
     }
     & when (@variationCardLink) {
-        .ui.ui.ui.ui.ui.basic.card:not(.raised):hover,
-        .ui.ui.ui.ui.ui.basic.cards:not(.raised) .card:not(.raised):hover {
+        .ui.ui.ui.ui.ui.basic.card@{notRaised}:hover,
+        .ui.ui.ui.ui.ui.basic.cards@{notRaised} .card@{notRaised}:hover {
             box-shadow: none;
         }
     }

--- a/src/definitions/views/feed.less
+++ b/src/definitions/views/feed.less
@@ -17,6 +17,8 @@
 
 @import (multiple) "../../theme.config";
 
+@notConnected: if(@variationFeedConnected, e(":not(.connected)"));
+
 /*******************************
          Activity Feed
 *******************************/
@@ -47,7 +49,7 @@
         border-top: @eventDivider;
     }
 }
-.ui.feed:not(.connected) > .event:first-child {
+.ui.feed@{notConnected} > .event:first-child {
     padding-top: 0;
 }
 .ui.feed > .event:last-child {

--- a/src/definitions/views/item.less
+++ b/src/definitions/views/item.less
@@ -17,6 +17,8 @@
 
 @import (multiple) "../../theme.config";
 
+@notUnstackable: if(@variationItemUnstackable, e(":not(.unstackable)"));
+
 /*******************************
             Standard
 *******************************/
@@ -370,22 +372,22 @@
 
 /* Mobile Only */
 @media only screen and (max-width: @largestMobileScreen) {
-    .ui.items:not(.unstackable) > .item {
+    .ui.items@{notUnstackable} > .item {
         flex-direction: column;
         margin: @mobileItemSpacing 0;
     }
-    .ui.items:not(.unstackable) > .item > .image {
+    .ui.items@{notUnstackable} > .item > .image {
         display: block;
         margin-left: auto;
         margin-right: auto;
     }
-    .ui.items:not(.unstackable) > .item > .image,
-    .ui.items:not(.unstackable) > .item > .image > img {
+    .ui.items@{notUnstackable} > .item > .image,
+    .ui.items@{notUnstackable} > .item > .image > img {
         max-width: 100% !important;
         width: @mobileImageWidth !important;
         max-height: @mobileImageMaxHeight !important;
     }
-    .ui.items:not(.unstackable) > .item > .image + .content {
+    .ui.items@{notUnstackable} > .item > .image + .content {
         display: block;
         padding: @mobileContentImageDistance 0 0;
     }

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -757,7 +757,8 @@
 @variationToastVertical: true;
 @variationToastAttached: true;
 @variationToastCompact: true;
-@variationToastCentered: true;
+@variationToastBasic: true;
+@variationToastUnclickable: true;
 @variationToastColors: @variationAllColors;
 
 /* Transition */

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -396,6 +396,9 @@
 @variationTableOverflowingVeryShort: true;
 @variationTableOverflowingLong: true;
 @variationTableOverflowingVeryLong: true;
+@variationTableRowSpanned: true;
+@variationTableFullWidth: true;
+@variationTableUnstackable: true;
 @variationTableSizes: @variationAllSizes;
 @variationTableColors: @variationAllColors;
 

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -257,6 +257,7 @@
 @variationStepEqualWidth: true;
 @variationStepSizes: @variationAllSizes;
 @variationStepCircular: true;
+@variationStepUnstackable: true;
 @variationStepColors: @variationAllColors;
 
 /* Text */

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -287,6 +287,7 @@
 @variationFormGrouped: true;
 @variationFormEqualWidth: true;
 @variationFormWide: true;
+@variationFormUnstackable: true;
 @variationFormSizes: @variationAllSizes;
 
 /* Grid */

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -300,6 +300,7 @@
 @variationGridPadded: true;
 @variationGridFloated: true;
 @variationGridDivided: true;
+@variationGridHorizontal: true;
 @variationGridVertical: true;
 @variationGridAligned: true;
 @variationGridAttached: true;

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -607,6 +607,7 @@
 @variationFlyoutRight: true;
 @variationFlyoutOverlay: true;
 @variationFlyoutScrolling: true;
+@variationFlyoutClose: true;
 
 /* Modal */
 @variationModalInverted: true;
@@ -617,6 +618,7 @@
 @variationModalResizable: true;
 @variationModalScrolling: true;
 @variationModalLegacy: true;
+@variationModalClose: true;
 @variationModalCloseInside: true;
 @variationModalCentered: true;
 @variationModalActions: true;

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -582,6 +582,7 @@
 @variationDropdownPointing: true;
 @variationDropdownColumnar: true;
 @variationDropdownScrollhint: true;
+@variationDropdownUnlimited: true;
 @variationDropdownHighlightMatches: false;
 @variationDropdownSizes: @variationAllSizes;
 

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -536,6 +536,7 @@
 @variationCheckboxReadonly: true;
 @variationCheckboxInverted: true;
 @variationCheckboxInvisible: true;
+@variationCheckboxCompact: true;
 @variationCheckboxRadio: true;
 @variationCheckboxSlider: true;
 @variationCheckboxToggle: true;

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -186,6 +186,7 @@
 @variationLoaderIndeterminate: true;
 @variationLoaderText: true;
 @variationLoaderInline: true;
+@variationLoaderDouble: true;
 @variationLoaderElastic: true;
 @variationLoaderSizes: @variationAllSizes;
 @variationLoaderColors: @variationAllColors;


### PR DESCRIPTION
## Description
A lot of `:not()` css selectors are not needed when the related variation has been disabled and thus isn't compiled
This PR makes sure such selectors are removed upon compilation which reduces the generated css even more

For example if one disables circular step in `variation.variables` (or in a custom site.variables)

```less
@variationStepCircular: false;
```

then all the `:not(.circular)` selectors can be removed as a `.ui.circular.step` won't exist after compilation, so there is no need to differentiate between them anymore

As everything is enabled by default, this change does not affect anything and is completely backward compatible