### PR TITLE
Introducing Fomantic UI Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The official community fork of the popular Semantic-UI framework.
 [![Dependabot Status](https://badgen.net/github/dependabot/fomantic/Fomantic-UI/?icon=dependabot)](https://github.com/features/security)
 [![Known Build Dependency Vulnerabilities](https://snyk.io/test/github/fomantic/Fomantic-UI/badge.svg?targetFile=package.json)](https://snyk.io/test/github/fomantic/Fomantic-UI?targetFile=package.json)
 [![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/7496/badge)](https://bestpractices.coreinfrastructure.org/projects/7496)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Fomantic%20UI%20Guru-006BFF)](https://gurubase.io/g/fomantic-ui)
 
 ---
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Fomantic UI Guru](https://gurubase.io/g/fomantic-ui) to Gurubase. Fomantic UI Guru uses the data from this repo and data from the [docs](https://fomantic-ui.com/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Fomantic UI Guru", which highlights that Fomantic UI now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Fomantic UI Guru in Gurubase, just let me know that's totally fine.
