### PR TITLE
fix(dropdown): set placeholdertext regardless of values

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -126,7 +126,8 @@
                             module.set.initialLoad();
                             module.change.values(settings.values);
                             module.remove.initialLoad();
-                        } else if (module.get.placeholderText() !== '') {
+                        }
+                        if (module.get.placeholderText() !== '') {
                             module.set.placeholderText();
                         }
 


### PR DESCRIPTION
## Description
In situations where values are given for a dropdown, but the list is empty (or no value is selected), and also `allowAdditions:true` is set, a given placeholder wont be shown. That's because internally the dropdownlist does not get cleared when allowAdditions is true which also does not (re-)set the placeholder.

By always trying to show a placeholder this situation gets fixed.

## Testcase
### Broken
https://jsfiddle.net/mkov7swt/

### Fixed
https://jsfiddle.net/lubber/ws65erf2/12/

## Closes
#3127 