### PR TITLE
feat(search): support remove icon

### DIFF
--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -203,9 +203,9 @@
                         }
                     },
                     remove: {
-                        click: function() {
+                        click: function () {
                             module.clear.value();
-                        }
+                        },
                     },
                     result: {
                         mousedown: function () {

--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -126,6 +126,7 @@
                             .on('mousedown' + eventNamespace, selector.results, module.event.result.mousedown)
                             .on('mouseup' + eventNamespace, selector.results, module.event.result.mouseup)
                             .on('click' + eventNamespace, selector.result, module.event.result.click)
+                            .on('click' + eventNamespace, selector.remove, module.event.remove.click)
                         ;
                     },
                 },
@@ -199,6 +200,11 @@
                         } else {
                             module.debug('Input blurred without user action, closing results');
                             callback();
+                        }
+                    },
+                    remove: {
+                        click: function() {
+                            module.clear.value();
                         }
                     },
                     result: {
@@ -837,6 +843,10 @@
                             $module.data(metadata.cache, cache);
                         }
                     },
+                    value: function () {
+                        module.set.value('');
+                        module.hideResults();
+                    },
                 },
 
                 read: {
@@ -1456,6 +1466,7 @@
 
         selector: {
             prompt: '.prompt',
+            remove: '> .icon.input > .remove.icon',
             searchButton: '.search.button',
             results: '.results',
             message: '.results > .message',

--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -205,6 +205,7 @@
                     remove: {
                         click: function () {
                             module.clear.value();
+                            $prompt.trigger('focus');
                         },
                     },
                     result: {
@@ -845,7 +846,6 @@
                     },
                     value: function () {
                         module.set.value('');
-                        module.hideResults();
                     },
                 },
 

--- a/src/definitions/modules/search.less
+++ b/src/definitions/modules/search.less
@@ -271,37 +271,38 @@
            Types
 *******************************/
 
-& when (@variationSearchSelection) {
+& when (@variationSearchClear) {
     /* --------------
-        Selection
+        Clear Icon
     --------------- */
 
-    .ui.search.selection .prompt {
-        border-radius: @selectionPromptBorderRadius;
-    }
-
-    /* Remove input */
-    .ui.search.selection > .icon.input > .remove.icon {
-        pointer-events: none;
-        position: absolute;
-        left: auto;
-        opacity: 0;
-        color: @selectionCloseIconColor;
-        top: @selectionCloseTop;
-        right: @selectionCloseRight;
-        transition: @selectionCloseTransition;
-    }
-    .ui.search.selection > .icon.input > .active.remove.icon {
+    .ui.search > .icon.input > .remove.icon {
+        pointer-events: all;
+        transition: @clearableIconTransition;
         cursor: pointer;
-        opacity: @selectionCloseIconOpacity;
-        pointer-events: auto;
+        opacity: @clearableIconOpacity;
     }
-    .ui.search.selection > .icon.input:not([class*="left icon"]) > .icon ~ .remove.icon {
-        right: @selectionCloseIconInputRight;
+    .ui.search > .icon.input:not([class*="left icon"]) > .icon ~ .remove.icon {
+        right: @clearableIconInputRight;
     }
-    .ui.search.selection > .icon.input > .remove.icon:hover {
-        opacity: @selectionCloseIconHoverOpacity;
-        color: @selectionCloseIconHoverColor;
+    .ui.search > .icon.input > .remove.icon:hover {
+        opacity: @clearableIconHoverOpacity;
+    }
+    .ui.search input[type="search"]::-webkit-search-cancel-button {
+        -webkit-appearance: none;
+        cursor: pointer;
+        transition: @clearableIconTransition;
+        opacity: @clearableIconOpacity;
+        /*
+         * Times icon taken from Font Awesome Free 5.15.4 by @fontawesome [https://fontawesome.com]
+         * License - https://fontawesome.com/license/free
+        */
+        background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 352 512'%3E%3Cpath d='M242.7 256l100.1-100.1c12.3-12.3 12.3-32.2 0-44.5l-22.2-22.2c-12.3-12.3-32.2-12.3-44.5 0L176 189.3 75.9 89.2c-12.3-12.3-32.2-12.3-44.5 0L9.2 111.5c-12.3 12.3-12.3 32.2 0 44.5L109.3 256 9.2 356.1c-12.3 12.3-12.3 32.2 0 44.5l22.2 22.2c12.3 12.3 32.2 12.3 44.5 0L176 322.7l100.1 100.1c12.3 12.3 32.2 12.3 44.5 0l22.2-22.2c12.3-12.3 12.3-32.2 0-44.5L242.7 256z'/%3E%3C/svg%3E") no-repeat;
+        height: @clearableIconHeight;
+        width: @clearableIconWidth;
+        &:hover {
+            opacity: @clearableIconHoverOpacity;
+        }
     }
 }
 

--- a/src/definitions/modules/search.less
+++ b/src/definitions/modules/search.less
@@ -309,7 +309,7 @@
     .ui.search.loading > .icon.input > .remove.icon {
         display: none;
     }
-    .ui.search > .icon.input > input:-ms-input-placeholder ~ .remove.icon when (@supportIE){
+    .ui.search > .icon.input > input:-ms-input-placeholder ~ .remove.icon when (@supportIE) {
       display: none;
     }
 }

--- a/src/definitions/modules/search.less
+++ b/src/definitions/modules/search.less
@@ -310,7 +310,7 @@
         display: none;
     }
     .ui.search > .icon.input > input:-ms-input-placeholder ~ .remove.icon when (@supportIE) {
-      display: none;
+        display: none;
     }
 }
 

--- a/src/definitions/modules/search.less
+++ b/src/definitions/modules/search.less
@@ -281,12 +281,12 @@
         transition: @clearableIconTransition;
         cursor: pointer;
         opacity: @clearableIconOpacity;
+        &:hover {
+            opacity: @clearableIconHoverOpacity;
+        }
     }
     .ui.search > .icon.input:not([class*="left icon"]) > .icon ~ .remove.icon {
         right: @clearableIconInputRight;
-    }
-    .ui.search > .icon.input > .remove.icon:hover {
-        opacity: @clearableIconHoverOpacity;
     }
     .ui.search input[type="search"]::-webkit-search-cancel-button {
         -webkit-appearance: none;

--- a/src/definitions/modules/search.less
+++ b/src/definitions/modules/search.less
@@ -293,16 +293,24 @@
         cursor: pointer;
         transition: @clearableIconTransition;
         opacity: @clearableIconOpacity;
-        /*
-         * Times icon taken from Font Awesome Free 5.15.4 by @fontawesome [https://fontawesome.com]
-         * License - https://fontawesome.com/license/free
-        */
-        background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 352 512'%3E%3Cpath d='M242.7 256l100.1-100.1c12.3-12.3 12.3-32.2 0-44.5l-22.2-22.2c-12.3-12.3-32.2-12.3-44.5 0L176 189.3 75.9 89.2c-12.3-12.3-32.2-12.3-44.5 0L9.2 111.5c-12.3 12.3-12.3 32.2 0 44.5L109.3 256 9.2 356.1c-12.3 12.3-12.3 32.2 0 44.5l22.2 22.2c12.3 12.3 32.2 12.3 44.5 0L176 322.7l100.1 100.1c12.3 12.3 32.2 12.3 44.5 0l22.2-22.2c12.3-12.3 12.3-32.2 0-44.5L242.7 256z'/%3E%3C/svg%3E") no-repeat;
+        background: @clearableIconBackground;
         height: @clearableIconHeight;
         width: @clearableIconWidth;
         &:hover {
             opacity: @clearableIconHoverOpacity;
         }
+    }
+    & when (@variationSearchLoading) {
+        .ui.loading.search input[type="search"]::-webkit-search-cancel-button {
+            display: none;
+        }
+    }
+    .ui.search > .icon.input > input:placeholder-shown ~ .remove.icon,
+    .ui.search.loading > .icon.input > .remove.icon {
+        display: none;
+    }
+    .ui.search > .icon.input > input:-ms-input-placeholder ~ .remove.icon when (@supportIE){
+      display: none;
     }
 }
 

--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -670,7 +670,7 @@
 
 /* Search */
 @variationSearchDisabled: true;
-@variationSearchSelection: true;
+@variationSearchClear: true;
 @variationSearchCategory: true;
 @variationSearchHorizontalCategory: true;
 @variationSearchLoading: true;

--- a/src/themes/default/modules/search.variables
+++ b/src/themes/default/modules/search.variables
@@ -127,8 +127,7 @@
 *******************************/
 
 /* Clearable */
-@clearableIconTransition:
-    opacity @defaultDuration @defaultEasing;
+@clearableIconTransition: opacity @defaultDuration @defaultEasing;
 @clearableIconOpacity: 0.6;
 @clearableIconHoverOpacity: 1;
 @clearableIconWidth: 1em;

--- a/src/themes/default/modules/search.variables
+++ b/src/themes/default/modules/search.variables
@@ -134,7 +134,12 @@
 @clearableIconWidth: 1em;
 @clearableIconHeight: @clearableIconWidth;
 
-@ClearableIconInputRight: 1.85714em;
+@clearableIconInputRight: 1.85714em;
+/*
+ * Times icon taken from Font Awesome Free 5.15.4 by @fontawesome [https://fontawesome.com]
+ * License - https://fontawesome.com/license/free
+*/
+@clearableIconBackground: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 352 512'%3E%3Cpath d='M242.7 256l100.1-100.1c12.3-12.3 12.3-32.2 0-44.5l-22.2-22.2c-12.3-12.3-32.2-12.3-44.5 0L176 189.3 75.9 89.2c-12.3-12.3-32.2-12.3-44.5 0L9.2 111.5c-12.3 12.3-12.3 32.2 0 44.5L109.3 256 9.2 356.1c-12.3 12.3-12.3 32.2 0 44.5l22.2 22.2c12.3 12.3 32.2 12.3 44.5 0L176 322.7l100.1 100.1c12.3 12.3 32.2 12.3 44.5 0l22.2-22.2c12.3-12.3 12.3-32.2 0-44.5L242.7 256z'/%3E%3C/svg%3E") no-repeat;
 
 /* Category */
 @categoryBackground: @darkWhite;

--- a/src/themes/default/modules/search.variables
+++ b/src/themes/default/modules/search.variables
@@ -126,20 +126,15 @@
             Types
 *******************************/
 
-/* Selection */
-@selectionPromptBorderRadius: @defaultBorderRadius;
-
-@selectionCloseTop: 0;
-@selectionCloseTransition:
-    color @defaultDuration @defaultEasing,
+/* Clearable */
+@clearableIconTransition:
     opacity @defaultDuration @defaultEasing;
-@selectionCloseRight: 0;
-@selectionCloseIconOpacity: 0.8;
-@selectionCloseIconColor: "";
-@selectionCloseIconHoverOpacity: 1;
-@selectionCloseIconHoverColor: @red;
+@clearableIconOpacity: 0.6;
+@clearableIconHoverOpacity: 1;
+@clearableIconWidth: 1em;
+@clearableIconHeight: @clearableIconWidth;
 
-@selectionCloseIconInputRight: 1.85714em;
+@ClearableIconInputRight: 1.85714em;
 
 /* Category */
 @categoryBackground: @darkWhite;

--- a/src/themes/default/modules/search.variables
+++ b/src/themes/default/modules/search.variables
@@ -135,10 +135,11 @@
 @clearableIconHeight: @clearableIconWidth;
 
 @clearableIconInputRight: 1.85714em;
+
 /*
  * Times icon taken from Font Awesome Free 5.15.4 by @fontawesome [https://fontawesome.com]
  * License - https://fontawesome.com/license/free
-*/
+ */
 @clearableIconBackground: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 352 512'%3E%3Cpath d='M242.7 256l100.1-100.1c12.3-12.3 12.3-32.2 0-44.5l-22.2-22.2c-12.3-12.3-32.2-12.3-44.5 0L176 189.3 75.9 89.2c-12.3-12.3-32.2-12.3-44.5 0L9.2 111.5c-12.3 12.3-12.3 32.2 0 44.5L109.3 256 9.2 356.1c-12.3 12.3-12.3 32.2 0 44.5l22.2 22.2c12.3 12.3 32.2 12.3 44.5 0L176 322.7l100.1 100.1c12.3 12.3 32.2 12.3 44.5 0l22.2-22.2c12.3-12.3 12.3-32.2 0-44.5L242.7 256z'/%3E%3C/svg%3E") no-repeat;
 
 /* Category */


### PR DESCRIPTION
## Description

Support remove icon for search module similar to dropdown module
Either via separate `remove icon` or by using a native `input[type="search"]` element

### Sidenote
I party reused code which was already implemented in 2015 but removed again (by accident or intentionally , only the original authors knows...)
That's why i also removed the left dead css code for `selection search` which never made it into any release and wasn't ever documented. 
Was commited by 4ea251490579a262f65d12ac75415e222b6ed8e0
... and immediatly removed again the same day by 6d34ae21e595d104b59481848ebf2f7873028dac

## Testcase
https://jsfiddle.net/lubber/m2k9gn8o/126/