### PR TITLE
feat(build): optionally include version in released filename

### DIFF
--- a/tasks/config/project/release.js
+++ b/tasks/config/project/release.js
@@ -9,7 +9,8 @@ let
     npmPackage,
     version,
     revision,
-    versionInFileName
+    versionInFileName,
+    includeVersionInFileName
 ;
 
 /*******************************
@@ -29,7 +30,7 @@ try {
 }
 
 // looks for version in config or package.json (whichever is available)
-version = npmPackage && npmPackage.version !== undefined && npmPackage.name === 'fomantic-ui'
+version = npmPackage && npmPackage.version != undefined && npmPackage.name === 'fomantic-ui'
     ? npmPackage.version
     : config.version;
 
@@ -41,12 +42,11 @@ includeVersionInFileName = config.includeVersionInFileName === undefined ? false
 versionInFileName = '';
 
 if (includeVersionInFileName) {
-	versionInFileName = '-' + version;
-	if (revision != '') {
-		versionInFileName += '-' + revision;
-	}
+    versionInFileName = '-' + version;
+    if (revision != '') {
+        versionInFileName += '-' + revision;
+    }
 }
-
 
 /*******************************
              Export

--- a/tasks/config/project/release.js
+++ b/tasks/config/project/release.js
@@ -7,7 +7,9 @@ const requireDotFile = require('require-dot-file');
 let
     config,
     npmPackage,
-    version
+    version,
+    revision,
+    versionInFileName
 ;
 
 /*******************************
@@ -30,6 +32,21 @@ try {
 version = npmPackage && npmPackage.version !== undefined && npmPackage.name === 'fomantic-ui'
     ? npmPackage.version
     : config.version;
+
+// looks for revision in config.
+revision = config.revision === undefined ? '' : config.revision;
+
+includeVersionInFileName = config.includeVersionInFileName === undefined ? false : config.includeVersionInFileName;
+
+versionInFileName = '';
+
+if (includeVersionInFileName) {
+	versionInFileName = '-' + version;
+	if (revision != '') {
+		versionInFileName += '-' + revision;
+	}
+}
+
 
 /*******************************
              Export
@@ -54,5 +71,6 @@ module.exports = {
         + ' */\n',
 
     version: version,
+    versionInFileName: versionInFileName,
 
 };

--- a/tasks/config/project/release.js
+++ b/tasks/config/project/release.js
@@ -30,7 +30,7 @@ try {
 }
 
 // looks for version in config or package.json (whichever is available)
-version = npmPackage && npmPackage.version != undefined && npmPackage.name === 'fomantic-ui'
+version = npmPackage && npmPackage.version !== undefined && npmPackage.name === 'fomantic-ui'
     ? npmPackage.version
     : config.version;
 

--- a/tasks/config/project/release.js
+++ b/tasks/config/project/release.js
@@ -43,7 +43,7 @@ versionInFileName = '';
 
 if (includeVersionInFileName) {
     versionInFileName = '-' + version;
-    if (revision != '') {
+    if (revision !== '') {
         versionInFileName += '-' + revision;
     }
 }

--- a/tasks/config/tasks.js
+++ b/tasks/config/tasks.js
@@ -44,8 +44,8 @@ module.exports = {
         concatenatedJS: 'semantic' + release.versionInFileName + '.js',
         concatenatedMinifiedCSS: 'semantic' + release.versionInFileName + '.min.css',
         concatenatedMinifiedJS: 'semantic' + release.versionInFileName + '.min.js',
-        concatenatedRTLCSS: 'semantic.rtl' + release.versionInFileName + '.css',
-        concatenatedMinifiedRTLCSS: 'semantic.rtl' + release.versionInFileName + '.min.css',
+        concatenatedRTLCSS: 'semantic' + release.versionInFileName + '.rtl.css',
+        concatenatedMinifiedRTLCSS: 'semantic' + release.versionInFileName + '.rtl.min.css',
     },
 
     regExp: {

--- a/tasks/config/tasks.js
+++ b/tasks/config/tasks.js
@@ -40,12 +40,12 @@ module.exports = {
     },
 
     filenames: {
-        concatenatedCSS: 'semantic' + release.versionInFileName  + '.css',
-        concatenatedJS: 'semantic' + release.versionInFileName  + '.js',
-        concatenatedMinifiedCSS: 'semantic' + release.versionInFileName  + '.min.css',
-        concatenatedMinifiedJS: 'semantic' + release.versionInFileName  + '.min.js',
-        concatenatedRTLCSS: 'semantic.rtl' + release.versionInFileName  + '.css',
-        concatenatedMinifiedRTLCSS: 'semantic.rtl' + release.versionInFileName  + '.min.css',
+        concatenatedCSS: 'semantic' + release.versionInFileName + '.css',
+        concatenatedJS: 'semantic' + release.versionInFileName + '.js',
+        concatenatedMinifiedCSS: 'semantic' + release.versionInFileName + '.min.css',
+        concatenatedMinifiedJS: 'semantic' + release.versionInFileName + '.min.js',
+        concatenatedRTLCSS: 'semantic.rtl' + release.versionInFileName + '.css',
+        concatenatedMinifiedRTLCSS: 'semantic.rtl' + release.versionInFileName + '.min.css',
     },
 
     regExp: {

--- a/tasks/config/tasks.js
+++ b/tasks/config/tasks.js
@@ -40,12 +40,12 @@ module.exports = {
     },
 
     filenames: {
-        concatenatedCSS: 'semantic.css',
-        concatenatedJS: 'semantic.js',
-        concatenatedMinifiedCSS: 'semantic.min.css',
-        concatenatedMinifiedJS: 'semantic.min.js',
-        concatenatedRTLCSS: 'semantic.rtl.css',
-        concatenatedMinifiedRTLCSS: 'semantic.rtl.min.css',
+        concatenatedCSS: 'semantic' + release.versionInFileName  + '.css',
+        concatenatedJS: 'semantic' + release.versionInFileName  + '.js',
+        concatenatedMinifiedCSS: 'semantic' + release.versionInFileName  + '.min.css',
+        concatenatedMinifiedJS: 'semantic' + release.versionInFileName  + '.min.js',
+        concatenatedRTLCSS: 'semantic.rtl' + release.versionInFileName  + '.css',
+        concatenatedMinifiedRTLCSS: 'semantic.rtl' + release.versionInFileName  + '.min.css',
     },
 
     regExp: {


### PR DESCRIPTION
 # Feature Request 

Instead of releasing the files:

```
semantic.css
semantic.js
semantic.min.css
semantic.min.js
```
optionally release the files that include the version number and an optional revision string:
```
semantic-2.9.3-a.css
semantic-2.9.3-a.js
semantic-2.9.3-a.min.css
semantic-2.9.3-a.min.js
```

The advantage is to make clear which version is currently being used, and preventing the browser cache from running an obsolete version.

This pull-request is fully backward compatible as the default behaviour does not change at all.

The change is activated in semantic.json by adding the relevant fields:

```
{
  // ...
  "permission": false,
  "autoInstall": false,
  "rtl": false,
  "includeVersionInFileName": true,          <== Here
  "revision": "a",                                           <== Optionally this, too.
  "version": "2.9.3"                                       <== version that is added.                                                                                                                                 
}
```

I can update the patch if variable names need to be changed, or to add relevant documentation.

Fixes: https://github.com/dreaming-augustin/Fomantic-UI/issues/1 