### PR TITLE
feat(build): customizable output filename

### DIFF
--- a/semantic.json.example
+++ b/semantic.json.example
@@ -16,7 +16,7 @@
     },
     "clean"        : "dist/"
   },
-  "fileName"     : "semantic",
+  "fileName"   : "semantic",
   "permission" : false,
   "autoInstall": false,
   "rtl": false

--- a/semantic.json.example
+++ b/semantic.json.example
@@ -16,7 +16,7 @@
     },
     "clean"        : "dist/"
   },
-
+  "fileName"     : "semantic",
   "permission" : false,
   "autoInstall": false,
   "rtl": false

--- a/tasks/config/defaults.js
+++ b/tasks/config/defaults.js
@@ -125,4 +125,6 @@ module.exports = {
         ignoredRTL: '!(*.min|*.map)',
     },
 
+    fileName: 'semantic',
+
 };

--- a/tasks/config/tasks.js
+++ b/tasks/config/tasks.js
@@ -40,12 +40,12 @@ module.exports = {
     },
 
     filenames: {
-        concatenatedCSS: 'semantic' + release.versionInFileName + '.css',
-        concatenatedJS: 'semantic' + release.versionInFileName + '.js',
-        concatenatedMinifiedCSS: 'semantic' + release.versionInFileName + '.min.css',
-        concatenatedMinifiedJS: 'semantic' + release.versionInFileName + '.min.js',
-        concatenatedRTLCSS: 'semantic' + release.versionInFileName + '.rtl.css',
-        concatenatedMinifiedRTLCSS: 'semantic' + release.versionInFileName + '.rtl.min.css',
+        concatenatedCSS: config.fileName + release.versionInFileName + '.css',
+        concatenatedJS: config.fileName + release.versionInFileName + '.js',
+        concatenatedMinifiedCSS: config.fileName + release.versionInFileName + '.min.css',
+        concatenatedMinifiedJS: config.fileName + release.versionInFileName + '.min.js',
+        concatenatedRTLCSS: config.fileName + release.versionInFileName + '.rtl.css',
+        concatenatedMinifiedRTLCSS: config.fileName + release.versionInFileName + '.rtl.min.css',
     },
 
     regExp: {


### PR DESCRIPTION
## Description

Support a custom filename instead of hardcoded "semantic" (which is still default).
This also prepares for a later change for the default from "semantic" to "fomantic" and a quicker fallback

