### PR TITLE
feat(calendar): "get date" can return formatted date

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -1145,7 +1145,7 @@
                     },
                     dateObjectOrFormatted: function (format, date) {
                         format = format || '';
-                        date = module.helper.sanitiseDate($module.data(metadata.date)) || null;
+                        date = module.helper.sanitiseDate(date) || null;
 
                         if (!date) {
                             return null;

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -802,28 +802,32 @@
                     formattedDate: function (format, date) {
                         return module.helper.dateFormat(format || formatter[settings.type], date || module.get.date());
                     },
-                    date: function (format = "") {
+                    date: function (format = '') {
                         if (!module.helper.sanitiseDate($module.data(metadata.date))) {
                             return null;
                         }
-                        else if (format == "") {
+
+                        if (format === '') {
                             return module.helper.sanitiseDate($module.data(metadata.date));
                         }
+
                         return module.helper.dateFormat(format, $module.data(metadata.date));
                     },
                     inputDate: function () {
                         return $input.val();
                     },
-                    focusDate: function (format = "") {
+                    focusDate: function (format = '') {
                         if (!module.helper.sanitiseDate($module.data(metadata.focusDate))) {
                             return null;
                         }
-                        else if (format == "") {
+
+                        if (format === '') {
                             return module.helper.sanitiseDate($module.data(metadata.focusDate));
                         }
+
                         return module.helper.dateFormat(format, $module.data(metadata.focusDate));
                     },
-                    startDate: function (format = "") {
+                    startDate: function (format = '') {
                         var startModule = module.get.calendarModule(settings.startCalendar);
 
                         if (startModule) {
@@ -833,12 +837,14 @@
                         if (!module.helper.sanitiseDate($module.data(metadata.startDate))) {
                             return null;
                         }
-                        else if (format == "") {
+
+                        if (format === '') {
                             return module.helper.sanitiseDate($module.data(metadata.startDate));
                         }
+
                         return module.helper.dateFormat(format, $module.data(metadata.startDate));
                     },
-                    endDate: function (format = "") {
+                    endDate: function (format = '') {
                         var endModule = module.get.calendarModule(settings.endCalendar);
 
                         if (endModule) {
@@ -848,9 +854,11 @@
                         if (!module.helper.sanitiseDate($module.data(metadata.endDate))) {
                             return null;
                         }
-                        else if (format == "") {
+
+                        if (format === '') {
                             return module.helper.sanitiseDate($module.data(metadata.endDate));
                         }
+
                         return module.helper.dateFormat(format, $module.data(metadata.endDate));
                     },
                     minDate: function () {

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -802,24 +802,56 @@
                     formattedDate: function (format, date) {
                         return module.helper.dateFormat(format || formatter[settings.type], date || module.get.date());
                     },
-                    date: function () {
-                        return module.helper.sanitiseDate($module.data(metadata.date)) || null;
+                    date: function (format = "") {
+                        if (!module.helper.sanitiseDate($module.data(metadata.date))) {
+                            return null;
+                        }
+                        else if (format == "") {
+                            return module.helper.sanitiseDate($module.data(metadata.date));
+                        }
+                        return module.helper.dateFormat(format, $module.data(metadata.date));
                     },
                     inputDate: function () {
                         return $input.val();
                     },
-                    focusDate: function () {
-                        return $module.data(metadata.focusDate) || null;
+                    focusDate: function (format = "") {
+                        if (!module.helper.sanitiseDate($module.data(metadata.focusDate))) {
+                            return null;
+                        }
+                        else if (format == "") {
+                            return module.helper.sanitiseDate($module.data(metadata.focusDate));
+                        }
+                        return module.helper.dateFormat(format, $module.data(metadata.focusDate));
                     },
-                    startDate: function () {
+                    startDate: function (format = "") {
                         var startModule = module.get.calendarModule(settings.startCalendar);
 
-                        return (startModule ? startModule.get.date() : $module.data(metadata.startDate)) || null;
+                        if (startModule) {
+                            return startModule.get.date(format);
+                        }
+
+                        if (!module.helper.sanitiseDate($module.data(metadata.startDate))) {
+                            return null;
+                        }
+                        else if (format == "") {
+                            return module.helper.sanitiseDate($module.data(metadata.startDate));
+                        }
+                        return module.helper.dateFormat(format, $module.data(metadata.startDate));
                     },
-                    endDate: function () {
+                    endDate: function (format = "") {
                         var endModule = module.get.calendarModule(settings.endCalendar);
 
-                        return (endModule ? endModule.get.date() : $module.data(metadata.endDate)) || null;
+                        if (endModule) {
+                            return endModule.get.date(format);
+                        }
+
+                        if (!module.helper.sanitiseDate($module.data(metadata.endDate))) {
+                            return null;
+                        }
+                        else if (format == "") {
+                            return module.helper.sanitiseDate($module.data(metadata.endDate));
+                        }
+                        return module.helper.dateFormat(format, $module.data(metadata.endDate));
                     },
                     minDate: function () {
                         return $module.data(metadata.minDate) || null;

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -802,64 +802,32 @@
                     formattedDate: function (format, date) {
                         return module.helper.dateFormat(format || formatter[settings.type], date || module.get.date());
                     },
-                    date: function (format = '') {
-                        if (!module.helper.sanitiseDate($module.data(metadata.date))) {
-                            return null;
-                        }
-
-                        if (format === '') {
-                            return module.helper.sanitiseDate($module.data(metadata.date));
-                        }
-
-                        return module.helper.dateFormat(format, $module.data(metadata.date));
+                    date: function (format) {
+                        return module.helper.dateObjectOrFormatted(format, $module.data(metadata.date));
                     },
                     inputDate: function () {
                         return $input.val();
                     },
-                    focusDate: function (format = '') {
-                        if (!module.helper.sanitiseDate($module.data(metadata.focusDate))) {
-                            return null;
-                        }
-
-                        if (format === '') {
-                            return module.helper.sanitiseDate($module.data(metadata.focusDate));
-                        }
-
-                        return module.helper.dateFormat(format, $module.data(metadata.focusDate));
+                    focusDate: function (format) {
+                        return module.helper.dateObjectOrFormatted(format, $module.data(metadata.focusDate));
                     },
-                    startDate: function (format = '') {
+                    startDate: function (format) {
                         var startModule = module.get.calendarModule(settings.startCalendar);
 
                         if (startModule) {
                             return startModule.get.date(format);
                         }
 
-                        if (!module.helper.sanitiseDate($module.data(metadata.startDate))) {
-                            return null;
-                        }
-
-                        if (format === '') {
-                            return module.helper.sanitiseDate($module.data(metadata.startDate));
-                        }
-
-                        return module.helper.dateFormat(format, $module.data(metadata.startDate));
+                        return module.helper.dateObjectOrFormatted(format, $module.data(metadata.startDate));
                     },
-                    endDate: function (format = '') {
+                    endDate: function (format) {
                         var endModule = module.get.calendarModule(settings.endCalendar);
 
                         if (endModule) {
                             return endModule.get.date(format);
                         }
 
-                        if (!module.helper.sanitiseDate($module.data(metadata.endDate))) {
-                            return null;
-                        }
-
-                        if (format === '') {
-                            return module.helper.sanitiseDate($module.data(metadata.endDate));
-                        }
-
-                        return module.helper.dateFormat(format, $module.data(metadata.endDate));
+                        return module.helper.dateObjectOrFormatted(format, $module.data(metadata.endDate));
                     },
                     minDate: function () {
                         return $module.data(metadata.minDate) || null;
@@ -1174,6 +1142,13 @@
 
                             return match.slice(1, -1);
                         });
+                    },
+                    dateObjectOrFormatted: function (format, date) {
+                        format = format || '';
+                        var date = module.helper.sanitiseDate($module.data(metadata.date)) || null;
+                        if (!date) return null;
+                        if (format === '') return date;
+                        return module.helper.dateFormat(format, date);
                     },
                     isDisabled: function (date, mode) {
                         return (mode === 'day' || mode === 'month' || mode === 'year' || mode === 'hour') && (((mode === 'day' && settings.disabledDaysOfWeek.indexOf(date.getDay()) !== -1) || settings.disabledDates.some(function (d) {

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -1145,9 +1145,16 @@
                     },
                     dateObjectOrFormatted: function (format, date) {
                         format = format || '';
-                        var date = module.helper.sanitiseDate($module.data(metadata.date)) || null;
-                        if (!date) return null;
-                        if (format === '') return date;
+                        date = module.helper.sanitiseDate($module.data(metadata.date)) || null;
+
+                        if (!date) {
+                            return null;
+                        }
+
+                        if (format === '') {
+                            return date;
+                        }
+
                         return module.helper.dateFormat(format, date);
                     },
                     isDisabled: function (date, mode) {


### PR DESCRIPTION
```
$('.ui.calendar').calendar('get date');
$('.ui.calendar').calendar('get focusDate');
$('.ui.calendar').calendar('get startDate');
$('.ui.calendar').calendar('get endDate');

```
could so far only return a Javascript Date object.

Now, given a `format` argument, they return a formatted date string:

```
$('.ui.calendar').calendar('get date',      "YYYY-MM-DD");
$('.ui.calendar').calendar('get focusDate', "YYYY-MM-DD");
$('.ui.calendar').calendar('get startDate', "YYYY-MM-DD");
$('.ui.calendar').calendar('get endDate',   "YYYY-MM-DD");

```

The `format` string is passed to the existing formatter.

This is backward compatible as the default behaviour does not change.

It makes it convenient for developers to get exactly what they need when they need it.
