### PR TITLE
Fix "$tab.activate.tab" called after renavigate

### DIFF
--- a/src/definitions/modules/tab.js
+++ b/src/definitions/modules/tab.js
@@ -475,11 +475,14 @@
                                     'X-Remote': true,
                                 },
                                 onSuccess: function (response) {
+                                    let $navigation = module.get.navElement(tabPath);
+                                    let isNavigationActive = $navigation.hasClass(className.active);
+
                                     if (settings.cacheType === 'response') {
                                         module.cache.add(fullTabPath, response);
                                     }
                                     module.update.content(tabPath, response);
-                                    if (tabPath == activeTabPath) {
+                                    if (isNavigationActive && tabPath == activeTabPath) {
                                         module.debug('Content loaded', tabPath);
                                         module.activate.tab(tabPath);
                                     } else {


### PR DESCRIPTION
fix #3156

Currently, the only "fetch" is invoked after https://github.com/fomantic/Fomantic-UI/blob/13b76ee714/src/definitions/modules/tab.js#L367 thus the "navigation" should be always active when the tab "is beiing activated and loading".