### PR TITLE
feat(dropdown): support submenus for selection dropdown

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -466,7 +466,7 @@ select.ui.dropdown {
         box-shadow: @selectionMenuBoxShadow;
         transition: @selectionMenuTransition;
     }
-    .ui.selection.dropdown@{notPointing}@{notFloating} .menu {
+    .ui.selection.dropdown@{notPointing}@{notFloating} > .menu {
         border-top-width: 0;
         border-radius: @selectionMenuBorderRadius;
     }
@@ -1313,7 +1313,7 @@ select.ui.dropdown {
 
     & when (@variationDropdownSelection) {
         /* Selection */
-        .ui.ui.upward.selection.dropdown@{notPointing}@{notFloating} .menu {
+        .ui.ui.upward.selection.dropdown@{notPointing}@{notFloating} > .menu {
             border-top-width: @menuBorderWidth;
             border-bottom-width: 0;
             box-shadow: @upwardSelectionMenuBoxShadow;


### PR DESCRIPTION
## Description

This PR fixes the upper/lower border of submenus when used inside a `unlimited selection dropdown` 

## Screenshots
### Before
![image](https://github.com/user-attachments/assets/c11162c7-6f71-4a5d-96df-c042922a455e)

### After
![image](https://github.com/user-attachments/assets/94e43f96-ab2a-4928-aada-23e8603a02ad)

The docs for `unlimited` should be enhanced to show that use case

## Closes
#3158 
