### PR TITLE
fix(dropdown):respect keepsearchterm on enter selection

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1620,7 +1620,7 @@
                                     module.verbose('Selecting item from keyboard shortcut', $selectedItem);
                                     module.event.item.click.call($selectedItem, event);
                                 }
-                                if (module.is.searchSelection()) {
+                                if (module.is.searchSelection() && !settings.keepSearchTerm) {
                                     module.remove.searchTerm();
                                 }
                                 if (module.is.multiple()) {


### PR DESCRIPTION
## Description
When `keepSearchTerm=true` and `allowAdditions=true` and also selecting a result item via cursor and enter key form the list, the searchterm will always be removed, which this PR fixes. 

## Testcase
- Create dropdown with class .ui, .multiple, .search, .selection, .dropdown
- Add options keepSearchTerm: true, allowAdditions: true
- Try search item and choose with enter (results still shown, search term disappear)
- Try search item and choose with mouse click (results still shown, search term still there)

### Broken
https://jsfiddle.net/1pavf7ym/

### Fixed
https://jsfiddle.net/lubber/bkdpLsnc/


## Closes
#3150 