### PR TITLE
fix(slider): resize ignored highlightrange setting

### DIFF
--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -493,7 +493,7 @@
                     resize: function (_event) {
                         // To avoid a useless performance cost, we only call the label refresh when its necessary
                         if (gapRatio !== module.get.gapRatio()) {
-                            module.setup.labels();
+                            module.resync();
                             gapRatio = module.get.gapRatio();
                         }
                     },
@@ -507,11 +507,11 @@
 
                 resync: function () {
                     module.verbose('Resyncing thumb position based on value');
+                    module.setup.labels();
                     if (module.is.range()) {
                         module.update.position(module.secondThumbVal, $secondThumb);
                     }
                     module.update.position(module.thumbVal, $thumb);
-                    module.setup.labels();
                 },
                 takeStep: function (multiplier) {
                     if (!multiplier) {


### PR DESCRIPTION
## Description
The new `highlightRange` option was visually ignored whenever the viewport triggered a resize and also the label were redrawn because of `autoAdjust:true`

## Testcase
- Watch the second example hghlightranges
- resize the viewport so the labels will change
- See the new labels are not highlighted within the selected range
- Clicking on a thumb will re-highlight them again
https://jsfiddle.net/lubber/1tvumckq/48/

