### PR TITLE
fix(dropdown): correct submenu positioning for upward pointing dropdowns

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -1815,7 +1815,7 @@ select.ui.dropdown {
 
     /* Upward pointing */
     .ui.pointing.upward.dropdown > .menu,
-    .ui.top.pointing.upward.dropdown>.menu {
+    .ui.top.pointing.upward.dropdown > .menu {
         top: auto !important;
         bottom: 100% !important;
         margin: 0 0 @pointingMenuDistance;

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -1814,15 +1814,15 @@ select.ui.dropdown {
     }
 
     /* Upward pointing */
-    .ui.pointing.upward.dropdown .menu,
-    .ui.top.pointing.upward.dropdown .menu {
+    .ui.pointing.upward.dropdown>.menu,
+    .ui.top.pointing.upward.dropdown>.menu {
         top: auto !important;
         bottom: 100% !important;
         margin: 0 0 @pointingMenuDistance;
         border-radius: @pointingUpwardMenuBorderRadius;
     }
-    .ui.pointing.upward.dropdown .menu::after,
-    .ui.top.pointing.upward.dropdown .menu::after {
+    .ui.pointing.upward.dropdown>.menu::after,
+    .ui.top.pointing.upward.dropdown>.menu::after {
         top: 100% !important;
         bottom: auto !important;
         box-shadow: @pointingUpwardArrowBoxShadow;

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -1814,14 +1814,14 @@ select.ui.dropdown {
     }
 
     /* Upward pointing */
-    .ui.pointing.upward.dropdown>.menu,
+    .ui.pointing.upward.dropdown > .menu,
     .ui.top.pointing.upward.dropdown>.menu {
         top: auto !important;
         bottom: 100% !important;
         margin: 0 0 @pointingMenuDistance;
         border-radius: @pointingUpwardMenuBorderRadius;
     }
-    .ui.pointing.upward.dropdown>.menu::after,
+    .ui.pointing.upward.dropdown > .menu::after,
     .ui.top.pointing.upward.dropdown>.menu::after {
         top: 100% !important;
         bottom: auto !important;

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -1822,7 +1822,7 @@ select.ui.dropdown {
         border-radius: @pointingUpwardMenuBorderRadius;
     }
     .ui.pointing.upward.dropdown > .menu::after,
-    .ui.top.pointing.upward.dropdown>.menu::after {
+    .ui.top.pointing.upward.dropdown > .menu::after {
         top: 100% !important;
         bottom: auto !important;
         box-shadow: @pointingUpwardArrowBoxShadow;


### PR DESCRIPTION
<!--
 Please read our Contributing Guide and Code of Conduct before you
 submit a pull request.
  
 Contributing Guide: https://github.com/fomantic/Fomantic-UI/blob/master/CONTRIBUTING.md
 Code of Conduct: https://github.com/fomantic/Fomantic-UI/blob/master/CODE_OF_CONDUCT.md

 ----

 Please use the following pull request title format:
 "[<scope>] <summary of what you fixed/changed>"
-->

## Description
<!-- Describe what you fixed/changed in great detail (required). -->
Fixes an issue where submenus of upward pointing dropdowns are misaligned.
I have limited the styling for the upward pointing menus to apply **only** to its direct child `.menu` 

## Test
<!--
  If possible create an example of your change via a JSFiddle. 

  How to create an example:
   1. Open the following JSFiddle - https://jsfiddle.net/31d6y7mn
   2. Click "Fork" at the top
   3. Add the minimum required HTML, CSS and JavaScript which shows your change
   4. Click "Save" at the top
   5. Copy the URL of your fiddle and link it here
-->
https://jsfiddle.net/ReiVanBjair/3x5r07fd/46/

## Screenshot (if possible)
<!--
  If possible include images or gifs of your issue.

  E.g. Incorrect component CSS should include an image of what the
  component looks like.
  
  If your looking for a tool we recommend ShareX - https://github.com/ShareX/ShareX
-->
![image](https://github.com/user-attachments/assets/647947b1-a5c7-461a-8d44-e32fbeecde4f)


## Closes
<!--
  List all the issues this pull request closes (only if it does).
-->
#3123 
