### PR TITLE
feat(dropdown, search): remove support check for ignoreDiacritics

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -114,11 +114,6 @@
                     if (module.is.alreadySetup()) {
                         module.setup.reference();
                     } else {
-                        if (settings.ignoreDiacritics && !String.prototype.normalize) {
-                            settings.ignoreDiacritics = false;
-                            module.error(error.noNormalize, element);
-                        }
-
                         module.create.id();
                         module.setup.layout();
 
@@ -4152,7 +4147,6 @@
             noAPI: 'The API module is required to load resources remotely',
             noStorage: 'Saving remote data requires session storage',
             noElement: 'This module requires ui {element}',
-            noNormalize: '"ignoreDiacritics" setting will be ignored. Browser does not support String().normalize(). You may consider including <https://cdn.jsdelivr.net/npm/unorm@1.4.1/lib/unorm.min.js> as a polyfill.',
         },
 
         regExp: {

--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -461,10 +461,6 @@
                             settings.fullTextSearch = parameters.searchFullText;
                             module.error(settings.error.oldSearchSyntax, element);
                         }
-                        if (settings.ignoreDiacritics && !String.prototype.normalize) {
-                            settings.ignoreDiacritics = false;
-                            module.error(error.noNormalize, element);
-                        }
                     },
                     inputEvent: function () {
                         var
@@ -1433,7 +1429,6 @@
             serverError: 'There was an issue querying the server.',
             maxResults: 'Results must be an array to use maxResults setting',
             method: 'The method you called is not defined.',
-            noNormalize: '"ignoreDiacritics" setting will be ignored. Browser does not support String().normalize(). You may consider including <https://cdn.jsdelivr.net/npm/unorm@1.4.1/lib/unorm.min.js> as a polyfill.',
         },
 
         metadata: {


### PR DESCRIPTION
## Description

Followup of #3183 
String.prototype.normalize is supported [by all major browsers](https://caniuse.com/?search=string%20normalize), so an extra check is not needed anymore