### PR TITLE
feat(dropdown): maintain a lower opacity of the clear icon unless being hovered

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -616,13 +616,17 @@ select.ui.dropdown {
         .ui.ui.selection.dropdown@{notInverted}:has(> input:focus) {
             border-color: @selectionFocusBorderColor;
             box-shadow: none;
-            & > i.icon {
+            & > i.icon:not(.remove) {
                 opacity: @selectionIconFocusOpacity;
             }
         }
     }
-    .ui.ui.selection.dropdown:focus > i.icon {
-        opacity: @selectionIconFocusOpacity;
+    .ui.ui.selection.dropdown {
+        &:focus, &:has(> input:focus) {
+            & > i.icon:not(.remove) {
+                opacity: @selectionIconFocusOpacity;
+            }
+        }
     }
 
     /* Visible */

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -622,7 +622,8 @@ select.ui.dropdown {
         }
 
         .ui.ui.selection.dropdown {
-            &:focus, &:has(> input:focus) {
+            &:focus,
+            &:has(> input:focus) {
                 & > i.icon:not(.remove) {
                     opacity: @selectionIconFocusOpacity;
                 }

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -620,11 +620,12 @@ select.ui.dropdown {
                 opacity: @selectionIconFocusOpacity;
             }
         }
-    }
-    .ui.ui.selection.dropdown {
-        &:focus, &:has(> input:focus) {
-            & > i.icon:not(.remove) {
-                opacity: @selectionIconFocusOpacity;
+
+        .ui.ui.selection.dropdown {
+            &:focus, &:has(> input:focus) {
+                & > i.icon:not(.remove) {
+                    opacity: @selectionIconFocusOpacity;
+                }
             }
         }
     }

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -628,7 +628,7 @@ select.ui.dropdown {
                     opacity: @selectionIconFocusOpacity;
                 }
                 & > i.icon.remove:not(:hover) {
-                    opacity: calc(@actionIconFocusOpacity);
+                    opacity: @actionIconFocusOpacity;
                 }
             }
         }

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -616,9 +616,6 @@ select.ui.dropdown {
         .ui.ui.selection.dropdown@{notInverted}:has(> input:focus) {
             border-color: @selectionFocusBorderColor;
             box-shadow: none;
-            & > i.icon:not(.remove) {
-                opacity: @selectionIconFocusOpacity;
-            }
         }
 
         .ui.ui.selection.dropdown {

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -627,6 +627,9 @@ select.ui.dropdown {
                 & > i.icon:not(.remove) {
                     opacity: @selectionIconFocusOpacity;
                 }
+                & > i.icon.remove:not(:hover) {
+                    opacity: calc(@actionIconFocusOpacity);
+                }
             }
         }
     }

--- a/src/themes/default/modules/dropdown.variables
+++ b/src/themes/default/modules/dropdown.variables
@@ -220,6 +220,7 @@
 @selectionVisibleIconOpacity: "";
 
 @selectionIconFocusOpacity: 1;
+@actionIconFocusOpacity: (@selectionIconFocusOpacity * 68) / 100;
 
 /* --------------
      Search

--- a/src/themes/default/modules/dropdown.variables
+++ b/src/themes/default/modules/dropdown.variables
@@ -220,7 +220,7 @@
 @selectionVisibleIconOpacity: "";
 
 @selectionIconFocusOpacity: 1;
-@actionIconFocusOpacity: (@selectionIconFocusOpacity * 68) / 100;
+@actionIconFocusOpacity: calc((@selectionIconFocusOpacity * 68) / 100);
 
 /* --------------
      Search

--- a/src/themes/default/modules/dropdown.variables
+++ b/src/themes/default/modules/dropdown.variables
@@ -220,7 +220,7 @@
 @selectionVisibleIconOpacity: "";
 
 @selectionIconFocusOpacity: 1;
-@actionIconFocusOpacity: calc((@selectionIconFocusOpacity * 68) / 100);
+@actionIconFocusOpacity: ((@selectionIconFocusOpacity * 68) / 100);
 
 /* --------------
      Search


### PR DESCRIPTION
## Description
When the dropdown allows for clearing, the clear icon should maintain a lower opacity unless it's being hovered. This improves user experience by indicating the option to clear the selection only when the user interacts with it.

## Testcase
**Current Version:** https://fomantic-ui.com/modules/dropdown.html#clearable-selection

Click the dropdown menu and check the clear icon. It displays with full opacity.

**New Version:** https://jsfiddle.net/ko2in/6gerqn2c/

Click the dropdown menu and check the clear icon. It will remain visible with low opacity until you hover the mouse over the icon.

## Screenshot
**Current Version:**
![Dropdown-Old-Feature](https://github.com/user-attachments/assets/a2d20dd8-e43c-4611-b703-d5e7ef613ba1)


**New Version:**
![Dropdown-New-Feature](https://github.com/user-attachments/assets/8be614f1-7bcd-456a-9530-56f51fbac0a7)


## Closes
#3211
