### PR TITLE
fix(dropdown): API query does not run when the dropdown is opened by pressing the down arrow key

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1757,6 +1757,7 @@
                                 }
                                 // down arrow (open menu)
                                 if (pressedKey === keys.downArrow && !module.is.visible()) {
+                                    focused = true;
                                     module.verbose('Down key pressed, showing dropdown');
                                     module.show();
                                     event.preventDefault();


### PR DESCRIPTION
## Description
When the dropdown uses API settings, it retrieves data from a remote source only if there are no items present in the dropdown.

If we press the down arrow key to open the dropdown, it doesn't execute the query method to fetch resources from remote API, if the dropdown is initialized with default values.

Naturally, the dropdown clears any existing items if it is opened by clicking the icon or focusing on the search field. But, it doesn't happen when pressing the down key. So, the dropdown remains to display the initial values without refreshing and doesn't receive the new data.

This issue is resolved by specifying the dropdown as focused when it's opened by pressing the down arrow key.

## Testcase
**Bug:** https://jsfiddle.net/5cw84dmn/

**Fix:** https://jsfiddle.net/lubber/qcnb5jg8/

## Closes
#3204
