### PR TITLE
Use "CSS.escape()" for building dynamic CSS selectors

### DIFF
--- a/src/definitions/behaviors/api.js
+++ b/src/definitions/behaviors/api.js
@@ -441,7 +441,7 @@
                                 if (!regExp.validate.test(el.name)) {
                                     return;
                                 }
-                                let isCheckbox = $('[name="' + el.name + '"]', $form).attr('type') === 'checkbox';
+                                let isCheckbox = $('[name="' + CSS.escape(el.name) + '"]', $form).attr('type') === 'checkbox';
                                 let floatValue = parseFloat(el.value);
                                 let value = (isCheckbox && el.value === 'on')
                                         || el.value === 'true'

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -599,21 +599,20 @@
                     },
                     field: function (identifier, strict, ignoreMissing) {
                         module.verbose('Finding field with identifier', identifier);
-                        identifier = module.escape.string(identifier);
                         let t;
-                        t = $field.filter('#' + identifier);
+                        t = $field.filter('#' + CSS.escape(identifier));
                         if (t.length > 0) {
                             return t;
                         }
-                        t = $field.filter('[name="' + identifier + '"]');
+                        t = $field.filter('[name="' + CSS.escape(identifier) + '"]');
                         if (t.length > 0) {
                             return t;
                         }
-                        t = $field.filter('[name="' + identifier + '[]"]');
+                        t = $field.filter('[name="' + CSS.escape(identifier) + '[]"]');
                         if (t.length > 0) {
                             return t;
                         }
-                        t = $field.filter('[data-' + metadata.validate + '="' + identifier + '"]');
+                        t = $field.filter('[data-' + metadata.validate + '="' + CSS.escape(identifier) + '"]');
                         if (t.length > 0) {
                             return t;
                         }
@@ -802,14 +801,6 @@
                         module.error(error.noElement.replace('{element}', element));
 
                         return false;
-                    },
-                },
-
-                escape: {
-                    string: function (text) {
-                        text = String(text);
-
-                        return text.replace(regExp.escape, '\\$&');
                     },
                 },
 
@@ -1098,7 +1089,7 @@
                                     module.verbose('Selecting multiple', value, $field);
                                     $element.checkbox('uncheck');
                                     $.each(value, function (index, value) {
-                                        $multipleField = $field.filter('[value="' + value + '"]');
+                                        $multipleField = $field.filter('[value="' + CSS.escape(value) + '"]');
                                         $element = $multipleField.parent();
                                         if ($multipleField.length > 0) {
                                             $element.checkbox('check');
@@ -1106,7 +1097,7 @@
                                     });
                                 } else if (isRadio) {
                                     module.verbose('Selecting radio value', value, $field);
-                                    $field.filter('[value="' + value + '"]')
+                                    $field.filter('[value="' + CSS.escape(value) + '"]')
                                         .parent(selector.uiCheckbox)
                                         .checkbox('check');
                                 } else if (isCheckbox) {

--- a/src/definitions/modules/checkbox.js
+++ b/src/definitions/modules/checkbox.js
@@ -339,7 +339,7 @@
                     radios: function () {
                         let name = module.get.name();
 
-                        return $('input[name="' + name + '"]').closest(selector.checkbox);
+                        return $('input[name="' + CSS.escape(name) + '"]').closest(selector.checkbox);
                     },
                     otherRadios: function () {
                         return module.get.radios().not($module);

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -735,7 +735,7 @@
                                 }
                                 if (module.is.multiple()) {
                                     $.each(preSelected, function (index, value) {
-                                        $item.filter('[data-' + metadata.value + '="' + value + '"]')
+                                        $item.filter('[data-' + metadata.value + '="' + CSS.escape(value) + '"]')
                                             .addClass(className.filtered);
                                     });
                                 }
@@ -2741,7 +2741,7 @@
                     },
                     optionValue: function (value) {
                         let escapedValue = module.escape.value(value);
-                        let $option = $input.find('option[value="' + module.escape.string(escapedValue) + '"]');
+                        let $option = $input.find('option[value="' + CSS.escape(escapedValue) + '"]');
                         let hasOption = $option.length > 0;
                         if (hasOption) {
                             return;
@@ -2918,7 +2918,7 @@
                     },
                     optionValue: function (value) {
                         let escapedValue = module.escape.value(value);
-                        let $option = $input.find('option[value="' + module.escape.string(escapedValue) + '"]');
+                        let $option = $input.find('option[value="' + CSS.escape(escapedValue) + '"]');
                         let hasOption = $option.length > 0;
                         if (!hasOption || !$option.hasClass(className.addition)) {
                             return;
@@ -3017,7 +3017,7 @@
                     label: function (value, shouldAnimate) {
                         let escapedValue = module.escape.value(value);
                         let $labels = $module.find(selector.label);
-                        let $removedLabel = $labels.filter('[data-' + metadata.value + '="' + module.escape.string(settings.ignoreCase ? escapedValue.toLowerCase() : escapedValue) + '"]');
+                        let $removedLabel = $labels.filter('[data-' + metadata.value + '="' + CSS.escape(settings.ignoreCase ? escapedValue.toLowerCase() : escapedValue) + '"]');
                         module.verbose('Removing label', $removedLabel);
                         $removedLabel.remove();
                     },
@@ -3134,7 +3134,7 @@
                             escapedValue = escapedValue.toLowerCase();
                         }
 
-                        return $labels.filter('[data-' + metadata.value + '="' + module.escape.string(escapedValue) + '"]').length > 0;
+                        return $labels.filter('[data-' + metadata.value + '="' + CSS.escape(escapedValue) + '"]').length > 0;
                     },
                     maxSelections: function () {
                         return settings.maxSelections && module.get.selectionCount() >= settings.maxSelections;

--- a/src/definitions/modules/tab.js
+++ b/src/definitions/modules/tab.js
@@ -254,14 +254,6 @@
                     },
                 },
 
-                escape: {
-                    string: function (text) {
-                        text = String(text);
-
-                        return text.replace(regExp.escape, '\\$&');
-                    },
-                },
-
                 set: {
                     auto: function () {
                         let url = typeof settings.path === 'string'
@@ -364,8 +356,7 @@
                             settings.onLoad.call($tab[0], currentPath, parameterArray, historyEvent);
                         } else if (tabPath.search('/') === -1 && tabPath !== '') {
                             // look for in page anchor
-                            tabPath = module.escape.string(tabPath);
-                            $anchor = $('#' + tabPath + ', a[name="' + tabPath + '"]');
+                            $anchor = $('#' + tabPath + ', a[name="' + CSS.escape(tabPath) + '"]');
                             currentPath = $anchor.closest('[data-tab]').data(metadata.tab);
                             $tab = module.get.tabElement(currentPath);
                             // if anchor exists, use parent tab
@@ -577,7 +568,7 @@
                         return module.utilities.pathToArray(module.get.defaultPath(tabPath));
                     },
                     defaultPath: function (tabPath) {
-                        let $defaultNav = $allModules.filter('[data-' + metadata.tab + '^="' + module.escape.string(tabPath) + '/"]').eq(0);
+                        let $defaultNav = $allModules.filter('[data-' + metadata.tab + '^="' + CSS.escape(tabPath) + '/"]').eq(0);
                         let defaultTab = $defaultNav.data(metadata.tab) || false;
                         if (defaultTab) {
                             module.debug('Found default tab', defaultTab);
@@ -597,7 +588,7 @@
                     navElement: function (tabPath) {
                         tabPath = tabPath || activeTabPath;
 
-                        return $allModules.filter('[data-' + metadata.tab + '="' + module.escape.string(tabPath) + '"]');
+                        return $allModules.filter('[data-' + metadata.tab + '="' + CSS.escape(tabPath) + '"]');
                     },
                     tabElement: function (tabPath) {
                         let $fullPathTab;
@@ -607,8 +598,8 @@
                         tabPath = tabPath || activeTabPath;
                         tabPathArray = module.utilities.pathToArray(tabPath);
                         lastTab = module.utilities.last(tabPathArray);
-                        $fullPathTab = $tabs.filter('[data-' + metadata.tab + '="' + module.escape.string(tabPath) + '"]');
-                        $simplePathTab = $tabs.filter('[data-' + metadata.tab + '="' + module.escape.string(lastTab) + '"]');
+                        $fullPathTab = $tabs.filter('[data-' + metadata.tab + '="' + CSS.escape(tabPath) + '"]');
+                        $simplePathTab = $tabs.filter('[data-' + metadata.tab + '="' + CSS.escape(lastTab) + '"]');
 
                         return $fullPathTab.length > 0
                             ? $fullPathTab
@@ -628,7 +619,7 @@
 
                             if ($tab.hasClass(className.active)) {
                                 let tabPath = $(this).data(metadata.tab);
-                                let $anchor = $allModules.filter('[data-' + metadata.tab + '="' + module.escape.string(tabPath) + '"]');
+                                let $anchor = $allModules.filter('[data-' + metadata.tab + '="' + CSS.escape(tabPath) + '"]');
 
                                 if ($anchor.hasClass(className.active)) {
                                     activeTab = tabPath;

--- a/src/definitions/modules/tab.js
+++ b/src/definitions/modules/tab.js
@@ -356,7 +356,7 @@
                             settings.onLoad.call($tab[0], currentPath, parameterArray, historyEvent);
                         } else if (tabPath.search('/') === -1 && tabPath !== '') {
                             // look for in page anchor
-                            $anchor = $('#' + tabPath + ', a[name="' + CSS.escape(tabPath) + '"]');
+                            $anchor = $('#' + CSS.escape(tabPath) + ', a[name="' + CSS.escape(tabPath) + '"]');
                             currentPath = $anchor.closest('[data-tab]').data(metadata.tab);
                             $tab = module.get.tabElement(currentPath);
                             // if anchor exists, use parent tab


### PR DESCRIPTION
extracted from #3205

Values in CSS selectors should never be dequoted (this is lossy operation), but instead of escaped using native CSS.escape(). This is described in https://developer.mozilla.org/en-US/docs/Web/API/CSS/escape_static#in_context_uses.

Under normal usage this PR should imply no function change.