### PR TITLE
feat(emoji): new default for variationEmojiNoColons is false

### DIFF
--- a/src/themes/default/globals/variation.variables
+++ b/src/themes/default/globals/variation.variables
@@ -789,7 +789,7 @@
 
 /* Emojis */
 @variationEmojiColons: true;
-@variationEmojiNoColons: true;
+@variationEmojiNoColons: false;
 @variationEmojiDisabled: true;
 @variationEmojiLoading: true;
 @variationEmojiLink: true;


### PR DESCRIPTION
## Description
As mentioned in https://github.com/fomantic/Fomantic-UI/discussions/3148#discussioncomment-12515513

This will heavily reduce CSS. The colons variant is preferred because widely used as standard definitions whenever used inside text and also because the fomantic docs selector ever since delivered the colons version

This is a BREAKING CHANGE as projects using no Colons emojis either need to 
- rebuild fomantic using `@variationEmojiNoColons: true` or
- change their code to add colons infront and after the emoji name