### PR TITLE
HTML escape should accept only string and null

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -3544,6 +3544,9 @@
                         return text.replace(regExp.escape, '\\$&');
                     },
                     htmlEntities: function (string) {
+                        if (string === null) {
+                            string = '';
+                        }
                         console.assert(typeof string === 'string');
 
                         const escapeMap = {
@@ -3969,6 +3972,9 @@
     /* Templates */
     $.fn.dropdown.settings.templates = {
         escape: function (string, settings) {
+            if (string === null) {
+                string = '';
+            }
             console.assert(typeof string === 'string');
 
             if (settings !== undefined && settings.preserveHTML) {

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -3552,7 +3552,7 @@
                             '>': '&gt;',
                         };
 
-                        return String(string).replace(/["&'<>]/g, (chr) => escapeMap[chr]);
+                        return string.replace(/["&'<>]/g, (chr) => escapeMap[chr]);
                     },
 
                     // https://github.com/fomantic/Fomantic-UI/issues/2782
@@ -3979,7 +3979,7 @@
                 '>': '&gt;',
             };
 
-            return String(string).replace(/["&'<>]/g, (chr) => escapeMap[chr]);
+            return string.replace(/["&'<>]/g, (chr) => escapeMap[chr]);
         },
         // generates dropdown from select values
         dropdown: function (select, settings) {

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -3544,6 +3544,8 @@
                         return text.replace(regExp.escape, '\\$&');
                     },
                     htmlEntities: function (string) {
+                        console.assert(typeof string === 'string');
+
                         const escapeMap = {
                             '"': '&quot;',
                             '&': '&amp;',
@@ -3967,6 +3969,8 @@
     /* Templates */
     $.fn.dropdown.settings.templates = {
         escape: function (string, settings) {
+            console.assert(typeof string === 'string');
+
             if (settings !== undefined && settings.preserveHTML) {
                 return string;
             }

--- a/src/definitions/modules/embed.js
+++ b/src/definitions/modules/embed.js
@@ -612,6 +612,8 @@
 
         templates: {
             escape: function (string) {
+                console.assert(typeof string === 'string');
+
                 const escapeMap = {
                     '"': '&quot;',
                     '&': '&amp;',

--- a/src/definitions/modules/embed.js
+++ b/src/definitions/modules/embed.js
@@ -612,6 +612,9 @@
 
         templates: {
             escape: function (string) {
+                if (string === null) {
+                    string = '';
+                }
                 console.assert(typeof string === 'string');
 
                 const escapeMap = {

--- a/src/definitions/modules/embed.js
+++ b/src/definitions/modules/embed.js
@@ -620,7 +620,7 @@
                     '>': '&gt;',
                 };
 
-                return String(string).replace(/["&'<>]/g, (chr) => escapeMap[chr]);
+                return string.replace(/["&'<>]/g, (chr) => escapeMap[chr]);
             },
             iframe: function (url, parameters) {
                 let src = url;

--- a/src/definitions/modules/flyout.js
+++ b/src/definitions/modules/flyout.js
@@ -1019,6 +1019,9 @@
 
                 helpers: {
                     escape: function (string, settings) {
+                        if (string === null) {
+                            string = '';
+                        }
                         console.assert(typeof string === 'string');
 
                         if (settings !== undefined && settings.preserveHTML) {

--- a/src/definitions/modules/flyout.js
+++ b/src/definitions/modules/flyout.js
@@ -1031,7 +1031,7 @@
                             '>': '&gt;',
                         };
 
-                        return String(string).replace(/["&'<>]/g, (chr) => escapeMap[chr]);
+                        return string.replace(/["&'<>]/g, (chr) => escapeMap[chr]);
                     },
                 },
 

--- a/src/definitions/modules/flyout.js
+++ b/src/definitions/modules/flyout.js
@@ -1019,6 +1019,8 @@
 
                 helpers: {
                     escape: function (string, settings) {
+                        console.assert(typeof string === 'string');
+
                         if (settings !== undefined && settings.preserveHTML) {
                             return string;
                         }

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -882,7 +882,7 @@
                             '>': '&gt;',
                         };
 
-                        return String(string).replace(/["&'<>]/g, (chr) => escapeMap[chr]);
+                        return string.replace(/["&'<>]/g, (chr) => escapeMap[chr]);
                     },
                 },
                 can: {

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -870,6 +870,9 @@
                 },
                 helpers: {
                     escape: function (string, settings) {
+                        if (string === null) {
+                            string = '';
+                        }
                         console.assert(typeof string === 'string');
 
                         if (settings !== undefined && settings.preserveHTML) {

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -870,6 +870,8 @@
                 },
                 helpers: {
                     escape: function (string, settings) {
+                        console.assert(typeof string === 'string');
+
                         if (settings !== undefined && settings.preserveHTML) {
                             return string;
                         }

--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -1463,7 +1463,7 @@
                     '>': '&gt;',
                 };
 
-                return String(string).replace(/["&'<>]/g, (chr) => escapeMap[chr]);
+                return string.replace(/["&'<>]/g, (chr) => escapeMap[chr]);
             },
             popup: function (text) {
                 let html = '';

--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -1455,6 +1455,9 @@
 
         templates: {
             escape: function (string) {
+                if (string === null) {
+                    string = '';
+                }
                 console.assert(typeof string === 'string');
 
                 const escapeMap = {

--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -1455,6 +1455,8 @@
 
         templates: {
             escape: function (string) {
+                console.assert(typeof string === 'string');
+
                 const escapeMap = {
                     '"': '&quot;',
                     '&': '&amp;',

--- a/src/definitions/modules/rating.js
+++ b/src/definitions/modules/rating.js
@@ -488,7 +488,7 @@
                     '>': '&gt;',
                 };
 
-                return String(string).replace(/["&'<>]/g, (chr) => escapeMap[chr]);
+                return string.replace(/["&'<>]/g, (chr) => escapeMap[chr]);
             },
             icon: function (maxRating, iconClass) {
                 let icon = 1;

--- a/src/definitions/modules/rating.js
+++ b/src/definitions/modules/rating.js
@@ -480,6 +480,9 @@
 
         templates: {
             escape: function (string) {
+                if (string === null) {
+                    string = '';
+                }
                 console.assert(typeof string === 'string');
 
                 const escapeMap = {

--- a/src/definitions/modules/rating.js
+++ b/src/definitions/modules/rating.js
@@ -480,6 +480,8 @@
 
         templates: {
             escape: function (string) {
+                console.assert(typeof string === 'string');
+
                 const escapeMap = {
                     '"': '&quot;',
                     '&': '&amp;',

--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -1384,6 +1384,8 @@
 
         templates: {
             escape: function (string, settings) {
+                console.assert(typeof string === 'string');
+
                 if (settings !== undefined && settings.preserveHTML) {
                     return string;
                 }

--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -1396,7 +1396,7 @@
                     '>': '&gt;',
                 };
 
-                string = String(string).replace(/["&'<>]/g, (chr) => escapeMap[chr]);
+                string = string.replace(/["&'<>]/g, (chr) => escapeMap[chr]);
 
                 // FUI controlled HTML is still allowed
                 string = string.replace(/&lt;(\/)*mark&gt;/g, '<$1mark>');

--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -1384,6 +1384,9 @@
 
         templates: {
             escape: function (string, settings) {
+                if (string === null) {
+                    string = '';
+                }
                 console.assert(typeof string === 'string');
 
                 if (settings !== undefined && settings.preserveHTML) {

--- a/src/definitions/modules/toast.js
+++ b/src/definitions/modules/toast.js
@@ -577,6 +577,8 @@
                         return result;
                     },
                     escape: function (string, settings) {
+                        console.assert(typeof string === 'string');
+
                         if (settings !== undefined && settings.preserveHTML) {
                             return string;
                         }

--- a/src/definitions/modules/toast.js
+++ b/src/definitions/modules/toast.js
@@ -589,7 +589,7 @@
                             '>': '&gt;',
                         };
 
-                        return String(string).replace(/["&'<>]/g, (chr) => escapeMap[chr]);
+                        return string.replace(/["&'<>]/g, (chr) => escapeMap[chr]);
                     },
                 },
 

--- a/src/definitions/modules/toast.js
+++ b/src/definitions/modules/toast.js
@@ -577,6 +577,9 @@
                         return result;
                     },
                     escape: function (string, settings) {
+                        if (string === null) {
+                            string = '';
+                        }
                         console.assert(typeof string === 'string');
 
                         if (settings !== undefined && settings.preserveHTML) {


### PR DESCRIPTION
#3222 fixes missing `number.replace` function well, but `null` type is converted to `"null"`. `""` is mostly wanted to be displayed instead.

`undefined` is converted to `"undefined"`. But most `undefined` cases are handled explicitly and values passed using `setting.someValue` should always be defined. Thus do not have to handle this case in general.

Casting `object` or `array` types using `String()` is bad and should never be done.