### PR TITLE
feat(chore): remove check for mutationoberserver support

### DIFF
--- a/src/definitions/behaviors/visibility.js
+++ b/src/definitions/behaviors/visibility.js
@@ -138,19 +138,17 @@
                 },
 
                 observeChanges: function () {
-                    if ('MutationObserver' in window) {
-                        contextObserver = new MutationObserver(module.event.contextChanged);
-                        observer = new MutationObserver(module.event.changed);
-                        contextObserver.observe(document, {
-                            childList: true,
-                            subtree: true,
-                        });
-                        observer.observe(element, {
-                            childList: true,
-                            subtree: true,
-                        });
-                        module.debug('Setting up mutation observer', observer);
-                    }
+                    contextObserver = new MutationObserver(module.event.contextChanged);
+                    observer = new MutationObserver(module.event.changed);
+                    contextObserver.observe(document, {
+                        childList: true,
+                        subtree: true,
+                    });
+                    observer.observe(element, {
+                        childList: true,
+                        subtree: true,
+                    });
+                    module.debug('Setting up mutation observer', observer);
                 },
 
                 bind: {

--- a/src/definitions/modules/accordion.js
+++ b/src/definitions/modules/accordion.js
@@ -82,17 +82,15 @@
                 },
 
                 observeChanges: function () {
-                    if ('MutationObserver' in window) {
-                        observer = new MutationObserver(function (mutations) {
-                            module.debug('DOM tree modified, updating selector cache');
-                            module.refresh();
-                        });
-                        observer.observe(element, {
-                            childList: true,
-                            subtree: true,
-                        });
-                        module.debug('Setting up mutation observer', observer);
-                    }
+                    observer = new MutationObserver(function (mutations) {
+                        module.debug('DOM tree modified, updating selector cache');
+                        module.refresh();
+                    });
+                    observer.observe(element, {
+                        childList: true,
+                        subtree: true,
+                    });
+                    module.debug('Setting up mutation observer', observer);
                 },
 
                 bind: {

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -732,11 +732,9 @@
                 },
 
                 observeChanges: function () {
-                    if ('MutationObserver' in window) {
-                        classObserver = new MutationObserver(module.event.class.mutation);
-                        module.debug('Setting up mutation observer', classObserver);
-                        module.observe.class();
-                    }
+                    classObserver = new MutationObserver(module.event.class.mutation);
+                    module.debug('Setting up mutation observer', classObserver);
+                    module.observe.class();
                 },
 
                 disconnect: {

--- a/src/definitions/modules/checkbox.js
+++ b/src/definitions/modules/checkbox.js
@@ -129,17 +129,15 @@
                 },
 
                 observeChanges: function () {
-                    if ('MutationObserver' in window) {
-                        observer = new MutationObserver(function (mutations) {
-                            module.debug('DOM tree modified, updating selector cache');
-                            module.refresh();
-                        });
-                        observer.observe(element, {
-                            childList: true,
-                            subtree: true,
-                        });
-                        module.debug('Setting up mutation observer', observer);
-                    }
+                    observer = new MutationObserver(function (mutations) {
+                        module.debug('DOM tree modified, updating selector cache');
+                        module.refresh();
+                    });
+                    observer.observe(element, {
+                        childList: true,
+                        subtree: true,
+                    });
+                    module.debug('Setting up mutation observer', observer);
                 },
 
                 attachEvents: function (selector, event) {

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -160,15 +160,13 @@
                 },
 
                 observeChanges: function () {
-                    if ('MutationObserver' in window) {
-                        selectObserver = new MutationObserver(module.event.select.mutation);
-                        menuObserver = new MutationObserver(module.event.menu.mutation);
-                        classObserver = new MutationObserver(module.event.class.mutation);
-                        module.debug('Setting up mutation observer', selectObserver, menuObserver, classObserver);
-                        module.observe.select();
-                        module.observe.menu();
-                        module.observe.class();
-                    }
+                    selectObserver = new MutationObserver(module.event.select.mutation);
+                    menuObserver = new MutationObserver(module.event.menu.mutation);
+                    classObserver = new MutationObserver(module.event.class.mutation);
+                    module.debug('Setting up mutation observer', selectObserver, menuObserver, classObserver);
+                    module.observe.select();
+                    module.observe.menu();
+                    module.observe.class();
                 },
 
                 disconnect: {

--- a/src/definitions/modules/flyout.js
+++ b/src/definitions/modules/flyout.js
@@ -445,52 +445,50 @@
                     },
                 },
                 observeChanges: function () {
-                    if ('MutationObserver' in window) {
-                        observer = new MutationObserver(function (mutations) {
-                            let collectNodes = function (parent) {
-                                let nodes = [];
-                                for (let c = 0, cl = parent.length; c < cl; c++) {
-                                    Array.prototype.push.apply(nodes, collectNodes(parent[c].childNodes));
-                                    nodes.push(parent[c]);
-                                }
-
-                                return nodes;
-                            };
-                            let shouldRefreshInputs = false;
-                            let ignoreAutofocus = true;
-                            mutations.every(function (mutation) {
-                                if (mutation.type === 'attributes') {
-                                    if (observeAttributes && (mutation.attributeName === 'disabled' || $(mutation.target).find(':input').addBack(':input').filter(':visible').length > 0)) {
-                                        shouldRefreshInputs = true;
-                                    }
-                                } else {
-                                    // mutationobserver only provides the parent nodes,
-                                    // so let's collect all childs as well to find nested inputs
-                                    let $addedInputs = $(collectNodes(mutation.addedNodes)).filter('a[href], [tabindex], :input:enabled').filter(':visible');
-                                    let $removedInputs = $(collectNodes(mutation.removedNodes)).filter('a[href], [tabindex], :input');
-                                    if ($addedInputs.length > 0 || $removedInputs.length > 0) {
-                                        shouldRefreshInputs = true;
-                                        if ($addedInputs.filter(':input').length > 0 || $removedInputs.filter(':input').length > 0) {
-                                            ignoreAutofocus = false;
-                                        }
-                                    }
-                                }
-
-                                return !shouldRefreshInputs;
-                            });
-
-                            if (shouldRefreshInputs) {
-                                module.refreshInputs(ignoreAutofocus);
+                    observer = new MutationObserver(function (mutations) {
+                        let collectNodes = function (parent) {
+                            let nodes = [];
+                            for (let c = 0, cl = parent.length; c < cl; c++) {
+                                Array.prototype.push.apply(nodes, collectNodes(parent[c].childNodes));
+                                nodes.push(parent[c]);
                             }
+
+                            return nodes;
+                        };
+                        let shouldRefreshInputs = false;
+                        let ignoreAutofocus = true;
+                        mutations.every(function (mutation) {
+                            if (mutation.type === 'attributes') {
+                                if (observeAttributes && (mutation.attributeName === 'disabled' || $(mutation.target).find(':input').addBack(':input').filter(':visible').length > 0)) {
+                                    shouldRefreshInputs = true;
+                                }
+                            } else {
+                                // mutationobserver only provides the parent nodes,
+                                // so let's collect all childs as well to find nested inputs
+                                let $addedInputs = $(collectNodes(mutation.addedNodes)).filter('a[href], [tabindex], :input:enabled').filter(':visible');
+                                let $removedInputs = $(collectNodes(mutation.removedNodes)).filter('a[href], [tabindex], :input');
+                                if ($addedInputs.length > 0 || $removedInputs.length > 0) {
+                                    shouldRefreshInputs = true;
+                                    if ($addedInputs.filter(':input').length > 0 || $removedInputs.filter(':input').length > 0) {
+                                        ignoreAutofocus = false;
+                                    }
+                                }
+                            }
+
+                            return !shouldRefreshInputs;
                         });
-                        observer.observe(element, {
-                            attributeFilter: ['class', 'disabled'],
-                            attributes: true,
-                            childList: true,
-                            subtree: true,
-                        });
-                        module.debug('Setting up mutation observer', observer);
-                    }
+
+                        if (shouldRefreshInputs) {
+                            module.refreshInputs(ignoreAutofocus);
+                        }
+                    });
+                    observer.observe(element, {
+                        attributeFilter: ['class', 'disabled'],
+                        attributes: true,
+                        childList: true,
+                        subtree: true,
+                    });
+                    module.debug('Setting up mutation observer', observer);
                 },
                 refresh: function () {
                     module.verbose('Refreshing selector cache');

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -252,58 +252,56 @@
                 },
 
                 observeChanges: function () {
-                    if ('MutationObserver' in window) {
-                        observer = new MutationObserver(function (mutations) {
-                            let collectNodes = function (parent) {
-                                let nodes = [];
-                                for (let c = 0, cl = parent.length; c < cl; c++) {
-                                    Array.prototype.push.apply(nodes, collectNodes(parent[c].childNodes));
-                                    nodes.push(parent[c]);
-                                }
+                    observer = new MutationObserver(function (mutations) {
+                        let collectNodes = function (parent) {
+                            let nodes = [];
+                            for (let c = 0, cl = parent.length; c < cl; c++) {
+                                Array.prototype.push.apply(nodes, collectNodes(parent[c].childNodes));
+                                nodes.push(parent[c]);
+                            }
 
-                                return nodes;
-                            };
-                            let shouldRefresh = false;
-                            let shouldRefreshInputs = false;
-                            let ignoreAutofocus = true;
-                            mutations.every(function (mutation) {
-                                if (mutation.type === 'attributes') {
-                                    if (observeAttributes && (mutation.attributeName === 'disabled' || $(mutation.target).find(':input').addBack(':input').filter(':visible').length > 0)) {
-                                        shouldRefreshInputs = true;
-                                    }
-                                } else {
-                                    shouldRefresh = true;
-                                    // mutationobserver only provides the parent nodes,
-                                    // so let's collect all childs as well to find nested inputs
-                                    let $addedInputs = $(collectNodes(mutation.addedNodes)).filter('a[href], [tabindex], :input:enabled').filter(':visible');
-                                    let $removedInputs = $(collectNodes(mutation.removedNodes)).filter('a[href], [tabindex], :input');
-                                    if ($addedInputs.length > 0 || $removedInputs.length > 0) {
-                                        shouldRefreshInputs = true;
-                                        if ($addedInputs.filter(':input').length > 0 || $removedInputs.filter(':input').length > 0) {
-                                            ignoreAutofocus = false;
-                                        }
+                            return nodes;
+                        };
+                        let shouldRefresh = false;
+                        let shouldRefreshInputs = false;
+                        let ignoreAutofocus = true;
+                        mutations.every(function (mutation) {
+                            if (mutation.type === 'attributes') {
+                                if (observeAttributes && (mutation.attributeName === 'disabled' || $(mutation.target).find(':input').addBack(':input').filter(':visible').length > 0)) {
+                                    shouldRefreshInputs = true;
+                                }
+                            } else {
+                                shouldRefresh = true;
+                                // mutationobserver only provides the parent nodes,
+                                // so let's collect all childs as well to find nested inputs
+                                let $addedInputs = $(collectNodes(mutation.addedNodes)).filter('a[href], [tabindex], :input:enabled').filter(':visible');
+                                let $removedInputs = $(collectNodes(mutation.removedNodes)).filter('a[href], [tabindex], :input');
+                                if ($addedInputs.length > 0 || $removedInputs.length > 0) {
+                                    shouldRefreshInputs = true;
+                                    if ($addedInputs.filter(':input').length > 0 || $removedInputs.filter(':input').length > 0) {
+                                        ignoreAutofocus = false;
                                     }
                                 }
-
-                                return !shouldRefreshInputs;
-                            });
-
-                            if (shouldRefresh && settings.observeChanges) {
-                                module.debug('DOM tree modified, refreshing');
-                                module.refresh();
                             }
-                            if (shouldRefreshInputs) {
-                                module.refreshInputs(ignoreAutofocus);
-                            }
+
+                            return !shouldRefreshInputs;
                         });
-                        observer.observe(element, {
-                            attributeFilter: ['class', 'disabled'],
-                            attributes: true,
-                            childList: true,
-                            subtree: true,
-                        });
-                        module.debug('Setting up mutation observer', observer);
-                    }
+
+                        if (shouldRefresh && settings.observeChanges) {
+                            module.debug('DOM tree modified, refreshing');
+                            module.refresh();
+                        }
+                        if (shouldRefreshInputs) {
+                            module.refreshInputs(ignoreAutofocus);
+                        }
+                    });
+                    observer.observe(element, {
+                        attributeFilter: ['class', 'disabled'],
+                        attributes: true,
+                        childList: true,
+                        subtree: true,
+                    });
+                    module.debug('Setting up mutation observer', observer);
                 },
 
                 refresh: function () {

--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -109,14 +109,12 @@
                 },
 
                 observeChanges: function () {
-                    if ('MutationObserver' in window) {
-                        documentObserver = new MutationObserver(module.event.documentChanged);
-                        documentObserver.observe(document, {
-                            childList: true,
-                            subtree: true,
-                        });
-                        module.debug('Setting up mutation observer', documentObserver);
-                    }
+                    documentObserver = new MutationObserver(module.event.documentChanged);
+                    documentObserver.observe(document, {
+                        childList: true,
+                        subtree: true,
+                    });
+                    module.debug('Setting up mutation observer', documentObserver);
                 },
 
                 refresh: function () {

--- a/src/definitions/modules/sticky.js
+++ b/src/definitions/modules/sticky.js
@@ -112,23 +112,21 @@
                 },
 
                 observeChanges: function () {
-                    if ('MutationObserver' in window) {
-                        documentObserver = new MutationObserver(module.event.documentChanged);
-                        observer = new MutationObserver(module.event.changed);
-                        documentObserver.observe(document, {
-                            childList: true,
-                            subtree: true,
-                        });
-                        observer.observe(element, {
-                            childList: true,
-                            subtree: true,
-                        });
-                        observer.observe($context[0], {
-                            childList: true,
-                            subtree: true,
-                        });
-                        module.debug('Setting up mutation observer', observer);
-                    }
+                    documentObserver = new MutationObserver(module.event.documentChanged);
+                    observer = new MutationObserver(module.event.changed);
+                    documentObserver.observe(document, {
+                        childList: true,
+                        subtree: true,
+                    });
+                    observer.observe(element, {
+                        childList: true,
+                        subtree: true,
+                    });
+                    observer.observe($context[0], {
+                        childList: true,
+                        subtree: true,
+                    });
+                    module.debug('Setting up mutation observer', observer);
                 },
 
                 determineContainer: function () {


### PR DESCRIPTION
## Description

Followup of #3183 
This PR removes the check for MutationOberserver support as [all browser since IE11 are supporting it](https://caniuse.com/?search=mutationobserver)

