### PR TITLE
Fix lossy HTML escape in all modules

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1955,7 +1955,7 @@
                             .find('option')
                             .each(function () {
                                 let $option = $(this);
-                                let name = module.escape.assumeUnescapedAmpersand($option.html());
+                                let name = module.escape.assumeUnescapedAmpLtGt($option.html());
                                 let disabled = $option.attr('disabled');
                                 let value = $option.attr('value') !== undefined
                                     ? $option.attr('value')
@@ -3557,13 +3557,13 @@
                     },
 
                     // https://github.com/fomantic/Fomantic-UI/issues/2782
-                    // https://jsfiddle.net/wdyjfvz0/
-                    assumeUnescapedAmpersand: function (string) {
+                    // https://jsfiddle.net/3efL7jnt/
+                    assumeUnescapedAmpLtGt: function (string) {
                         if (settings.preserveHTML) {
                             return string;
                         }
 
-                        return string.replaceAll('&amp;', '&');
+                        return string.replaceAll('&amp;', '&').replaceAll('&lt;', '<').replaceAll('&gt;', '>');
                     },
                 },
 

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -3562,7 +3562,13 @@
                             return string;
                         }
 
-                        return string.replaceAll('&amp;', '&').replaceAll('&lt;', '<').replaceAll('&gt;', '>');
+                        const unescapeMap = {
+                            '&amp;': '&',
+                            '&lt;': '<',
+                            '&gt;': '>',
+                        };
+
+                        return string.replace(/&(?:amp|lt|gt);/g, (v) => unescapeMap[v]);
                     },
                 },
 

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -3563,7 +3563,7 @@
                             return string;
                         }
 
-                        return string.replace('&amp;', '&');
+                        return string.replaceAll('&amp;', '&');
                     },
                 },
 

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -3544,8 +3544,7 @@
                         return text.replace(regExp.escape, '\\$&');
                     },
                     htmlEntities: function (string) {
-                        const badChars = /["&'<>]/g;
-                        const escape = {
+                        const escapeMap = {
                             '"': '&quot;',
                             '&': '&amp;',
                             "'": '&apos;',
@@ -3553,7 +3552,7 @@
                             '>': '&gt;',
                         };
 
-                        return String(string).replace(badChars, (chr) => escape[chr]);
+                        return String(string).replace(/["&'<>]/g, (chr) => escapeMap[chr]);
                     },
 
                     // https://github.com/fomantic/Fomantic-UI/issues/2782
@@ -3966,8 +3965,7 @@
                 return string;
             }
 
-            const badChars = /["&'<>]/g;
-            const escape = {
+            const escapeMap = {
                 '"': '&quot;',
                 '&': '&amp;',
                 "'": '&apos;',
@@ -3975,7 +3973,7 @@
                 '>': '&gt;',
             };
 
-            return String(string).replace(badChars, (chr) => escape[chr]);
+            return String(string).replace(/["&'<>]/g, (chr) => escapeMap[chr]);
         },
         // generates dropdown from select values
         dropdown: function (select, settings) {

--- a/src/definitions/modules/embed.js
+++ b/src/definitions/modules/embed.js
@@ -612,7 +612,7 @@
 
         templates: {
             escape: function (string) {
-                const badChars = /["'<>]|&(?![\d#A-Za-z]{1,12};)/g;
+                const badChars = /["&'<>]/g;
                 const escape = {
                     '"': '&quot;',
                     '&': '&amp;',

--- a/src/definitions/modules/embed.js
+++ b/src/definitions/modules/embed.js
@@ -612,8 +612,7 @@
 
         templates: {
             escape: function (string) {
-                const badChars = /["&'<>]/g;
-                const escape = {
+                const escapeMap = {
                     '"': '&quot;',
                     '&': '&amp;',
                     "'": '&apos;',
@@ -621,7 +620,7 @@
                     '>': '&gt;',
                 };
 
-                return String(string).replace(badChars, (chr) => escape[chr]);
+                return String(string).replace(/["&'<>]/g, (chr) => escapeMap[chr]);
             },
             iframe: function (url, parameters) {
                 let src = url;

--- a/src/definitions/modules/flyout.js
+++ b/src/definitions/modules/flyout.js
@@ -1023,7 +1023,7 @@
                             return string;
                         }
 
-                        const badChars = /["'<>]|&(?![\d#A-Za-z]{1,12};)/g;
+                        const badChars = /["&'<>]/g;
                         const escape = {
                             '"': '&quot;',
                             '&': '&amp;',

--- a/src/definitions/modules/flyout.js
+++ b/src/definitions/modules/flyout.js
@@ -1023,8 +1023,7 @@
                             return string;
                         }
 
-                        const badChars = /["&'<>]/g;
-                        const escape = {
+                        const escapeMap = {
                             '"': '&quot;',
                             '&': '&amp;',
                             "'": '&apos;',
@@ -1032,7 +1031,7 @@
                             '>': '&gt;',
                         };
 
-                        return String(string).replace(badChars, (chr) => escape[chr]);
+                        return String(string).replace(/["&'<>]/g, (chr) => escapeMap[chr]);
                     },
                 },
 

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -874,7 +874,7 @@
                             return string;
                         }
 
-                        const badChars = /["'<>]|&(?![\d#A-Za-z]{1,12};)/g;
+                        const badChars = /["&'<>]/g;
                         const escape = {
                             '"': '&quot;',
                             '&': '&amp;',

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -874,8 +874,7 @@
                             return string;
                         }
 
-                        const badChars = /["&'<>]/g;
-                        const escape = {
+                        const escapeMap = {
                             '"': '&quot;',
                             '&': '&amp;',
                             "'": '&apos;',
@@ -883,7 +882,7 @@
                             '>': '&gt;',
                         };
 
-                        return String(string).replace(badChars, (chr) => escape[chr]);
+                        return String(string).replace(/["&'<>]/g, (chr) => escapeMap[chr]);
                     },
                 },
                 can: {

--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -1455,7 +1455,7 @@
 
         templates: {
             escape: function (string) {
-                const badChars = /["'<>]|&(?![\d#A-Za-z]{1,12};)/g;
+                const badChars = /["&'<>]/g;
                 const escape = {
                     '"': '&quot;',
                     '&': '&amp;',

--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -1455,8 +1455,7 @@
 
         templates: {
             escape: function (string) {
-                const badChars = /["&'<>]/g;
-                const escape = {
+                const escapeMap = {
                     '"': '&quot;',
                     '&': '&amp;',
                     "'": '&apos;',
@@ -1464,7 +1463,7 @@
                     '>': '&gt;',
                 };
 
-                return String(string).replace(badChars, (chr) => escape[chr]);
+                return String(string).replace(/["&'<>]/g, (chr) => escapeMap[chr]);
             },
             popup: function (text) {
                 let html = '';

--- a/src/definitions/modules/rating.js
+++ b/src/definitions/modules/rating.js
@@ -480,8 +480,7 @@
 
         templates: {
             escape: function (string) {
-                const badChars = /["&'<>]/g;
-                const escape = {
+                const escapeMap = {
                     '"': '&quot;',
                     '&': '&amp;',
                     "'": '&apos;',
@@ -489,7 +488,7 @@
                     '>': '&gt;',
                 };
 
-                return String(string).replace(badChars, (chr) => escape[chr]);
+                return String(string).replace(/["&'<>]/g, (chr) => escapeMap[chr]);
             },
             icon: function (maxRating, iconClass) {
                 let icon = 1;

--- a/src/definitions/modules/rating.js
+++ b/src/definitions/modules/rating.js
@@ -480,7 +480,7 @@
 
         templates: {
             escape: function (string) {
-                const badChars = /["'<>]|&(?![\d#A-Za-z]{1,12};)/g;
+                const badChars = /["&'<>]/g;
                 const escape = {
                     '"': '&quot;',
                     '&': '&amp;',

--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -1388,8 +1388,7 @@
                     return string;
                 }
 
-                const badChars = /["&'<>]/g;
-                const escape = {
+                const escapeMap = {
                     '"': '&quot;',
                     '&': '&amp;',
                     "'": '&apos;',
@@ -1397,7 +1396,7 @@
                     '>': '&gt;',
                 };
 
-                string = String(string).replace(badChars, (chr) => escape[chr]);
+                string = String(string).replace(/["&'<>]/g, (chr) => escapeMap[chr]);
 
                 // FUI controlled HTML is still allowed
                 string = string.replace(/&lt;(\/)*mark&gt;/g, '<$1mark>');

--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -1388,7 +1388,7 @@
                     return string;
                 }
 
-                const badChars = /["'<>]|&(?![\d#A-Za-z]{1,12};)/g;
+                const badChars = /["&'<>]/g;
                 const escape = {
                     '"': '&quot;',
                     '&': '&amp;',

--- a/src/definitions/modules/toast.js
+++ b/src/definitions/modules/toast.js
@@ -581,7 +581,7 @@
                             return string;
                         }
 
-                        const badChars = /["'<>]|&(?![\d#A-Za-z]{1,12};)/g;
+                        const badChars = /["&'<>]/g;
                         const escape = {
                             '"': '&quot;',
                             '&': '&amp;',

--- a/src/definitions/modules/toast.js
+++ b/src/definitions/modules/toast.js
@@ -581,8 +581,7 @@
                             return string;
                         }
 
-                        const badChars = /["&'<>]/g;
-                        const escape = {
+                        const escapeMap = {
                             '"': '&quot;',
                             '&': '&amp;',
                             "'": '&apos;',
@@ -590,7 +589,7 @@
                             '>': '&gt;',
                         };
 
-                        return String(string).replace(badChars, (chr) => escape[chr]);
+                        return String(string).replace(/["&'<>]/g, (chr) => escapeMap[chr]);
                     },
                 },
 


### PR DESCRIPTION
as discussed in https://github.com/fomantic/Fomantic-UI/pull/3205#discussion_r2014886407

The first 2 commits fix #3224.

The remaining commits are relanding postponed https://github.com/fomantic/Fomantic-UI/pull/3224/commits/8590c2101875d0158960ccb9135b87469dc40008. I checked all `escape(` usages in each module. Text like `&amp;` should be always encoded into `&amp;amp;` as the meaning is to encode the input and the input is never from innerHTML.