### PR TITLE
fix(table): inverted basic table background

### DIFF
--- a/src/definitions/collections/table.less
+++ b/src/definitions/collections/table.less
@@ -1667,19 +1667,19 @@
     .ui.basic.table > tfoot {
         box-shadow: none;
     }
-    .ui.basic.table > thead > tr > th,
-    .ui.basic.table > tbody > tr > th,
-    .ui.basic.table > tfoot > tr > th,
-    .ui.basic.table > tr > th {
+    .ui.ui.basic.table > thead > tr > th,
+    .ui.ui.basic.table > tbody > tr > th,
+    .ui.ui.basic.table > tfoot > tr > th,
+    .ui.ui.basic.table > tr > th {
         background: @basicTableHeaderBackground;
         border-left: @basicTableHeaderDivider;
     }
     .ui.basic.table > tbody > tr {
         border-bottom: @basicTableCellBorder;
     }
-    .ui.basic.table > tbody > tr > td,
-    .ui.basic.table > tfoot > tr > td,
-    .ui.basic.table > tr > td {
+    .ui.ui.basic.table > tbody > tr > td,
+    .ui.ui.basic.table > tfoot > tr > td,
+    .ui.ui.basic.table > tr > td {
         background: @basicTableCellBackground;
     }
     & when (@variationTableStriped) {


### PR DESCRIPTION
## Description
`inverted basic table` table cells needed more specificity to override the background color in its header/footer elements

## Testcase
Remove CSS to see issue
https://jsfiddle.net/yjgb6e3v/

## Closes
#3251

