### PR TITLE
fix(dropdown): keep object values as string

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1852,6 +1852,11 @@
                             return range.text.length - rangeLength;
                         }
                     },
+                    stringValue: function (value) {
+                        return typeof value === 'object'
+                            ? JSON.stringify(value)
+                            : String(value);
+                    },
                     value: function () {
                         let value = $input.length > 0
                             ? $input.val()
@@ -1923,7 +1928,7 @@
                         let choiceValue = $choice.data(metadata.value);
 
                         return choiceValue !== undefined
-                            ? JSON.stringify(choiceValue)
+                            ? module.get.stringValue(choiceValue)
                             : (typeof choiceText === 'string'
                                 ? String(
                                     settings.ignoreSearchCase
@@ -2539,10 +2544,10 @@
                         let hasInput = $input.length > 0;
                         let currentValue = module.get.values();
                         let stringValue = value !== undefined
-                            ? JSON.stringify(value)
+                            ? module.get.stringValue(value)
                             : value;
                         if (hasInput) {
-                            if (!settings.allowReselection && stringValue === JSON.stringify(currentValue)) {
+                            if (!settings.allowReselection && stringValue === module.get.stringValue(currentValue)) {
                                 module.verbose('Skipping value update already same value', value, currentValue);
                                 if (!module.is.initialLoad()) {
                                     return;

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1920,9 +1920,10 @@
                         if (!$choice) {
                             return false;
                         }
+                        let choiceValue = $choice.data(metadata.value);
 
-                        return $choice.data(metadata.value) !== undefined
-                            ? String($choice.data(metadata.value))
+                        return choiceValue !== undefined
+                            ? JSON.stringify(choiceValue)
                             : (typeof choiceText === 'string'
                                 ? String(
                                     settings.ignoreSearchCase
@@ -2538,10 +2539,10 @@
                         let hasInput = $input.length > 0;
                         let currentValue = module.get.values();
                         let stringValue = value !== undefined
-                            ? String(value)
+                            ? JSON.stringify(value)
                             : value;
                         if (hasInput) {
-                            if (!settings.allowReselection && stringValue == currentValue) {
+                            if (!settings.allowReselection && stringValue === JSON.stringify(currentValue)) {
                                 module.verbose('Skipping value update already same value', value, currentValue);
                                 if (!module.is.initialLoad()) {
                                     return;


### PR DESCRIPTION
## Description
If a JSON value was used as a dropdown item value, it was internally broken as the value was casted to String resulting into `[object Object]`
Now, having multiple JSON values for more than 1 dropdown item the value couldn't be compared / set correctly as each values had the same `[object Object]`.
This PR fixes it by replacing the simple castings to JSON stringify which keeps the value structure so the dropdown items keep their unique value

## Testcase
- Open console
- Select "Option A"
- check the debug log for "Updating input value"

### Broken
https://jsfiddle.net/ReiVanBjair/ry4123z0/11/

### Fixed
https://jsfiddle.net/lubber/L0ysfoqj/

## Screenshots
### Broken
![image](https://github.com/user-attachments/assets/f7cf860d-6447-4277-a3e1-7f9bca3918aa)

### Fixed
![image](https://github.com/user-attachments/assets/40750374-4467-4265-b7cd-46514f561ae4)

## Closes
#3005