### PR TITLE
fix(button): stackable needs fluid for 100% width

### DIFF
--- a/src/definitions/elements/button.less
+++ b/src/definitions/elements/button.less
@@ -658,7 +658,6 @@
     @media only screen and (max-width: @largestMobileScreen) {
         .ui.stackable.buttons {
             flex-direction: column;
-            width: 100%;
             & .button:first-child {
                 border-bottom-left-radius: 0;
                 border-top-right-radius: @borderRadius;


### PR DESCRIPTION
## Description

Stackable buttons always had a 100% width on mobile. While this might work in most cases, it doesnt when multiple buttons groups are used in the same row like `floated` buttons.

This PR removes the forced 100% width on mobile. If one needs to still have them being 100% wide, the `fluid` class is needed (which will evenly divide such buttons on non-mobile as well but doesnt break the ui appearance). Therefore i tag this as breaking change

## Testcase
- Upper example uses `fluid`, the second one doesnt
- Adjust the viewport to switch between mobile and desktop size
https://jsfiddle.net/lubber/1b2mr0tz/5/

## Closes
#3266
