### PR TITLE
fix(label): resolve the overlap issue during the image transition

### DIFF
--- a/src/definitions/elements/label.less
+++ b/src/definitions/elements/label.less
@@ -471,6 +471,7 @@ a.ui.label {
     .ui.card .image > .ribbon.label {
         position: absolute;
         top: @ribbonImageTopDistance;
+        z-index: 1;
     }
     .ui.card .image > .ui.ribbon.label,
     .ui.image > .ui.ribbon.label {


### PR DESCRIPTION
## Description
When using the ribbon label for the image card that features a visibility transition effect for lazy loading, it was observed that the ribbon label was partially overlapped by the image during the transition. This occurred because the ribbon is positioned absolutely without z-index value, which results the sibling image element to overlap.

This PR sets z-index value to the ribbon label within the image card which resolve the overlap issue.

## Testcase
**Before**: https://jsfiddle.net/spjeqh47/3/
**After**: https://jsfiddle.net/ko2in/9sma0c3z/

## Screenshot
| Before | After |
| ----------- | ----------- |
| ![fui-label-bug](https://github.com/user-attachments/assets/6e3b6cc5-b84a-4412-8d71-dcfa59a04c62) | ![fui-label-fixed](https://github.com/user-attachments/assets/fe492d5b-9fd3-41fe-ae24-7ce8a26df9e2) |

## Closes
#3279
