### PR TITLE
fix(reveal): Add background and width to content

### DIFF
--- a/src/definitions/elements/reveal.less
+++ b/src/definitions/elements/reveal.less
@@ -155,6 +155,7 @@
 
     .ui.move.reveal > .content {
         display: block;
+        width: 100%;
         float: left;
         white-space: normal;
         margin: 0;

--- a/src/definitions/elements/reveal.less
+++ b/src/definitions/elements/reveal.less
@@ -28,6 +28,7 @@
 }
 
 .ui.reveal > .visible.content {
+    background: #fff;
     position: absolute !important;
     top: 0 !important;
     left: 0 !important;


### PR DESCRIPTION
<!--
 Please read our Contributing Guide and Code of Conduct before you
 submit a pull request.
  
 Contributing Guide: https://github.com/fomantic/Fomantic-UI/blob/master/CONTRIBUTING.md
 Code of Conduct: https://github.com/fomantic/Fomantic-UI/blob/master/CODE_OF_CONDUCT.md

 ----

 Please use the following pull request title format:
 "[<scope>] <summary of what you fixed/changed>"
-->

## Description
This PR fix transparent background on visible content that makes hidden content displayed as well and add default width to the content so it will fully hidden on hover.

Add `background` to `.ui.reveal>.visible.content` and `width` to `.ui.move.reveal>.content`

## Testcase
https://jsfiddle.net/w80avgu9/9/


## Closes
#3292 
