### PR TITLE
fix(dropdown): support selected values in nested menus

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1009,15 +1009,21 @@
                         let menuConfig = {};
                         menuConfig[fields.values] = values;
                         module.setup.menu(menuConfig);
-                        $.each(values, function (index, item) {
-                            if (item.selected === true) {
-                                module.debug('Setting initial selection to', item[fields.value]);
-                                module.set.selected(item[fields.value]);
-                                if (!module.is.multiple()) {
-                                    return false;
+                        let findSelected = function (values) {
+                            $.each(values, function (index, item) {
+                                let itemType = item.type || 'item';
+                                if (item.selected === true) {
+                                    module.debug('Setting initial selection to', item[fields.value]);
+                                    module.set.selected(item[fields.value]);
+                                    if (!module.is.multiple()) {
+                                        return false;
+                                    }
+                                } else if (itemType.indexOf('menu') !== -1) {
+                                    return findSelected(item.values || []);
                                 }
-                            }
-                        });
+                            });
+                        };
+                        findSelected(values);
 
                         if (module.has.selectInput()) {
                             module.disconnect.selectObserver();

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1010,18 +1010,23 @@
                         menuConfig[fields.values] = values;
                         module.setup.menu(menuConfig);
                         let findSelected = function (values) {
+                            let hasMultiple = true;
                             $.each(values, function (index, item) {
                                 let itemType = item.type || 'item';
                                 if (item.selected === true) {
                                     module.debug('Setting initial selection to', item[fields.value]);
                                     module.set.selected(item[fields.value]);
                                     if (!module.is.multiple()) {
-                                        return false;
+                                        hasMultiple = false;
                                     }
                                 } else if (itemType.indexOf('menu') !== -1) {
-                                    return findSelected(item.values || []);
+                                    hasMultiple = findSelected(item.values || []);
                                 }
+
+                                return hasMultiple;
                             });
+
+                            return hasMultiple;
                         };
                         findSelected(values);
 


### PR DESCRIPTION
## Description
If given values contain submenus and an item is declared as selected inside a submenu, such items were ignored and not shown inside the dropdown as selected.

## Testcase
### Broken
No preselected value
https://jsfiddle.net/lubber/Lpru6omj/3/

### Fixed
"Baby" is selected
https://jsfiddle.net/lubber/Lpru6omj/5/

## Closes
#3299 