### PR TITLE
fix(modal, flyout, sidebar): remove style, if initial bodymargin was 0

### DIFF
--- a/src/definitions/modules/flyout.js
+++ b/src/definitions/modules/flyout.js
@@ -81,7 +81,8 @@
             let ignoreRepeatedEvents = false;
             let isBody = $context[0] === $body[0];
             let initialBodyMargin = '';
-            let tempBodyMargin = '';
+            let initialBodyMarginInt = 0;
+            let tempBodyMargin = 0;
             let hadScrollbar = false;
             let windowRefocused = false;
 
@@ -936,9 +937,9 @@
                     },
                     bodyMargin: function () {
                         initialBodyMargin = $context.css((isBody ? 'margin-' : 'padding-') + (module.can.leftBodyScrollbar() ? 'left' : 'right'));
-                        let bodyMarginRightPixel = parseInt(initialBodyMargin.replace(/[^\d.]/g, ''), 10);
+                        initialBodyMarginInt = parseInt(initialBodyMargin.replace(/[^\d.]/g, ''), 10);
                         let bodyScrollbarWidth = isBody ? window.innerWidth - document.documentElement.clientWidth : $context[0].offsetWidth - $context[0].clientWidth;
-                        tempBodyMargin = bodyMarginRightPixel + bodyScrollbarWidth;
+                        tempBodyMargin = initialBodyMarginInt + bodyScrollbarWidth;
                     },
                 },
 
@@ -1008,7 +1009,7 @@
                     },
                     bodyMargin: function () {
                         let position = module.can.leftBodyScrollbar() ? 'left' : 'right';
-                        $context.css((isBody ? 'margin-' : 'padding-') + position, initialBodyMargin);
+                        $context.css((isBody ? 'margin-' : 'padding-') + position, initialBodyMarginInt === 0 ? '' : initialBodyMargin);
                         $context.find(selector.bodyFixed.replace('right', position)).each(function () {
                             let el = $(this);
                             let attribute = el.css('position') === 'fixed' ? 'padding-' + position : position;

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -82,7 +82,8 @@
             let initialMouseDownInModal;
             let initialMouseDownInScrollbar;
             let initialBodyMargin = '';
-            let tempBodyMargin = '';
+            let initialBodyMarginInt = 0;
+            let tempBodyMargin = 0;
             let keepScrollingClass = false;
             let hadScrollbar = false;
             let windowRefocused = false;
@@ -779,9 +780,9 @@
                     },
                     bodyMargin: function () {
                         initialBodyMargin = $context.css((isBody ? 'margin-' : 'padding-') + (module.can.leftBodyScrollbar() ? 'left' : 'right'));
-                        let bodyMarginRightPixel = parseInt(initialBodyMargin.replace(/[^\d.]/g, ''), 10);
+                        initialBodyMarginInt = parseInt(initialBodyMargin.replace(/[^\d.]/g, ''), 10);
                         let bodyScrollbarWidth = isBody ? window.innerWidth - document.documentElement.clientWidth : $context[0].offsetWidth - $context[0].clientWidth;
-                        tempBodyMargin = bodyMarginRightPixel + bodyScrollbarWidth;
+                        tempBodyMargin = initialBodyMarginInt + bodyScrollbarWidth;
                     },
                 },
 
@@ -793,7 +794,7 @@
                     },
                     bodyMargin: function () {
                         let position = module.can.leftBodyScrollbar() ? 'left' : 'right';
-                        $context.css((isBody ? 'margin-' : 'padding-') + position, initialBodyMargin);
+                        $context.css((isBody ? 'margin-' : 'padding-') + position, initialBodyMarginInt === 0 ? '' : initialBodyMargin);
                         $context.find(selector.bodyFixed.replace('right', position)).each(function () {
                             let el = $(this);
                             let attribute = el.css('position') === 'fixed' ? 'padding-' + position : position;

--- a/src/definitions/modules/sidebar.js
+++ b/src/definitions/modules/sidebar.js
@@ -78,7 +78,8 @@
             let id;
             let currentScroll;
             let initialBodyMargin = '';
-            let tempBodyMargin = '';
+            let initialBodyMarginInt = 0;
+            let tempBodyMargin = 0;
             let hadScrollbar = false;
 
             let module;
@@ -325,9 +326,9 @@
                 save: {
                     bodyMargin: function () {
                         initialBodyMargin = $context.css((isBody ? 'margin-' : 'padding-') + (module.can.leftBodyScrollbar() ? 'left' : 'right'));
-                        let bodyMarginRightPixel = parseInt(initialBodyMargin.replace(/[^\d.]/g, ''), 10);
+                        initialBodyMarginInt = parseInt(initialBodyMargin.replace(/[^\d.]/g, ''), 10);
                         let bodyScrollbarWidth = isBody ? window.innerWidth - document.documentElement.clientWidth : $context[0].offsetWidth - $context[0].clientWidth;
-                        tempBodyMargin = bodyMarginRightPixel + bodyScrollbarWidth;
+                        tempBodyMargin = initialBodyMarginInt + bodyScrollbarWidth;
                     },
                 },
                 show: function (callback) {
@@ -626,7 +627,7 @@
                 restore: {
                     bodyMargin: function () {
                         let position = module.can.leftBodyScrollbar() ? 'left' : 'right';
-                        $context.css((isBody ? 'margin-' : 'padding-') + position, initialBodyMargin);
+                        $context.css((isBody ? 'margin-' : 'padding-') + position, initialBodyMarginInt === 0 ? '' : initialBodyMargin);
                         $context.find(selector.bodyFixed.replace('right', position)).each(function () {
                             let el = $(this);
                             let attribute = el.css('position') === 'fixed' ? 'padding-' + position : position;


### PR DESCRIPTION
## Description

When a modal/flyout/sidebar is opened, it adjusts the body (or context) margin to avoid moving the modal by the width of a possible scrollbar.
When the modal closes, it reverts the value back to the initial one.
However, the default of margin/padding if 0, so there is no need to keep the inline style to 0. Instead the style attribute can be simply removed. This solves some issues in cases people use custom classes which adjusts the body margin as well

## Closes
#3303