### PR TITLE
feat(lint): modern rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -93,7 +93,6 @@ module.exports = {
         'unicorn/no-array-for-each': 'off',
         'unicorn/prefer-code-point': 'off',
         'unicorn/prefer-number-properties': 'off',
-        'unicorn/prefer-optional-catch-binding': 'off',
         'unicorn/prefer-reflect-apply': 'off',
         'unicorn/prefer-top-level-await': 'off', // needs Node 14+
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -86,7 +86,6 @@ module.exports = {
         'no-restricted-globals': 'off',
         'no-restricted-properties': 'off',
         'prefer-const': 'off',
-        'prefer-exponentiation-operator': 'off',
         'unicorn/no-array-for-each': 'off',
         'unicorn/no-for-loop': 'off', // autofixes to "for of"
         'unicorn/prefer-code-point': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,7 +41,6 @@ module.exports = {
         'linebreak-style': ['error', 'unix'],
         'max-len': 'off',
         'no-console': 'off',
-        'no-continue': 'off',
         'no-lonely-if': 'off',
         'no-nested-ternary': 'off',
         'no-param-reassign': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -91,7 +91,6 @@ module.exports = {
         'no-restricted-properties': 'off',
         'prefer-const': 'off',
         'unicorn/no-array-for-each': 'off',
-        'unicorn/prefer-code-point': 'off',
         'unicorn/prefer-number-properties': 'off',
         'unicorn/prefer-reflect-apply': 'off',
         'unicorn/prefer-top-level-await': 'off', // needs Node 14+

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -91,13 +91,11 @@ module.exports = {
         'no-restricted-properties': 'off',
         'prefer-const': 'off',
         'unicorn/no-array-for-each': 'off',
-        'unicorn/no-for-loop': 'off', // autofixes to "for of"
         'unicorn/prefer-code-point': 'off',
         'unicorn/prefer-number-properties': 'off',
         'unicorn/prefer-optional-catch-binding': 'off',
         'unicorn/prefer-reflect-apply': 'off',
         'unicorn/prefer-top-level-await': 'off', // needs Node 14+
-        'vars-on-top': 'off',
 
         // TODO rules with a lot of errors to be fixed manually, fix in a separate PR
         eqeqeq: 'off', // about 20 errors to be fixed manually

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -82,7 +82,6 @@ module.exports = {
         'wrap-iife': ['error', 'inside'],
 
         // TODO rules to be removed/fixed in v2.10.0 as fixes are not compatible with IE11
-        'guard-for-in': 'off', // refactor to "for of"
         'no-restricted-globals': 'off',
         'no-restricted-properties': 'off',
         'prefer-const': 'off',

--- a/src/definitions/behaviors/api.js
+++ b/src/definitions/behaviors/api.js
@@ -130,7 +130,7 @@
                         if (response !== undefined && typeof response === 'string') {
                             try {
                                 response = JSON.parse(response);
-                            } catch (e) {
+                            } catch {
                                 // isn't json string
                             }
                         }

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -1700,7 +1700,6 @@
                 let isDateOnly = !settings.type.includes('time');
 
                 let words = text.split(settings.regExp.dateWords);
-                let word;
                 let numbers = text.split(settings.regExp.dateNumbers);
                 let number;
 
@@ -1738,8 +1737,7 @@
 
                 if (!isTimeOnly) {
                     // textual month
-                    for (i = 0; i < words.length; i++) {
-                        word = words[i];
+                    for (const word of words) {
                         if (word.length > 0) {
                             for (j = 0; j < settings.text.months.length; j++) {
                                 monthString = settings.text.months[j];

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -1234,9 +1234,7 @@
                     },
                     findDayAsObject: function (date, mode, dates) {
                         if (mode === 'day' || mode === 'month' || mode === 'year') {
-                            let d;
-                            for (let i = 0; i < dates.length; i++) {
-                                d = dates[i];
+                            for (let d of dates) {
                                 if (typeof d === 'string') {
                                     d = module.helper.sanitiseDate(d);
                                 }
@@ -1290,7 +1288,6 @@
                     },
                     findHourAsObject: function (date, mode, hours) {
                         if (mode === 'hour') {
-                            let d;
                             let hourCheck = function (date, d) {
                                 if (d[metadata.hours]) {
                                     if (typeof d[metadata.hours] === 'number' && date.getHours() === d[metadata.hours]) {
@@ -1303,8 +1300,7 @@
                                     }
                                 }
                             };
-                            for (let i = 0; i < hours.length; i++) {
-                                d = hours[i];
+                            for (let d of hours) {
                                 if (typeof d === 'number' && date.getHours() === d) {
                                     return null;
                                 }

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -864,7 +864,7 @@
                             document.createEvent('TouchEvent');
 
                             return true;
-                        } catch (e) {
+                        } catch {
                             return false;
                         }
                     },

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -1744,30 +1744,26 @@
                     // textual month
                     for (i = 0; i < words.length; i++) {
                         word = words[i];
-                        if (word.length <= 0) {
-                            continue;
-                        }
-                        for (j = 0; j < settings.text.months.length; j++) {
-                            monthString = settings.text.months[j];
-                            monthString = monthString.slice(0, word.length).toLowerCase();
-                            if (monthString === word) {
-                                month = j + 1;
+                        if (word.length > 0) {
+                            for (j = 0; j < settings.text.months.length; j++) {
+                                monthString = settings.text.months[j];
+                                monthString = monthString.slice(0, word.length).toLowerCase();
+                                if (monthString === word) {
+                                    month = j + 1;
 
+                                    break;
+                                }
+                            }
+                            if (month >= 0) {
                                 break;
                             }
-                        }
-                        if (month >= 0) {
-                            break;
                         }
                     }
 
                     // year > settings.centuryBreak
                     for (i = 0; i < numbers.length; i++) {
                         j = parseInt(numbers[i], 10);
-                        if (isNaN(j)) {
-                            continue;
-                        }
-                        if (j >= settings.centuryBreak && i === numbers.length - 1) {
+                        if (!isNaN(j) && j >= settings.centuryBreak && i === numbers.length - 1) {
                             if (j <= 99) {
                                 j += settings.currentCentury - 100;
                             }
@@ -1785,10 +1781,7 @@
                                 ? i
                                 : (i === 1 ? 0 : 1);
                             j = parseInt(numbers[k], 10);
-                            if (isNaN(j)) {
-                                continue;
-                            }
-                            if (j >= 1 && j <= 12) {
+                            if (!isNaN(j) && j >= 1 && j <= 12) {
                                 month = j;
                                 numbers.splice(k, 1);
 
@@ -1800,10 +1793,7 @@
                     // day
                     for (i = 0; i < numbers.length; i++) {
                         j = parseInt(numbers[i], 10);
-                        if (isNaN(j)) {
-                            continue;
-                        }
-                        if (j >= 1 && j <= 31) {
+                        if (!isNaN(j) && j >= 1 && j <= 31) {
                             day = j;
                             numbers.splice(i, 1);
 
@@ -1815,16 +1805,15 @@
                     if (year < 0) {
                         for (i = numbers.length - 1; i >= 0; i--) {
                             j = parseInt(numbers[i], 10);
-                            if (isNaN(j)) {
-                                continue;
-                            }
-                            if (j <= 99) {
-                                j += settings.currentCentury;
-                            }
-                            year = j;
-                            numbers.splice(i, 1);
+                            if (!isNaN(j)) {
+                                if (j <= 99) {
+                                    j += settings.currentCentury;
+                                }
+                                year = j;
+                                numbers.splice(i, 1);
 
-                            break;
+                                break;
+                            }
                         }
                     }
                 }
@@ -1834,10 +1823,7 @@
                     if (hour < 0) {
                         for (i = 0; i < numbers.length; i++) {
                             j = parseInt(numbers[i], 10);
-                            if (isNaN(j)) {
-                                continue;
-                            }
-                            if (j >= 0 && j <= 23) {
+                            if (!isNaN(j) && j >= 0 && j <= 23) {
                                 hour = j;
                                 numbers.splice(i, 1);
 
@@ -1850,10 +1836,7 @@
                     if (minute < 0) {
                         for (i = 0; i < numbers.length; i++) {
                             j = parseInt(numbers[i], 10);
-                            if (isNaN(j)) {
-                                continue;
-                            }
-                            if (j >= 0 && j <= 59) {
+                            if (!isNaN(j) && j >= 0 && j <= 59) {
                                 minute = j;
                                 numbers.splice(i, 1);
 

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -938,9 +938,9 @@
                     }
                     for (let characterIndex = 0, nextCharacterIndex = 0; characterIndex < queryLength; characterIndex++) {
                         let continueSearch = false;
-                        let queryCharacter = query.charCodeAt(characterIndex);
+                        let queryCharacter = query.codePointAt(characterIndex);
                         while (nextCharacterIndex < termLength) {
-                            if (term.charCodeAt(nextCharacterIndex++) === queryCharacter) {
+                            if (term.codePointAt(nextCharacterIndex++) === queryCharacter) {
                                 continueSearch = true;
 
                                 break;
@@ -1659,7 +1659,7 @@
                             }
                         } else {
                             if (!module.has.search()) {
-                                module.set.selectedLetter(String.fromCharCode(pressedKey));
+                                module.set.selectedLetter(String.fromCodePoint(pressedKey));
                             }
                         }
                     },

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -3992,9 +3992,11 @@
                     let dataKey;
                     let dataKeyEscaped;
                     for (dataKey in dataObject) {
-                        dataKeyEscaped = String(dataKey).replace(/\W/g, '');
-                        if (Object.prototype.hasOwnProperty.call(dataObject, dataKey) && !['text', 'value'].includes(dataKeyEscaped.toLowerCase())) {
-                            maybeData += ' data-' + dataKeyEscaped + '="' + escape(String(dataObject[dataKey])) + '"';
+                        if (Object.prototype.hasOwnProperty.call(dataObject, dataKey)) {
+                            dataKeyEscaped = String(dataKey).replace(/\W/g, '');
+                            if (!['text', 'value'].includes(dataKeyEscaped.toLowerCase())) {
+                                maybeData += ' data-' + dataKeyEscaped + '="' + escape(String(dataObject[dataKey])) + '"';
+                            }
                         }
                     }
                 }

--- a/src/definitions/modules/embed.js
+++ b/src/definitions/modules/embed.js
@@ -289,7 +289,9 @@
                         let urlString = [];
                         let index;
                         for (index in parameters) {
-                            urlString.push(encodeURIComponent(index) + '=' + encodeURIComponent(parameters[index]));
+                            if (Object.prototype.hasOwnProperty.call(parameters, index)) {
+                                urlString.push(encodeURIComponent(index) + '=' + encodeURIComponent(parameters[index]));
+                            }
                         }
 
                         return urlString.join('&amp;');

--- a/src/definitions/modules/flyout.js
+++ b/src/definitions/modules/flyout.js
@@ -449,8 +449,8 @@
                     observer = new MutationObserver(function (mutations) {
                         let collectNodes = function (parent) {
                             let nodes = [];
-                            for (let c = 0, cl = parent.length; c < cl; c++) {
-                                nodes.push(...collectNodes(parent[c].childNodes), parent[c]);
+                            for (const c of parent) {
+                                nodes.push(...collectNodes(c.childNodes), c);
                             }
 
                             return nodes;

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -256,8 +256,8 @@
                     observer = new MutationObserver(function (mutations) {
                         let collectNodes = function (parent) {
                             let nodes = [];
-                            for (let c = 0, cl = parent.length; c < cl; c++) {
-                                nodes.push(...collectNodes(parent[c].childNodes), parent[c]);
+                            for (const c of parent) {
+                                nodes.push(...collectNodes(c.childNodes), c);
                             }
 
                             return nodes;

--- a/src/definitions/modules/nag.js
+++ b/src/definitions/modules/nag.js
@@ -205,8 +205,8 @@
                             },
                             getItem: function (key) {
                                 let cookies = document.cookie.split('; ');
-                                for (let i = 0, il = cookies.length; i < il; i++) {
-                                    let parts = cookies[i].split('=');
+                                for (const c of cookies) {
+                                    let parts = c.split('=');
                                     let foundKey = parts[0].replace(/(%[\da-f]{2})+/gi, decodeURIComponent);
                                     if (key === foundKey) {
                                         return parts[1] || '';

--- a/src/definitions/modules/progress.js
+++ b/src/definitions/modules/progress.js
@@ -92,7 +92,7 @@
                             if (ratio > 1) {
                                 break;
                             }
-                            precision = Math.pow(10, precisionPower++);
+                            precision = 10 ** precisionPower++;
                         }
 
                         return precision;

--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -675,11 +675,9 @@
                 },
                 wordSearch: function (query, term, matchAll) {
                     let allWords = query.split(/\s+/);
-                    let w;
-                    let wL = allWords.length;
                     let found = false;
-                    for (w = 0; w < wL; w++) {
-                        found = module.exactSearch(allWords[w], term);
+                    for (const w of allWords) {
+                        found = module.exactSearch(w, term);
                         if ((!found && matchAll) || (found && !matchAll)) {
                             break;
                         }

--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -1526,7 +1526,7 @@
 
     $.extend($.easing, {
         easeOutExpo: function (x) {
-            return x === 1 ? 1 : 1 - Math.pow(2, -10 * x);
+            return x === 1 ? 1 : 1 - 2 ** (-10 * x);
         },
     });
 })(jQuery, window, document);

--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -705,9 +705,9 @@
                     }
                     for (let characterIndex = 0, nextCharacterIndex = 0; characterIndex < queryLength; characterIndex++) {
                         let continueSearch = false;
-                        let queryCharacter = query.charCodeAt(characterIndex);
+                        let queryCharacter = query.codePointAt(characterIndex);
                         while (nextCharacterIndex < termLength) {
-                            if (term.charCodeAt(nextCharacterIndex++) === queryCharacter) {
+                            if (term.codePointAt(nextCharacterIndex++) === queryCharacter) {
                                 continueSearch = true;
 
                                 break;
@@ -828,7 +828,7 @@
                         let id;
                         if (categoryIndex !== undefined) {
                             // start char code for "A"
-                            letterID = String.fromCharCode(97 + categoryIndex);
+                            letterID = String.fromCodePoint(97 + categoryIndex);
                             id = letterID + resultID;
                             module.verbose('Creating category result id', id);
                         } else {

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -897,9 +897,9 @@
                         if (event.type === 'touchmove' || event.type === 'touchend') {
                             let touchEvent = event.touches ? event : event.originalEvent;
                             let touch = touchEvent.changedTouches[0]; // fall back to first touch if correct touch not found
-                            for (let i = 0; i < touchEvent.touches.length; i++) {
-                                if (touchEvent.touches[i].identifier === touchIdentifier) {
-                                    touch = touchEvent.touches[i];
+                            for (const t of touchEvent.touches) {
+                                if (t.identifier === touchIdentifier) {
+                                    touch = t;
 
                                     break;
                                 }

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -665,7 +665,7 @@
                             } else {
                                 decimalPlaces = settings.decimalPlaces;
                             }
-                            let precision = Math.pow(10, decimalPlaces);
+                            let precision = 10 ** decimalPlaces;
                             module.debug('Precision determined', precision);
                             module.cache.precision = precision;
                         }

--- a/tasks/admin/components/create.js
+++ b/tasks/admin/components/create.js
@@ -38,12 +38,9 @@ const version = project.version;
 const output = config.paths.output;
 
 module.exports = function (callback) {
-    let index;
     let tasks = [];
 
-    for (index in release.components) {
-        let component = release.components[index];
-
+    for (const component of release.components) {
         // streams... designed to save time and make coding fun...
         (function (component) {
             let outputDirectory = path.join(release.outputRoot, component);

--- a/tasks/admin/distributions/create.js
+++ b/tasks/admin/distributions/create.js
@@ -30,12 +30,9 @@ const project = require('../../config/project/release');
 const version = project.version;
 
 module.exports = function (callback) {
-    let index;
     let tasks = [];
 
-    for (index in release.distributions) {
-        let distribution = release.distributions[index];
-
+    for (const distribution of release.distributions) {
         // streams... designed to save time and make coding fun...
         (function (distribution) {
             let distLowerCase = distribution.toLowerCase();
@@ -83,13 +80,7 @@ module.exports = function (callback) {
 
             // spaces out list correctly
             createList = function (files) {
-                let filenames = '';
-                for (let file in files) {
-                    filenames += "'" + files[file] + "'"
-                        + (file === files.length - 1 ? '' : ',\n    ');
-                }
-
-                return filenames;
+                return files.map((f) => "'" + f + "'").join(',\n    ');
             };
 
             tasks.push(function () {

--- a/tasks/config/project/release.js
+++ b/tasks/config/project/release.js
@@ -19,7 +19,7 @@ config = requireDotFile('semantic.json', process.cwd());
 
 try {
     npmPackage = require('../../../package.json'); // eslint-disable-line global-require
-} catch (error) {
+} catch {
     // generate fake package
     npmPackage = {
         name: 'Unknown',

--- a/tasks/docs/metadata.js
+++ b/tasks/docs/metadata.js
@@ -87,14 +87,13 @@ function parser(file, callback) {
                 if (startsWith(line, '---')) {
                     active = true;
                 }
-
-                continue;
+            } else {
+                // End of metadata block, stop parsing.
+                if (startsWith(line, '---')) {
+                    break;
+                }
+                yaml.push(line);
             }
-            // End of metadata block, stop parsing.
-            if (startsWith(line, '---')) {
-                break;
-            }
-            yaml.push(line);
         }
 
         // Parse yaml.

--- a/tasks/install.js
+++ b/tasks/install.js
@@ -273,7 +273,7 @@ module.exports = function (callback) {
                 fs.mkdirpSync(installPaths.definition);
                 fs.mkdirpSync(installPaths.theme);
                 fs.mkdirpSync(installPaths.tasks);
-            } catch (error) {
+            } catch {
                 console.error('NPM does not have permissions to create folders at your specified path. Adjust your folders permissions and run "npm install" again');
             }
 


### PR DESCRIPTION
## Description
Activate more modern lint rules 

- no-continue
- guard-for-in
- no-for-loop
- vars-on-top

Also use features, which all modern browsers  support , but only IE11 does not (which we dropped)

- prefer-exponentiation-operator
- prefer-optional-catch-binding
- prefer-code-point
