### PR TITLE
fix(chore): replace deprecated event triggering

### DIFF
--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -230,9 +230,8 @@
                     change: function () {
                         let inputElement = $input[0];
                         if (inputElement) {
-                            let events = document.createEvent('HTMLEvents');
+                            let events = new Event('change', { bubbles: true });
                             module.verbose('Triggering native change event');
-                            events.initEvent('change', true, false);
                             inputElement.dispatchEvent(events);
                         }
                     },

--- a/src/definitions/modules/calendar.js
+++ b/src/definitions/modules/calendar.js
@@ -230,9 +230,9 @@
                     change: function () {
                         let inputElement = $input[0];
                         if (inputElement) {
-                            let events = new Event('change', { bubbles: true });
+                            let event = new Event('change', { bubbles: true });
                             module.verbose('Triggering native change event');
-                            inputElement.dispatchEvent(events);
+                            inputElement.dispatchEvent(event);
                         }
                     },
                 },

--- a/src/definitions/modules/checkbox.js
+++ b/src/definitions/modules/checkbox.js
@@ -553,9 +553,8 @@
                     change: function () {
                         let inputElement = $input[0];
                         if (inputElement) {
-                            let events = document.createEvent('HTMLEvents');
+                            let events = new Event('change', { bubbles: true });
                             module.verbose('Triggering native change event');
-                            events.initEvent('change', true, false);
                             inputElement.dispatchEvent(events);
                         }
                     },

--- a/src/definitions/modules/checkbox.js
+++ b/src/definitions/modules/checkbox.js
@@ -553,9 +553,9 @@
                     change: function () {
                         let inputElement = $input[0];
                         if (inputElement) {
-                            let events = new Event('change', { bubbles: true });
+                            let event = new Event('change', { bubbles: true });
                             module.verbose('Triggering native change event');
-                            inputElement.dispatchEvent(events);
+                            inputElement.dispatchEvent(event);
                         }
                     },
                 },

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1669,9 +1669,8 @@
                     change: function () {
                         let inputElement = $input[0];
                         if (inputElement) {
-                            let events = document.createEvent('HTMLEvents');
+                            let events = new Event('change', { bubbles: true });
                             module.verbose('Triggering native change event');
-                            events.initEvent('change', true, false);
                             inputElement.dispatchEvent(events);
                         }
                     },

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1669,9 +1669,9 @@
                     change: function () {
                         let inputElement = $input[0];
                         if (inputElement) {
-                            let events = new Event('change', { bubbles: true });
+                            let event = new Event('change', { bubbles: true });
                             module.verbose('Triggering native change event');
-                            inputElement.dispatchEvent(events);
+                            inputElement.dispatchEvent(event);
                         }
                     },
                 },


### PR DESCRIPTION
## Description

Replace deprecated event creation by modern Event() constructor. Only IE11 was not supporting it, so it's time to replace this 😉 