### PR TITLE
fix(ci): use trust publishing (OICD) instead of tokens

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,6 +3,7 @@ on:
   schedule:
   - cron: 00 23 * * *
 permissions:
+  id-token: write  # Required for OIDC
   contents: read
 
 jobs:
@@ -18,8 +19,11 @@ jobs:
         ref: develop
     - uses: actions/setup-node@v6
       with:
-        node-version: 18
+        node-version: 20
         registry-url: https://registry.npmjs.org/
+    # Ensure npm 11.5.1 or later is installed
+    - name: Update npm
+      run: npm install -g npm@latest
     - name: pre-setup
       run: sh ./scripts/preinstall.sh
     - name: install dependencies
@@ -34,7 +38,5 @@ jobs:
       if: ${{ steps.nightly-version.outputs.shouldPublish == 'yes' }}
       env:
         CI: true
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTOMATION }}
       run: |
-        npm config set //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN
         npm publish --tag nightly


### PR DESCRIPTION
## Description

Due to npm currently securing their ecosystem to limit token based  access

> This is urgent, as npm already starts to revoke existing tokens and the nightly publish wont work anymore soon otherwise

This PR switches from token based nom access  to trusted publishing (which is recommended by now now), which has already been setup on the Fomantic-UI package by me. 
The only other option would be to manually renew the npm token every 90 days, which i dont find suitable for a nightly github action

https://github.blog/changelog/2025-09-29-strengthening-npm-security-important-changes-to-authentication-and-token-management/

Trusted publishing does not need to renew any tokens every 90 days and is more secure as it limits access from one specific github action (nightly.yml in this case)

The nightly action has been adjusted according to https://docs.npmjs.com/trusted-publishers

btw: The release.yml will be kept token based for now as it only fires upon a new release. Until then we will decide weither we renew the NPM token or switch to manual publish