### PR TITLE
fix(dropdown): prevent change loop trigger

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -2597,7 +2597,11 @@
                             if (settings.useLabels) {
                                 module.remove.selectedItem();
                                 if (value === undefined) {
-                                    module.remove.labels($module.find(selector.label), true);
+                                    let existingLabels = $module.find(selector.label);
+                                    if (existingLabels.length > 0) {
+                                        preventChangeTrigger = true;
+                                        module.remove.labels(existingLabels, true);
+                                    }
                                 }
                             }
                         } else {
@@ -3267,7 +3271,7 @@
                         return $module.hasClass(className.selection);
                     },
                     userValue: function (value) {
-                        return module.get.userValues().includes(value);
+                        return (module.get.userValues() || []).includes(value);
                     },
                     upward: function ($menu) {
                         let $element = $menu || $module;


### PR DESCRIPTION
## Description

Whenever a dropdown selection should be cleared, we added a check  for existing labels to remove them by #3000 in case the input value was modified manually outside of fui logic.

This worked as long as there isnt any additional event listener outside of fomantic which itself does again changes to the dropdown input itself, like the example from #3382 using vuejs to generate the option values and listen to their changes and modifies/retriggers the change event aga.

In such cases we now explicitely prevent the change trigger for additional set values after the removal of existing labels.
Rare case, but possible.

This PR also fixes a regression of #3344 where `includes` was sometimes performed on a boolean value which in turn results in a console error

## Closes
#3382 