### PR TITLE
feat(lint): no-restricted-globals

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -81,7 +81,6 @@ module.exports = {
         'wrap-iife': ['error', 'inside'],
 
         // TODO rules to be removed/fixed in v2.10.0 as fixes are not compatible with IE11
-        'no-restricted-globals': 'off',
         'no-restricted-properties': 'off',
         'unicorn/prefer-reflect-apply': 'off',
         'unicorn/prefer-top-level-await': 'off', // needs Node 14+

--- a/src/definitions/modules/checkbox.js
+++ b/src/definitions/modules/checkbox.js
@@ -153,13 +153,6 @@
                     }
                 },
 
-                preventDefaultOnInputTarget: function () {
-                    if (event !== undefined && event !== null && $(event.target).is(selector.input)) {
-                        module.verbose('Preventing default check action after manual check action');
-                        event.preventDefault();
-                    }
-                },
-
                 event: {
                     change: function (event) {
                         if (!module.should.ignoreCallbacks()) {
@@ -262,7 +255,6 @@
                         settings.onChecked.call(input);
                         module.trigger.change();
                     }
-                    module.preventDefaultOnInputTarget();
                 },
 
                 uncheck: function () {
@@ -275,7 +267,6 @@
                         settings.onUnchecked.call(input);
                         module.trigger.change();
                     }
-                    module.preventDefaultOnInputTarget();
                 },
 
                 indeterminate: function () {

--- a/src/definitions/modules/flyout.js
+++ b/src/definitions/modules/flyout.js
@@ -950,7 +950,7 @@
                         return module.cache.isFirefox;
                     },
                     iframe: function () {
-                        return !(self === top);
+                        return !(window.self === window.top);
                     },
                     mobile: function () {
                         const userAgent = navigator.userAgent;

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -958,7 +958,7 @@
                         return module.cache.isFirefox;
                     },
                     iframe: function () {
-                        return !(self === top);
+                        return !(window.self === window.top);
                     },
                 },
 

--- a/src/definitions/modules/sidebar.js
+++ b/src/definitions/modules/sidebar.js
@@ -672,7 +672,7 @@
                         return module.cache.isFirefox;
                     },
                     iframe: function () {
-                        return !(self === top);
+                        return !(window.self === window.top);
                     },
                     mobile: function () {
                         const userAgent = navigator.userAgent;


### PR DESCRIPTION
## Description

Enabled and fixed eslint no-restricted-globals rule.

For this reason, this will also revert #509, which was only needed for IE11 and old Edge. That code isn't needed anymore as we dropped thoese browsers