### PR TITLE
feat(lint): update to stylelint 15

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -6,6 +6,7 @@ module.exports = {
             options: {
                 parser: 'less',
                 printWidth: Infinity,
+                singleQuote: false,
             },
         },
     ],

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -6,7 +6,6 @@ module.exports = {
             options: {
                 parser: 'less',
                 printWidth: Infinity,
-                singleQuote: false,
             },
         },
     ],

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -11,12 +11,9 @@ module.exports = {
         'at-rule-empty-line-before': null,
         'block-no-empty': null,
         'font-family-no-missing-generic-family-keyword': null,
-        'function-no-unknown': null,
         'import-notation': null,
-        indentation: null, // handled by Prettier
         'keyframes-name-pattern': null,
         'no-descending-specificity': null,
-        'no-extra-semicolons': null, // handled by Prettier
         'no-duplicate-selectors': null,
         'number-max-precision': 5,
         'property-no-vendor-prefix': [true, {

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
     extends: [
-        'stylelint-config-standard',
+        'stylelint-config-standard-less',
     ],
     customSyntax: 'postcss-less',
     ignoreFiles: [
@@ -10,9 +10,7 @@ module.exports = {
     rules: {
         'at-rule-empty-line-before': null,
         'at-rule-name-case': null,
-        'at-rule-no-unknown': null,
         'block-no-empty': null,
-        'color-hex-case': 'lower',
         'declaration-colon-newline-after': null, // handled by Prettier
         'font-family-no-missing-generic-family-keyword': null,
         'function-no-unknown': null,
@@ -35,7 +33,6 @@ module.exports = {
             ],
         }],
         'rule-empty-line-before': null,
-        'string-quotes': 'double',
         'value-keyword-case': null,
 
         // TODO rules to be removed/fixed in v2.10.0 as fixes are not compatible with IE11

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -32,7 +32,6 @@ module.exports = {
 
         // TODO rules to be removed/fixed in v2.10.0 as fixes are not compatible with IE11
         'alpha-value-notation': 'number', // https://caniuse.com/mdn-css_properties_opacity_percentages
-        'selector-no-vendor-prefix': null,
     },
     reportNeedlessDisables: true,
 };

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -9,21 +9,17 @@ module.exports = {
     ],
     rules: {
         'at-rule-empty-line-before': null,
-        'at-rule-name-case': null,
         'block-no-empty': null,
-        'declaration-colon-newline-after': null, // handled by Prettier
         'font-family-no-missing-generic-family-keyword': null,
         'function-no-unknown': null,
         'import-notation': null,
         indentation: null, // handled by Prettier
         'keyframes-name-pattern': null,
         linebreaks: 'unix',
-        'max-line-length': null,
         'no-descending-specificity': null,
         'no-extra-semicolons': null, // handled by Prettier
         'no-duplicate-selectors': null,
         'number-max-precision': 5,
-        'property-case': null,
         'property-no-vendor-prefix': [true, {
             ignoreProperties: [
                 'background-clip', // https://caniuse.com/background-clip-text

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -15,7 +15,6 @@ module.exports = {
         'import-notation': null,
         indentation: null, // handled by Prettier
         'keyframes-name-pattern': null,
-        linebreaks: 'unix',
         'no-descending-specificity': null,
         'no-extra-semicolons': null, // handled by Prettier
         'no-duplicate-selectors': null,

--- a/package.json
+++ b/package.json
@@ -85,8 +85,8 @@
     "postcss": "^8.4.19",
     "postcss-less": "^6.0.0",
     "semver": "^7.3.5",
-    "stylelint": "^14.16.0",
-    "stylelint-config-standard": "^29.0.0",
+    "stylelint": "^15.11.0",
+    "stylelint-config-standard-less": "^2.0.0",
     "typescript": "~5.7.3"
   },
   "engines": {

--- a/src/definitions/collections/breadcrumb.less
+++ b/src/definitions/collections/breadcrumb.less
@@ -115,5 +115,4 @@
     });
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -402,8 +402,6 @@
 /* browsers require these rules separate */
 .ui.form ::placeholder {
     color: @inputPlaceholderColor;
-}
-.ui.form ::-moz-placeholder {
     opacity: 1;
 }
 

--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -372,10 +372,7 @@
     .ui.form .inline.fields .field .prompt::before,
     .ui.form .inline.field .prompt::before {
         border-width: 0 0 @inlinePromptBorderWidth @inlinePromptBorderWidth;
-        bottom: auto;
-        right: auto;
-        top: 50%;
-        left: 0;
+        inset: 50% auto auto 0;
     }
 }
 
@@ -1195,5 +1192,4 @@
     });
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/collections/grid.less
+++ b/src/definitions/collections/grid.less
@@ -1936,5 +1936,4 @@
     }
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -1707,10 +1707,7 @@ Floated Menu / Item
 
     .ui.fixed.menu,
     .ui[class*="top fixed"].menu {
-        top: 0;
-        left: 0;
-        right: auto;
-        bottom: auto;
+        inset: 0 auto auto 0;
     }
     .ui[class*="top fixed"].menu {
         border-top: none;
@@ -1721,10 +1718,7 @@ Floated Menu / Item
         border-top: none;
         border-bottom: none;
         border-right: none;
-        top: 0;
-        right: 0;
-        left: auto;
-        bottom: auto;
+        inset: 0 0 auto auto;
         width: auto;
         height: 100%;
     }
@@ -1732,19 +1726,13 @@ Floated Menu / Item
         border-bottom: none;
         border-left: none;
         border-right: none;
-        bottom: 0;
-        left: 0;
-        top: auto;
-        right: auto;
+        inset: auto auto 0 0;
     }
     .ui[class*="left fixed"].menu {
         border-top: none;
         border-bottom: none;
         border-left: none;
-        top: 0;
-        left: 0;
-        right: auto;
-        bottom: auto;
+        inset: 0 auto auto 0;
         width: auto;
         height: 100%;
     }
@@ -1780,10 +1768,7 @@ Floated Menu / Item
     & when (@variationMenuVertical) {
         .ui.vertical.pointing.menu .item::after {
             position: absolute;
-            top: 50%;
-            right: 0;
-            bottom: auto;
-            left: auto;
+            inset: 50% 0 auto auto;
             transform: translateX(50%) translateY(-50%) rotate(45deg);
             margin: 0 -(@arrowBorderWidth / 2) 0 0;
             border: none;
@@ -2023,5 +2008,4 @@ Floated Menu / Item
     }
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/collections/message.less
+++ b/src/definitions/collections/message.less
@@ -443,5 +443,4 @@
     });
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/collections/table.less
+++ b/src/definitions/collections/table.less
@@ -1987,5 +1987,4 @@
     });
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/button.less
+++ b/src/definitions/elements/button.less
@@ -2041,5 +2041,4 @@
     }
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/container.less
+++ b/src/definitions/elements/container.less
@@ -359,5 +359,4 @@
     }
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/divider.less
+++ b/src/definitions/elements/divider.less
@@ -295,5 +295,4 @@
     });
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/emoji.less
+++ b/src/definitions/elements/emoji.less
@@ -79,6 +79,7 @@ each(@size-map, {
     }
 });
 
+// stylelint-disable less/no-duplicate-variables
 each(@emoji-map, {
     & when (@variationEmojiColons) {
         em[data-emoji=":@{value}:"]::before {
@@ -93,5 +94,4 @@ each(@emoji-map, {
 
 /* rtl:end:ignore */
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/flag.less
+++ b/src/definitions/elements/flag.less
@@ -47,6 +47,7 @@ each(@size-map, {
 /* rtl:begin:ignore */
 
 // for simplicity, class and alias names have to be unique and different to countrycode otherwise false
+// stylelint-disable less/no-duplicate-variables
 each(@flags, {
     @unicode: replace(@key, "@", "");
     @cc: replace(@flags[@@unicode][countrycode], "_", ".", "g");
@@ -83,5 +84,4 @@ each(@flags, {
 
 /* rtl:end:ignore */
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/header.less
+++ b/src/definitions/elements/header.less
@@ -498,5 +498,4 @@
     font-size: @mediumFontSize;
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -603,7 +603,7 @@ i.icons {
     }
 
     .generateIcons(@icon-duotone-map);
-  // stylelint-disable less/no-duplicate-variables
+    // stylelint-disable less/no-duplicate-variables
     .generateIcons(@icon-duotone-secondary-map, false, after);
 
     & when (@variationIconAliases) {

--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -408,10 +408,7 @@ i.icons {
     & when (@variationIconCorner) {
         /* Corner Icon */
         i.icons .corner.icon {
-            top: auto;
-            left: auto;
-            right: @cornerOffset;
-            bottom: @cornerOffset;
+            inset: auto @cornerOffset @cornerOffset auto;
             font-size: @cornerIconSize;
             text-shadow: @cornerIconShadow;
             &@{notRotated}@{notFlipped} {
@@ -419,28 +416,16 @@ i.icons {
             }
         }
         i.icons .icon.corner[class*="top right"] {
-            top: @cornerOffset;
-            left: auto;
-            right: @cornerOffset;
-            bottom: auto;
+            inset: @cornerOffset @cornerOffset auto auto;
         }
         i.icons .icon.corner[class*="top left"] {
-            top: @cornerOffset;
-            left: @cornerOffset;
-            right: auto;
-            bottom: auto;
+            inset: @cornerOffset auto auto @cornerOffset;
         }
         i.icons .icon.corner[class*="bottom left"] {
-            top: auto;
-            left: @cornerOffset;
-            right: auto;
-            bottom: @cornerOffset;
+            inset: auto auto @cornerOffset @cornerOffset;
         }
         i.icons .icon.corner[class*="bottom right"] {
-            top: auto;
-            left: auto;
-            right: @cornerOffset;
-            bottom: @cornerOffset;
+            inset: auto @cornerOffset @cornerOffset auto;
         }
         & when (@variationIconInverted) {
             i.icons .inverted.corner.icon {
@@ -490,31 +475,19 @@ i.icons {
         i.circular.icons .icon.corner,
         i.bordered.icons .icon.corner[class*="bottom right"],
         i.circular.icons .icon.corner[class*="bottom right"] {
-            top: auto;
-            left: auto;
-            right: @borderedGroupCornerOffset;
-            bottom: @borderedGroupCornerOffset;
+            inset: auto @borderedGroupCornerOffset @borderedGroupCornerOffset auto;
         }
         i.bordered.icons .icon.corner[class*="top right"],
         i.circular.icons .icon.corner[class*="top right"] {
-            top: @borderedGroupCornerOffset;
-            left: auto;
-            right: @borderedGroupCornerOffset;
-            bottom: auto;
+            inset: @borderedGroupCornerOffset @borderedGroupCornerOffset auto auto;
         }
         i.bordered.icons .icon.corner[class*="top left"],
         i.circular.icons .icon.corner[class*="top left"] {
-            top: @borderedGroupCornerOffset;
-            left: @borderedGroupCornerOffset;
-            right: auto;
-            bottom: auto;
+            inset: @borderedGroupCornerOffset auto auto @borderedGroupCornerOffset;
         }
         i.bordered.icons .icon.corner[class*="bottom left"],
         i.circular.icons .icon.corner[class*="bottom left"] {
-            top: auto;
-            left: @borderedGroupCornerOffset;
-            right: auto;
-            bottom: @borderedGroupCornerOffset;
+            inset: auto auto @borderedGroupCornerOffset @borderedGroupCornerOffset;
         }
     }
 }
@@ -630,6 +603,7 @@ i.icons {
     }
 
     .generateIcons(@icon-duotone-map);
+  // stylelint-disable less/no-duplicate-variables
     .generateIcons(@icon-duotone-secondary-map, false, after);
 
     & when (@variationIconAliases) {
@@ -662,5 +636,4 @@ i.icons {
     }
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/image.less
+++ b/src/definitions/elements/image.less
@@ -307,5 +307,4 @@ img.ui.image {
     }
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/input.less
+++ b/src/definitions/elements/input.less
@@ -754,5 +754,4 @@
     });
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/input.less
+++ b/src/definitions/elements/input.less
@@ -74,8 +74,6 @@
 
 .ui.input > input::placeholder {
     color: @placeholderColor;
-}
-.ui.input > input::-moz-placeholder {
     opacity: 1;
 }
 

--- a/src/definitions/elements/label.less
+++ b/src/definitions/elements/label.less
@@ -538,10 +538,7 @@ a.ui.label {
         border-radius: 0 @attachedBorderRadius 0 @attachedCornerBorderRadius;
     }
     .ui[class*="bottom right attached"].label {
-        top: auto;
-        bottom: 0;
-        left: auto;
-        right: 0;
+        inset: auto 0 0 auto;
         width: auto;
         border-radius: @attachedBorderRadius 0 @attachedCornerBorderRadius 0;
     }
@@ -945,10 +942,7 @@ a.ui.active.label:hover::before {
     .ui[class*="left pointing"].label::before {
         border-width: 0 0 @borderWidth @borderWidth;
         transform: translateX(-50%) translateY(-50%) rotate(45deg);
-        bottom: auto;
-        right: auto;
-        top: 50%;
-        left: 0;
+        inset: 50% auto auto 0;
     }
 
     /* --- Right --- */
@@ -959,10 +953,7 @@ a.ui.active.label:hover::before {
     .ui[class*="right pointing"].label::before {
         border-width: @borderWidth @borderWidth 0 0;
         transform: translateX(50%) translateY(-50%) rotate(45deg);
-        top: 50%;
-        right: 0;
-        bottom: auto;
-        left: auto;
+        inset: 50% 0 auto auto;
     }
     & when (@variationLabelBasic) {
         /* Basic Pointing */
@@ -1043,5 +1034,4 @@ a.ui.active.label:hover::before {
     });
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/list.less
+++ b/src/definitions/elements/list.less
@@ -1030,5 +1030,4 @@ ol.ui.list ol li,
     });
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/loader.less
+++ b/src/definitions/elements/loader.less
@@ -428,5 +428,4 @@
     }
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/placeholder.less
+++ b/src/definitions/elements/placeholder.less
@@ -248,5 +248,4 @@
     }
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/rail.less
+++ b/src/definitions/elements/rail.less
@@ -144,5 +144,4 @@
     });
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/reveal.less
+++ b/src/definitions/elements/reveal.less
@@ -225,10 +225,7 @@
         position: static !important;
         display: block !important;
         opacity: 1 !important;
-        top: 0 !important;
-        left: 0 !important;
-        right: auto !important;
-        bottom: auto !important;
+        inset: 0 auto auto 0 !important;
         transform: none !important;
     }
     .ui.disabled.reveal:hover > .hidden.hidden.content {
@@ -280,5 +277,4 @@
     });
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -1030,5 +1030,4 @@
     });
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/step.less
+++ b/src/definitions/elements/step.less
@@ -941,5 +941,4 @@
     });
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/elements/text.less
+++ b/src/definitions/elements/text.less
@@ -71,5 +71,4 @@ span.ui.medium.text {
     });
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/globals/reset.less
+++ b/src/definitions/globals/reset.less
@@ -40,5 +40,4 @@ input[type="password"] {
     -moz-appearance: none; /* mobile firefox too! */
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/globals/site.less
+++ b/src/definitions/globals/site.less
@@ -196,5 +196,4 @@ input::selection {
     color: @inputHighlightColor;
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/accordion.less
+++ b/src/definitions/modules/accordion.less
@@ -366,5 +366,4 @@
     }
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/calendar.less
+++ b/src/definitions/modules/calendar.less
@@ -246,5 +246,4 @@
     }
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/checkbox.less
+++ b/src/definitions/modules/checkbox.less
@@ -758,5 +758,4 @@
     });
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/dimmer.less
+++ b/src/definitions/modules/dimmer.less
@@ -387,5 +387,4 @@ body.dimmable > .dimmer {
     }
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -442,8 +442,7 @@ select.ui.dropdown {
 
     /* Selection Menu */
     .ui.selection.dropdown@{notUnlimited} .menu {
-        overflow-x: hidden;
-        overflow-y: auto;
+        overflow: hidden auto;
         overscroll-behavior: @overscrollBehavior;
         backface-visibility: hidden;
     }
@@ -798,8 +797,7 @@ select.ui.dropdown {
 
     /* Search Menu */
     .ui.search.dropdown@{notUnlimited} .menu {
-        overflow-x: hidden;
-        overflow-y: auto;
+        overflow: hidden auto;
         overscroll-behavior: @overscrollBehavior;
         backface-visibility: hidden;
     }
@@ -1375,8 +1373,7 @@ select.ui.dropdown {
     /* Selection Menu */
     .ui.scrolling.dropdown .menu,
     .ui.dropdown .scrolling.menu {
-        overflow-x: hidden;
-        overflow-y: auto;
+        overflow: hidden auto;
         overscroll-behavior: @overscrollBehavior;
         backface-visibility: hidden;
         min-width: 100% !important;
@@ -1595,8 +1592,7 @@ select.ui.dropdown {
         /* Scrolling */
         .ui.simple.scrolling.active.dropdown > .menu,
         .ui.simple.scrolling.dropdown:hover > .menu {
-            overflow-x: hidden;
-            overflow-y: auto;
+            overflow: hidden auto;
             overscroll-behavior: @overscrollBehavior;
         }
     }
@@ -1685,17 +1681,11 @@ select.ui.dropdown {
 
     /* Top Left Pointing */
     .ui.top.left.pointing.dropdown > .menu {
-        top: 100%;
-        bottom: auto;
-        left: 0;
-        right: auto;
+        inset: 100% auto auto 0;
         margin: @pointingArrowDistanceFromEdge 0 0;
     }
     .ui.top.left.pointing.dropdown > .menu {
-        top: 100%;
-        bottom: auto;
-        left: 0;
-        right: auto;
+        inset: 100% auto auto 0;
         margin: @pointingArrowDistanceFromEdge 0 0;
     }
     .ui.top.left.pointing.dropdown > .menu::after {
@@ -1708,10 +1698,7 @@ select.ui.dropdown {
 
     /* Top Right Pointing */
     .ui.top.right.pointing.dropdown > .menu {
-        top: 100%;
-        bottom: auto;
-        right: 0;
-        left: auto;
+        inset: 100% 0 auto auto;
         margin: @pointingArrowDistanceFromEdge 0 0;
     }
     .ui.top.pointing.dropdown > .left.menu::after,
@@ -1766,10 +1753,7 @@ select.ui.dropdown {
 
     /* Bottom Pointing */
     .ui.bottom.pointing.dropdown > .menu {
-        top: auto;
-        bottom: 100%;
-        left: 0;
-        right: auto;
+        inset: auto auto 100% 0;
         margin: 0 0 @pointingArrowDistanceFromEdge;
     }
     .ui.bottom.pointing.dropdown > .menu::after {
@@ -2101,5 +2085,4 @@ select.ui.dropdown {
     }
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/embed.less
+++ b/src/definitions/modules/embed.less
@@ -155,5 +155,4 @@
     }
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/flyout.less
+++ b/src/definitions/modules/flyout.less
@@ -651,5 +651,4 @@ body.pushable > .pusher {
     }
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/modal.less
+++ b/src/definitions/modules/modal.less
@@ -656,5 +656,4 @@
     }
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/nag.less
+++ b/src/definitions/modules/nag.less
@@ -212,5 +212,4 @@ a.ui.nag {
     }
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/popup.less
+++ b/src/definitions/modules/popup.less
@@ -237,18 +237,12 @@
                 /* Top Center (default) */
                 [data-tooltip]:not([data-position])::after,
                 [data-position="top center"][data-tooltip]::after {
-                    top: auto;
-                    right: auto;
-                    left: 50%;
-                    bottom: 100%;
+                    inset: auto auto 100% 50%;
                     margin-bottom: @tooltipDistanceAway;
                 }
                 [data-tooltip]:not([data-position])::before,
                 [data-position="top center"][data-tooltip]::before {
-                    top: auto;
-                    right: auto;
-                    bottom: 100%;
-                    left: 50%;
+                    inset: auto auto 100% 50%;
                     background: @tooltipArrowTopBackground;
                     margin-left: @tooltipArrowHorizontalOffset;
                     margin-bottom: -@tooltipArrowVerticalOffset;
@@ -257,17 +251,11 @@
             & when (@variationPopupLeft) {
                 /* Top Left */
                 [data-position="top left"][data-tooltip]::after {
-                    top: auto;
-                    right: auto;
-                    left: 0;
-                    bottom: 100%;
+                    inset: auto auto 100% 0;
                     margin-bottom: @tooltipDistanceAway;
                 }
                 [data-position="top left"][data-tooltip]::before {
-                    top: auto;
-                    right: auto;
-                    bottom: 100%;
-                    left: @arrowDistanceFromEdge;
+                    inset: auto auto 100% @arrowDistanceFromEdge;
                     margin-left: @tooltipArrowHorizontalOffset;
                     margin-bottom: -@tooltipArrowVerticalOffset;
                 }
@@ -275,17 +263,11 @@
             & when (@variationPopupRight) {
                 /* Top Right */
                 [data-position="top right"][data-tooltip]::after {
-                    top: auto;
-                    left: auto;
-                    right: 0;
-                    bottom: 100%;
+                    inset: auto 0 100% auto;
                     margin-bottom: @tooltipDistanceAway;
                 }
                 [data-position="top right"][data-tooltip]::before {
-                    top: auto;
-                    left: auto;
-                    bottom: 100%;
-                    right: @arrowDistanceFromEdge;
+                    inset: auto @arrowDistanceFromEdge 100% auto;
                     margin-left: @tooltipArrowHorizontalOffset;
                     margin-bottom: -@tooltipArrowVerticalOffset;
                 }
@@ -300,17 +282,11 @@
             & when (@variationPopupCenter) {
                 /* Bottom Center */
                 [data-position="bottom center"][data-tooltip]::after {
-                    bottom: auto;
-                    right: auto;
-                    left: 50%;
-                    top: 100%;
+                    inset: 100% auto auto 50%;
                     margin-top: @tooltipDistanceAway;
                 }
                 [data-position="bottom center"][data-tooltip]::before {
-                    bottom: auto;
-                    right: auto;
-                    top: 100%;
-                    left: 50%;
+                    inset: 100% auto auto 50%;
                     margin-left: @tooltipArrowHorizontalOffset;
                     margin-top: -@arrowOffset;
                 }
@@ -323,10 +299,7 @@
                     margin-top: @tooltipDistanceAway;
                 }
                 [data-position="bottom left"][data-tooltip]::before {
-                    bottom: auto;
-                    right: auto;
-                    top: 100%;
-                    left: @arrowDistanceFromEdge;
+                    inset: 100% auto auto @arrowDistanceFromEdge;
                     margin-left: @tooltipArrowHorizontalOffset;
                     margin-top: -@tooltipArrowVerticalOffset;
                 }
@@ -339,10 +312,7 @@
                     margin-top: @tooltipDistanceAway;
                 }
                 [data-position="bottom right"][data-tooltip]::before {
-                    bottom: auto;
-                    left: auto;
-                    top: 100%;
-                    right: @arrowDistanceFromEdge;
+                    inset: 100% @arrowDistanceFromEdge auto auto;
                     margin-left: @tooltipArrowVerticalOffset;
                     margin-top: -@tooltipArrowHorizontalOffset;
                 }
@@ -548,10 +518,7 @@
     /* --- Below --- */
     .ui.bottom.center.popup::before {
         margin-left: @arrowOffset;
-        top: @arrowOffset;
-        left: 50%;
-        right: auto;
-        bottom: auto;
+        inset: @arrowOffset auto auto 50%;
         box-shadow: @bottomArrowBoxShadow;
     }
 
@@ -561,10 +528,7 @@
 
     /* rtl:rename */
     .ui.bottom.left.popup::before {
-        top: @arrowOffset;
-        left: @arrowDistanceFromEdge;
-        right: auto;
-        bottom: auto;
+        inset: @arrowOffset auto auto @arrowDistanceFromEdge;
         margin-left: 0;
         box-shadow: @bottomArrowBoxShadow;
     }
@@ -575,10 +539,7 @@
 
     /* rtl:rename */
     .ui.bottom.right.popup::before {
-        top: @arrowOffset;
-        right: @arrowDistanceFromEdge;
-        bottom: auto;
-        left: auto;
+        inset: @arrowOffset @arrowDistanceFromEdge auto auto;
         margin-left: 0;
         box-shadow: @bottomArrowBoxShadow;
     }
@@ -588,10 +549,7 @@
     /* --- Above --- */
     & when (@variationPopupCenter) {
         .ui.top.center.popup::before {
-            top: auto;
-            right: auto;
-            bottom: @arrowOffset;
-            left: 50%;
+            inset: auto auto @arrowOffset 50%;
             margin-left: @arrowOffset;
         }
     }
@@ -602,10 +560,7 @@
 
         /* rtl:rename */
         .ui.top.left.popup::before {
-            bottom: @arrowOffset;
-            left: @arrowDistanceFromEdge;
-            top: auto;
-            right: auto;
+            inset: auto auto @arrowOffset @arrowDistanceFromEdge;
             margin-left: 0;
         }
     }
@@ -616,10 +571,7 @@
 
         /* rtl:rename */
         .ui.top.right.popup::before {
-            bottom: @arrowOffset;
-            right: @arrowDistanceFromEdge;
-            top: auto;
-            left: auto;
+            inset: auto @arrowDistanceFromEdge @arrowOffset auto;
             margin-left: 0;
         }
     }
@@ -631,10 +583,7 @@
     /* rtl:rename */
     & when (@variationPopupLeft) {
         .ui.left.center.popup::before {
-            top: 50%;
-            right: @arrowOffset;
-            bottom: auto;
-            left: auto;
+            inset: 50% @arrowOffset auto auto;
             margin-top: @arrowOffset;
             box-shadow: @leftArrowBoxShadow;
         }
@@ -644,10 +593,7 @@
 
         /* rtl:rename */
         .ui.right.center.popup::before {
-            top: 50%;
-            left: @arrowOffset;
-            bottom: auto;
-            right: auto;
+            inset: 50% auto auto @arrowOffset;
             margin-top: @arrowOffset;
             box-shadow: @rightArrowBoxShadow;
         }
@@ -932,5 +878,4 @@
     });
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/progress.less
+++ b/src/definitions/modules/progress.less
@@ -91,10 +91,7 @@
     position: @progressPosition;
     width: @progressWidth;
     font-size: @progressSize;
-    top: @progressTop;
-    right: @progressRight;
-    left: @progressLeft;
-    bottom: @progressBottom;
+    inset: @progressTop @progressRight @progressBottom @progressLeft;
     color: @progressColor;
     text-shadow: @progressTextShadow;
     margin-top: @progressOffset;
@@ -117,10 +114,7 @@
     position: absolute;
     width: @labelWidth;
     font-size: @labelSize;
-    top: @labelTop;
-    right: @labelRight;
-    left: @labelLeft;
-    bottom: @labelBottom;
+    inset: @labelTop @labelRight @labelBottom @labelLeft;
     color: @labelColor;
     font-weight: @labelFontWeight;
     text-shadow: @labelTextShadow;
@@ -352,10 +346,7 @@
         content: "";
         opacity: 0;
         position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
+        inset: 0;
         background: @activePulseColor;
         border-radius: @barBorderRadius;
         animation: progress-active @activePulseDuration @defaultEasing infinite;
@@ -668,5 +659,4 @@
     }
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/rating.less
+++ b/src/definitions/modules/rating.less
@@ -177,5 +177,4 @@
     });
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/search.less
+++ b/src/definitions/modules/search.less
@@ -402,8 +402,7 @@
     .ui.scrolling.search > .results,
     .ui.search.long > .results,
     .ui.search.short > .results {
-        overflow-x: hidden;
-        overflow-y: auto;
+        overflow: hidden auto;
         overscroll-behavior: @overscrollBehavior;
         backface-visibility: hidden;
     }
@@ -597,5 +596,4 @@
     }
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/shape.less
+++ b/src/definitions/modules/shape.less
@@ -143,5 +143,4 @@
     display: block;
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/sidebar.less
+++ b/src/definitions/modules/sidebar.less
@@ -667,5 +667,4 @@ body.pushable > .pusher {
     }
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/slider.less
+++ b/src/definitions/modules/slider.less
@@ -528,5 +528,4 @@
     });
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/sticky.less
+++ b/src/definitions/modules/sticky.less
@@ -65,5 +65,4 @@
     position: sticky;
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/tab.less
+++ b/src/definitions/modules/tab.less
@@ -82,5 +82,4 @@
     }
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/toast.less
+++ b/src/definitions/modules/toast.less
@@ -732,5 +732,4 @@
     }
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/modules/transition.less
+++ b/src/definitions/modules/transition.less
@@ -113,5 +113,4 @@
     }
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/views/ad.less
+++ b/src/definitions/views/ad.less
@@ -293,5 +293,4 @@
     }
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/views/card.less
+++ b/src/definitions/views/card.less
@@ -1180,5 +1180,4 @@
     }
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/views/comment.less
+++ b/src/definitions/views/comment.less
@@ -298,5 +298,4 @@
     }
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/views/feed.less
+++ b/src/definitions/views/feed.less
@@ -536,5 +536,4 @@
     }
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/views/item.less
+++ b/src/definitions/views/item.less
@@ -607,5 +607,4 @@
     }
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/definitions/views/statistic.less
+++ b/src/definitions/views/statistic.less
@@ -414,5 +414,4 @@
     });
 }
 
-// stylelint-disable no-invalid-position-at-import-rule
 @import (multiple, optional) "../../overrides.less";

--- a/src/semantic.less
+++ b/src/semantic.less
@@ -10,7 +10,7 @@
   Import this file into your LESS project to use Fomantic-UI without build tools
 */
 
-// stylelint-disable no-invalid-position-at-import-rule
+
 
 /* Global */
 & { @import "definitions/globals/reset"; }

--- a/src/themes/amazon/elements/button.variables
+++ b/src/themes/amazon/elements/button.variables
@@ -29,7 +29,6 @@
     0 1px 0 1px rgb(255 255 255 / 0.3) inset,
     0 0 0 1px #adb2bb inset;
 
-@coloredBackgroundImage: linear-gradient(rgb(255 255 255 / 0.2), rgb(0 0 0 / 0.2));
 @coloredBoxShadow: 0 1px 0 0 rgb(255 255 255 / 0.2) inset;
 
 @downBoxShadow:

--- a/src/themes/amazon/globals/site.variables
+++ b/src/themes/amazon/globals/site.variables
@@ -18,7 +18,6 @@
 @disabledOpacity: 0.3;
 
 @black: #444c55;
-@orange: #fde07b;
 
 @linkColor: #0066c0;
 @linkHoverColor: #c45500;

--- a/src/themes/bootstrap3/elements/button.variables
+++ b/src/themes/bootstrap3/elements/button.variables
@@ -23,7 +23,6 @@
 
 @borderBoxShadowColor: rgb(0 0 0 / 0.14);
 
-@green: #5cb85c;
 @red: #d9534f;
 @blue: #337ab7;
 @green: #60b044;

--- a/src/themes/default/collections/form.variables
+++ b/src/themes/default/collections/form.variables
@@ -129,7 +129,6 @@
 /* Inverted */
 @invertedInputBackground: @inputBackground;
 @invertedInputBorderColor: @whiteBorderColor;
-@invertedInputBoxShadow: @inputBoxShadow;
 @invertedInputColor: @inputColor;
 @invertedLabelColor: @invertedTextColor;
 @invertedInputBoxShadow: none;

--- a/src/themes/default/elements/button.variables
+++ b/src/themes/default/elements/button.variables
@@ -156,7 +156,6 @@
 @iconButtonOpacity: 0.9;
 
 /* Labeled */
-@labeledLabelFontSize: @medium;
 @labeledLabelAlign: center;
 @labeledLabelPadding: "";
 @labeledLabelFontSize: @relativeMedium;

--- a/src/themes/default/modules/accordion.variables
+++ b/src/themes/default/modules/accordion.variables
@@ -75,7 +75,6 @@
 @styledTitlePadding: 0.75em 1em;
 @styledTitleFontWeight: @bold;
 @styledTitleColor: @unselectedTextColor;
-@styledTitleTransition: background-color @defaultDuration @defaultEasing;
 @styledTitleBorder: 1px solid @borderColor;
 @styledTitleTransition:
     background @defaultDuration @defaultEasing,

--- a/src/themes/default/views/card.variables
+++ b/src/themes/default/views/card.variables
@@ -49,7 +49,6 @@
 /* Image */
 @imageBackground: @transparentBlack;
 @imagePadding: 0;
-@imageBorder: none;
 @imageBoxShadow: none;
 @imageBorder: none;
 

--- a/src/themes/default/views/item.variables
+++ b/src/themes/default/views/item.variables
@@ -46,7 +46,6 @@
 @imageVerticalAlign: start;
 @imageMargin: 0;
 @imagePadding: 0;
-@imageBorder: none;
 @imageBorderRadius: 0.125rem;
 @imageBoxShadow: none;
 @imageBorder: none;

--- a/src/themes/github/modules/dropdown.variables
+++ b/src/themes/github/modules/dropdown.variables
@@ -4,8 +4,6 @@
 
 @transition: width @defaultDuration @defaultEasing;
 
-@menuPadding: 0;
-
 @itemVerticalPadding: @relative8px;
 @itemHorizontalPadding: @relative14px;
 

--- a/src/themes/twitter/elements/button.variables
+++ b/src/themes/twitter/elements/button.variables
@@ -7,7 +7,6 @@
     Helvetica,
     Arial,
     sans-serif;
-@textColor: #66757f;
 @blue: #55acee;
 
 /* -------------------

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,10 +65,25 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@csstools/selector-specificity@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-2.0.2.tgz#1bfafe4b7ed0f3e4105837e056e0a89b108ebe36"
-  integrity sha512-IkpVW/ehM1hWKln4fCA3NzJU8KwD+kIOvPZA4cqxoJHtE21CCzjyp+Kxbu0i5I4tBNOlXPL9mjwnWlL0VEG4Fg==
+"@csstools/css-parser-algorithms@^2.3.1":
+  version "2.7.1"
+  resolved "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.7.1.tgz#6d93a8f7d8aeb7cd9ed0868f946e46f021b6aa70"
+  integrity sha512-2SJS42gxmACHgikc1WGesXLIT8d/q2l0UFM7TaEeIzdFCE/FPMtTiizcPGGJtlPo2xuQzY09OhrLTzRxqJqwGw==
+
+"@csstools/css-tokenizer@^2.2.0":
+  version "2.4.1"
+  resolved "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.4.1.tgz#1d8b2e200197cf5f35ceb07ca2dade31f3a00ae8"
+  integrity sha512-eQ9DIktFJBhGjioABJRtUucoWR2mwllurfnM8LuNGAqX3ViZXaUchqk+1s7jjtkFiT9ySdACsFEA3etErkALUg==
+
+"@csstools/media-query-list-parser@^2.1.4":
+  version "2.1.13"
+  resolved "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.13.tgz#f00be93f6bede07c14ddf51a168ad2748e4fe9e5"
+  integrity sha512-XaHr+16KRU9Gf8XLi3q8kDlI18d5vzKSKCY510Vrtc9iNR0NJzbY9hhTmwhzYZj/ZwGL4VmB3TA9hJW0Um2qFA==
+
+"@csstools/selector-specificity@^3.0.0":
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.1.1.tgz#63085d2995ca0f0e55aa8b8a07d69bfd48b844fe"
+  integrity sha512-a7cxGcJ2wIlMFLlh8z2ONm+715QkPHiyJcxwQlKOz/03GPw1COpfhcmC9wm4xlZfp//jWHNNMwzjtqHXVWU9KA==
 
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.2.0"
@@ -420,10 +435,10 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
-"@types/minimist@^1.2.0":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
-  integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
+"@types/minimist@^1.2.2":
+  version "1.2.5"
+  resolved "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz#ec10755e871497bcd83efe927e43ec46e8c0747e"
+  integrity sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==
 
 "@types/node@*":
   version "17.0.23"
@@ -434,11 +449,6 @@
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
   integrity sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==
-
-"@types/parse-json@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
-  integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
 "@types/semver@^7.3.12":
   version "7.5.8"
@@ -1155,19 +1165,20 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
-camelcase-keys@^6.2.2:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-6.2.2.tgz#5e755d6ba51aa223ec7d3d52f25778210f9dc3c0"
-  integrity sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==
+camelcase-keys@^7.0.0:
+  version "7.0.2"
+  resolved "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-7.0.2.tgz#d048d8c69448745bb0de6fc4c1c52a30dfbe7252"
+  integrity sha512-Rjs1H+A9R+Ig+4E/9oyB66UC5Mj9Xq3N//vcLf2WzgdTi/3gUu3Z9KoqmlrEG4VuuLK8wJHofxzdQXz/knhiYg==
   dependencies:
-    camelcase "^5.3.1"
-    map-obj "^4.0.0"
-    quick-lru "^4.0.1"
+    camelcase "^6.3.0"
+    map-obj "^4.1.0"
+    quick-lru "^5.1.1"
+    type-fest "^1.2.1"
 
-camelcase@^5.3.1:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
-  integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
+camelcase@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
+  integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001426, caniuse-lite@^1.0.30001751:
   version "1.0.30001751"
@@ -1403,16 +1414,15 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
-cosmiconfig@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.1.0.tgz#1443b9afa596b670082ea46cbd8f6a62b84635f6"
-  integrity sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==
+cosmiconfig@^8.2.0:
+  version "8.3.6"
+  resolved "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz#060a2b871d66dba6c8538ea1118ba1ac16f5fae3"
+  integrity sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==
   dependencies:
-    "@types/parse-json" "^4.0.0"
-    import-fresh "^3.2.1"
-    parse-json "^5.0.0"
+    import-fresh "^3.3.0"
+    js-yaml "^4.1.0"
+    parse-json "^5.2.0"
     path-type "^4.0.0"
-    yaml "^1.10.0"
 
 cross-spawn@^7.0.2, cross-spawn@^7.0.6:
   version "7.0.6"
@@ -1423,10 +1433,18 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.6:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-css-functions-list@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/css-functions-list/-/css-functions-list-3.1.0.tgz#cf5b09f835ad91a00e5959bcfc627cd498e1321b"
-  integrity sha512-/9lCvYZaUbBGvYUgYGFJ4dcYiyqdhSjG7IPVluoV8A1ILjkF7ilmhp1OGUz8n+nmBcu0RNrQAzgD8B6FJbrt2w==
+css-functions-list@^3.2.1:
+  version "3.2.3"
+  resolved "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.2.3.tgz#95652b0c24f0f59b291a9fc386041a19d4f40dbe"
+  integrity sha512-IQOkD3hbR5KrN93MtcYuad6YPuTSUhntLHDuLEbFWE+ff2/XSZNdZG+LcbbIW5AXKg/WFIfYItIzVoHngHXZzA==
+
+css-tree@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz#10264ce1e5442e8572fc82fbe490644ff54b5c20"
+  integrity sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==
+  dependencies:
+    mdn-data "2.0.30"
+    source-map-js "^1.0.1"
 
 cssesc@^3.0.0:
   version "3.0.0"
@@ -1509,10 +1527,15 @@ decamelize-keys@^1.1.0:
     decamelize "^1.1.0"
     map-obj "^1.0.0"
 
-decamelize@^1.1.0, decamelize@^1.2.0:
+decamelize@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
+
+decamelize@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.npmjs.org/decamelize/-/decamelize-5.0.1.tgz#db11a92e58c741ef339fb0a2868d8a06a9a7b1e9"
+  integrity sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==
 
 deep-is@^0.1.3:
   version "0.1.4"
@@ -2222,7 +2245,7 @@ fast-fifo@^1.1.0:
   resolved "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz#286e31de96eb96d38a97899815740ba2a4f3640c"
   integrity sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==
 
-fast-glob@^3.2.12, fast-glob@^3.2.9:
+fast-glob@^3.2.9:
   version "3.2.12"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
   integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
@@ -2233,7 +2256,7 @@ fast-glob@^3.2.12, fast-glob@^3.2.9:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
-fast-glob@^3.3.2, fast-glob@^3.3.3:
+fast-glob@^3.3.1, fast-glob@^3.3.2, fast-glob@^3.3.3:
   version "3.3.3"
   resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz#d06d585ce8dba90a16b0505c543c3ccfb3aeb818"
   integrity sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==
@@ -2293,6 +2316,13 @@ file-entry-cache@^6.0.1:
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
+
+file-entry-cache@^7.0.0:
+  version "7.0.2"
+  resolved "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-7.0.2.tgz#2d61bb70ba89b9548e3035b7c9173fe91deafff0"
+  integrity sha512-TfW7/1iI4Cy7Y8L6iqNdZQVvdXn0f8B4QcIXmkIbtTIe/Okm/nSlHb4IwGzRVOd3WfSieCgvf5cMzEfySAIl0g==
+  dependencies:
+    flat-cache "^3.2.0"
 
 fill-range@^7.1.1:
   version "7.1.1"
@@ -2356,10 +2386,24 @@ flat-cache@^3.0.4:
     flatted "^3.1.0"
     rimraf "^3.0.2"
 
+flat-cache@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz#2c0c2d5040c99b1632771a9d105725c0115363ee"
+  integrity sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==
+  dependencies:
+    flatted "^3.2.9"
+    keyv "^4.5.3"
+    rimraf "^3.0.2"
+
 flatted@^3.1.0:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
+
+flatted@^3.2.9:
+  version "3.3.3"
+  resolved "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz#67c8fad95454a7c7abebf74bb78ee74a44023358"
+  integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
 
 for-each@^0.3.3:
   version "0.3.3"
@@ -3080,10 +3124,10 @@ hosted-git-info@^4.0.1:
   dependencies:
     lru-cache "^6.0.0"
 
-html-tags@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-3.2.0.tgz#dbb3518d20b726524e4dd43de397eb0a95726961"
-  integrity sha512-vy7ClnArOZwCnqZgvv+ddgHgJiAFXe3Ge9ML5/mBctVJoUoYPCdxVucOywjDARn6CVoh3dRSFdPHy2sX80L0Wg==
+html-tags@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz#a04026a18c882e4bba8a01a3d39cfe465d40b5ce"
+  integrity sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==
 
 iconv-lite@^0.6.3:
   version "0.6.3"
@@ -3097,7 +3141,7 @@ ieee754@^1.1.13, ieee754@^1.2.1:
   resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
-ignore@^5.2.0, ignore@^5.2.1:
+ignore@^5.2.0, ignore@^5.2.4:
   version "5.3.2"
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
   integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
@@ -3123,6 +3167,14 @@ import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
   integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
+  dependencies:
+    parent-module "^1.0.0"
+    resolve-from "^4.0.0"
+
+import-fresh@^3.3.0:
+  version "3.3.1"
+  resolved "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz#9cecb56503c0ada1f2741dbbd6546e4b13b57ccf"
+  integrity sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==
   dependencies:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
@@ -3153,6 +3205,11 @@ indent-string@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
   integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
+
+indent-string@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz#4fd2980fccaf8622d14c64d694f4cf33c81951a5"
+  integrity sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -3712,6 +3769,11 @@ jsesc@~0.5.0:
   resolved "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
   integrity sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==
 
+json-buffer@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
+  integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
+
 json-parse-even-better-errors@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
@@ -3748,6 +3810,13 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+keyv@^4.5.3:
+  version "4.5.4"
+  resolved "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz#a879a99e29452f942439f2a405e3af8b31d4de93"
+  integrity sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==
+  dependencies:
+    json-buffer "3.0.1"
+
 kind-of@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-1.1.0.tgz#140a3d2d41a36d2efcfa9377b62c24f8495a5c44"
@@ -3758,10 +3827,10 @@ kind-of@^6.0.2, kind-of@^6.0.3:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
-known-css-properties@^0.26.0:
-  version "0.26.0"
-  resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.26.0.tgz#008295115abddc045a9f4ed7e2a84dc8b3a77649"
-  integrity sha512-5FZRzrZzNTBruuurWpvZnvP9pum+fe0HcK8z/ooo+U+Hmp4vtbyp1/QDsqmufirXy4egGzbaH/y2uCZf+6W5Kg==
+known-css-properties@^0.29.0:
+  version "0.29.0"
+  resolved "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.29.0.tgz#e8ba024fb03886f23cb882e806929f32d814158f"
+  integrity sha512-Ne7wqW7/9Cz54PDt4I3tcV+hAyat8ypyOGzYRJQfdxnnjeWsTxt1cy8pjvvKeI5kfXuyvULyeeAvwvvtAX3ayQ==
 
 last-run@^2.0.0:
   version "2.0.0"
@@ -3900,9 +3969,9 @@ map-obj@^1.0.0:
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
   integrity sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==
 
-map-obj@^4.0.0:
+map-obj@^4.1.0:
   version "4.3.0"
-  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.3.0.tgz#9304f906e93faae70880da102a9f1df0ea8bb05a"
+  resolved "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz#9304f906e93faae70880da102a9f1df0ea8bb05a"
   integrity sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==
 
 map-stream@0.0.7:
@@ -3925,23 +3994,28 @@ mathml-tag-names@^2.1.3:
   resolved "https://registry.yarnpkg.com/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz#4ddadd67308e780cf16a47685878ee27b736a0a3"
   integrity sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==
 
-meow@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/meow/-/meow-9.0.0.tgz#cd9510bc5cac9dee7d03c73ee1f9ad959f4ea364"
-  integrity sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==
+mdn-data@2.0.30:
+  version "2.0.30"
+  resolved "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz#ce4df6f80af6cfbe218ecd5c552ba13c4dfa08cc"
+  integrity sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==
+
+meow@^10.1.5:
+  version "10.1.5"
+  resolved "https://registry.npmjs.org/meow/-/meow-10.1.5.tgz#be52a1d87b5f5698602b0f32875ee5940904aa7f"
+  integrity sha512-/d+PQ4GKmGvM9Bee/DPa8z3mXs/pkvJE2KEThngVNOqtmljC6K7NMPxtc2JeZYTmpWb9k/TmxjeL18ez3h7vCw==
   dependencies:
-    "@types/minimist" "^1.2.0"
-    camelcase-keys "^6.2.2"
-    decamelize "^1.2.0"
+    "@types/minimist" "^1.2.2"
+    camelcase-keys "^7.0.0"
+    decamelize "^5.0.0"
     decamelize-keys "^1.1.0"
     hard-rejection "^2.1.0"
     minimist-options "4.1.0"
-    normalize-package-data "^3.0.0"
-    read-pkg-up "^7.0.1"
-    redent "^3.0.0"
-    trim-newlines "^3.0.0"
-    type-fest "^0.18.0"
-    yargs-parser "^20.2.3"
+    normalize-package-data "^3.0.2"
+    read-pkg-up "^8.0.0"
+    redent "^4.0.0"
+    trim-newlines "^4.0.2"
+    type-fest "^1.2.2"
+    yargs-parser "^20.2.9"
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -4084,9 +4158,9 @@ normalize-package-data@^2.5.0:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
-normalize-package-data@^3.0.0:
+normalize-package-data@^3.0.2:
   version "3.0.3"
-  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-3.0.3.tgz#dbcc3e2da59509a0983422884cd172eefdfa525e"
+  resolved "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz#dbcc3e2da59509a0983422884cd172eefdfa525e"
   integrity sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==
   dependencies:
     hosted-git-info "^4.0.1"
@@ -4353,7 +4427,7 @@ parse-import@^2.0.0:
   dependencies:
     get-imports "^1.0.0"
 
-parse-json@^5.0.0:
+parse-json@^5.0.0, parse-json@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
   integrity sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
@@ -4476,11 +4550,6 @@ postcss-less@^6.0.0:
   resolved "https://registry.yarnpkg.com/postcss-less/-/postcss-less-6.0.0.tgz#463b34c60f53b648c237f569aeb2e09149d85af4"
   integrity sha512-FPX16mQLyEjLzEuuJtxA8X3ejDLNGGEG503d2YGZR5Ask1SpDN8KmZUMpzCvyalWRywAn1n1VOA5dcqfCLo5rg==
 
-postcss-media-query-parser@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz#27b39c6f4d94f81b1a73b8f76351c609e5cef244"
-  integrity sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==
-
 postcss-resolve-nested-selector@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz#29ccbc7c37dedfac304e9fff0bf1596b3f6a0e4e"
@@ -4491,20 +4560,20 @@ postcss-safe-parser@^6.0.0:
   resolved "https://registry.yarnpkg.com/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz#bb4c29894171a94bc5c996b9a30317ef402adaa1"
   integrity sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==
 
-postcss-selector-parser@^6.0.11:
-  version "6.0.11"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz#2e41dc39b7ad74046e1615185185cd0b17d0c8dc"
-  integrity sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==
+postcss-selector-parser@^6.0.13:
+  version "6.1.2"
+  resolved "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz#27ecb41fb0e3b6ba7a1ec84fff347f734c7929de"
+  integrity sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==
   dependencies:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
 
-postcss-value-parser@^4.2.0:
+postcss-value-parser@4.2.0, postcss-value-parser@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.3.0, postcss@^8.3.11, postcss@^8.4.19:
+postcss@^8.3.0, postcss@^8.3.11, postcss@^8.4.19, postcss@^8.4.28:
   version "8.5.6"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.6.tgz#2825006615a619b4f62a9e7426cc120b349a8f3c"
   integrity sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==
@@ -4548,10 +4617,10 @@ queue-tick@^1.0.1:
   resolved "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz#f6f07ac82c1fd60f82e098b417a80e52f1f4c142"
   integrity sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==
 
-quick-lru@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
-  integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
+quick-lru@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
+  integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
 read-pkg-up@^7.0.1:
   version "7.0.1"
@@ -4562,6 +4631,15 @@ read-pkg-up@^7.0.1:
     read-pkg "^5.2.0"
     type-fest "^0.8.1"
 
+read-pkg-up@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-8.0.0.tgz#72f595b65e66110f43b052dd9af4de6b10534670"
+  integrity sha512-snVCqPczksT0HS2EC+SxUndvSzn6LRCwpfSvLrIfR5BKDQQZMaI6jPRC9dYvYFDRAuFEAnkwww8kBBNE/3VvzQ==
+  dependencies:
+    find-up "^5.0.0"
+    read-pkg "^6.0.0"
+    type-fest "^1.0.1"
+
 read-pkg@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-5.2.0.tgz#7bf295438ca5a33e56cd30e053b34ee7250c93cc"
@@ -4571,6 +4649,16 @@ read-pkg@^5.2.0:
     normalize-package-data "^2.5.0"
     parse-json "^5.0.0"
     type-fest "^0.6.0"
+
+read-pkg@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/read-pkg/-/read-pkg-6.0.0.tgz#a67a7d6a1c2b0c3cd6aa2ea521f40c458a4a504c"
+  integrity sha512-X1Fu3dPuk/8ZLsMhEj5f4wFAF0DWoK7qhGJvgaijocXxBmSToKfbFtqbxMO7bVjNA1dmE5huAzjXj/ey86iw9Q==
+  dependencies:
+    "@types/normalize-package-data" "^2.4.0"
+    normalize-package-data "^3.0.2"
+    parse-json "^5.2.0"
+    type-fest "^1.0.1"
 
 "readable-stream@2 || 3", readable-stream@3, readable-stream@^3.4.0:
   version "3.6.0"
@@ -4630,13 +4718,13 @@ rechoir@^0.8.0:
   dependencies:
     resolve "^1.20.0"
 
-redent@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"
-  integrity sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==
+redent@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz#0c0ba7caabb24257ab3bb7a4fd95dd1d5c5681f9"
+  integrity sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==
   dependencies:
-    indent-string "^4.0.0"
-    strip-indent "^3.0.0"
+    indent-string "^5.0.0"
+    strip-indent "^4.0.0"
 
 reflect.getprototypeof@^1.0.6, reflect.getprototypeof@^1.0.9:
   version "1.0.10"
@@ -5074,7 +5162,7 @@ side-channel@^1.1.0:
     side-channel-map "^1.0.1"
     side-channel-weakmap "^1.0.2"
 
-signal-exit@^3.0.2, signal-exit@^3.0.7:
+signal-exit@^3.0.2:
   version "3.0.7"
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
@@ -5098,7 +5186,7 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
-source-map-js@^1.2.1:
+source-map-js@^1.0.1, source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
@@ -5338,6 +5426,11 @@ strip-indent@^3.0.0:
   dependencies:
     min-indent "^1.0.0"
 
+strip-indent@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.npmjs.org/strip-indent/-/strip-indent-4.1.1.tgz#aba13de189d4ad9a17f6050e76554ac27585c7af"
+  integrity sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==
+
 strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
@@ -5348,61 +5441,88 @@ style-search@^0.1.0:
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
   integrity sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==
 
-stylelint-config-recommended@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-9.0.0.tgz#1c9e07536a8cd875405f8ecef7314916d94e7e40"
-  integrity sha512-9YQSrJq4NvvRuTbzDsWX3rrFOzOlYBmZP+o513BJN/yfEmGSr0AxdvrWs0P/ilSpVV/wisamAHu5XSk8Rcf4CQ==
-
-stylelint-config-standard@^29.0.0:
-  version "29.0.0"
-  resolved "https://registry.yarnpkg.com/stylelint-config-standard/-/stylelint-config-standard-29.0.0.tgz#4cc0e0f05512a39bb8b8e97853247d3a95d66fa2"
-  integrity sha512-uy8tZLbfq6ZrXy4JKu3W+7lYLgRQBxYTUUB88vPgQ+ZzAxdrvcaSUW9hOMNLYBnwH+9Kkj19M2DHdZ4gKwI7tg==
+stylelint-config-recommended-less@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/stylelint-config-recommended-less/-/stylelint-config-recommended-less-2.0.0.tgz#faaacaaadc93abed7e9deaa81f85583069944c5b"
+  integrity sha512-6X5A9kdusuLzS/9yfkQfzYg5ry43KHXMnUmiPCIidwQEW/cegn44CtRPfN+9SLcVkUVcRNpuLYfHtbLtoUHgkA==
   dependencies:
-    stylelint-config-recommended "^9.0.0"
+    postcss-less "^6.0.0"
+    stylelint-config-recommended "^13.0.0"
+    stylelint-less "^2.0.0"
 
-stylelint@^14.16.0:
-  version "14.16.1"
-  resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-14.16.1.tgz#b911063530619a1bbe44c2b875fd8181ebdc742d"
-  integrity sha512-ErlzR/T3hhbV+a925/gbfc3f3Fep9/bnspMiJPorfGEmcBbXdS+oo6LrVtoUZ/w9fqD6o6k7PtUlCOsCRdjX/A==
+stylelint-config-recommended@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-13.0.0.tgz#c48a358cc46b629ea01f22db60b351f703e00597"
+  integrity sha512-EH+yRj6h3GAe/fRiyaoO2F9l9Tgg50AOFhaszyfov9v6ayXJ1IkSHwTxd7lB48FmOeSGDPLjatjO11fJpmarkQ==
+
+stylelint-config-standard-less@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/stylelint-config-standard-less/-/stylelint-config-standard-less-2.0.0.tgz#bc5a5824b7b20f6e4ae7c049ff1b5631b0f00c84"
+  integrity sha512-hLrK5oNV2Ombs0IC11gzGsYtADX8dquevs+Ls2jY4IY2wywPLnUSW5a5ofxXVan1j1z6OMcs8fWikbpj9Y5VgQ==
   dependencies:
-    "@csstools/selector-specificity" "^2.0.2"
+    stylelint-config-recommended-less "^2.0.0"
+    stylelint-config-standard "^34.0.0"
+
+stylelint-config-standard@^34.0.0:
+  version "34.0.0"
+  resolved "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-34.0.0.tgz#309f3c48118a02aae262230c174282e40e766cf4"
+  integrity sha512-u0VSZnVyW9VSryBG2LSO+OQTjN7zF9XJaAJRX/4EwkmU0R2jYwmBSN10acqZisDitS0CLiEiGjX7+Hrq8TAhfQ==
+  dependencies:
+    stylelint-config-recommended "^13.0.0"
+
+stylelint-less@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/stylelint-less/-/stylelint-less-2.0.0.tgz#c9b9c9091ee522dbeeb6ea54c02809a2826ff942"
+  integrity sha512-HwRdAdrNDBg64BzIOP3SSHFPJHvRJEpqFn8Kp5m5Enw6pf7kI9XoNT3jn1S2zvfzaK/7hdwy6La3cyJT78fK3A==
+  dependencies:
+    postcss-resolve-nested-selector "^0.1.1"
+    postcss-value-parser "4.2.0"
+
+stylelint@^15.11.0:
+  version "15.11.0"
+  resolved "https://registry.npmjs.org/stylelint/-/stylelint-15.11.0.tgz#3ff8466f5f5c47362bc7c8c9d382741c58bc3292"
+  integrity sha512-78O4c6IswZ9TzpcIiQJIN49K3qNoXTM8zEJzhaTE/xRTCZswaovSEVIa/uwbOltZrk16X4jAxjaOhzz/hTm1Kw==
+  dependencies:
+    "@csstools/css-parser-algorithms" "^2.3.1"
+    "@csstools/css-tokenizer" "^2.2.0"
+    "@csstools/media-query-list-parser" "^2.1.4"
+    "@csstools/selector-specificity" "^3.0.0"
     balanced-match "^2.0.0"
     colord "^2.9.3"
-    cosmiconfig "^7.1.0"
-    css-functions-list "^3.1.0"
+    cosmiconfig "^8.2.0"
+    css-functions-list "^3.2.1"
+    css-tree "^2.3.1"
     debug "^4.3.4"
-    fast-glob "^3.2.12"
+    fast-glob "^3.3.1"
     fastest-levenshtein "^1.0.16"
-    file-entry-cache "^6.0.1"
+    file-entry-cache "^7.0.0"
     global-modules "^2.0.0"
     globby "^11.1.0"
     globjoin "^0.1.4"
-    html-tags "^3.2.0"
-    ignore "^5.2.1"
+    html-tags "^3.3.1"
+    ignore "^5.2.4"
     import-lazy "^4.0.0"
     imurmurhash "^0.1.4"
     is-plain-object "^5.0.0"
-    known-css-properties "^0.26.0"
+    known-css-properties "^0.29.0"
     mathml-tag-names "^2.1.3"
-    meow "^9.0.0"
+    meow "^10.1.5"
     micromatch "^4.0.5"
     normalize-path "^3.0.0"
     picocolors "^1.0.0"
-    postcss "^8.4.19"
-    postcss-media-query-parser "^0.2.3"
+    postcss "^8.4.28"
     postcss-resolve-nested-selector "^0.1.1"
     postcss-safe-parser "^6.0.0"
-    postcss-selector-parser "^6.0.11"
+    postcss-selector-parser "^6.0.13"
     postcss-value-parser "^4.2.0"
     resolve-from "^5.0.0"
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
     style-search "^0.1.0"
-    supports-hyperlinks "^2.3.0"
+    supports-hyperlinks "^3.0.0"
     svg-tags "^1.0.0"
     table "^6.8.1"
-    v8-compile-cache "^2.3.0"
-    write-file-atomic "^4.0.2"
+    write-file-atomic "^5.0.1"
 
 supports-color@^5.3.0:
   version "5.5.0"
@@ -5418,10 +5538,10 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-supports-hyperlinks@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz#3943544347c1ff90b15effb03fc14ae45ec10624"
-  integrity sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==
+supports-hyperlinks@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz#b8e485b179681dea496a1e7abdf8985bd3145461"
+  integrity sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==
   dependencies:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
@@ -5540,10 +5660,10 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
 
-trim-newlines@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
-  integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
+trim-newlines@^4.0.2:
+  version "4.1.1"
+  resolved "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.1.1.tgz#28c88deb50ed10c7ba6dc2474421904a00139125"
+  integrity sha512-jRKj0n0jXWo6kh62nA5TEh3+4igKDXLvzBJcPpiizP7oOolUrYIxmVBG9TOtHYFHoddUk6YvAkGeGoSVTXfQXQ==
 
 ts-api-utils@^2.1.0:
   version "2.1.0"
@@ -5589,11 +5709,6 @@ type-check@^0.4.0, type-check@~0.4.0:
   dependencies:
     prelude-ls "^1.2.1"
 
-type-fest@^0.18.0:
-  version "0.18.1"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.18.1.tgz#db4bc151a4a2cf4eebf9add5db75508db6cc841f"
-  integrity sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==
-
 type-fest@^0.20.2:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
@@ -5613,6 +5728,11 @@ type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
+type-fest@^1.0.1, type-fest@^1.2.1, type-fest@^1.2.2:
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
+  integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
 
 typed-array-buffer@^1.0.0:
   version "1.0.0"
@@ -5828,11 +5948,6 @@ util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
-
-v8-compile-cache@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
-  integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
 
 v8flags@^4.0.0:
   version "4.0.1"
@@ -6109,13 +6224,13 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
-write-file-atomic@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-4.0.2.tgz#a9df01ae5b77858a027fd2e80768ee433555fcfd"
-  integrity sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==
+write-file-atomic@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz#68df4717c55c6fa4281a7860b4c2ba0a6d2b11e7"
+  integrity sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==
   dependencies:
     imurmurhash "^0.1.4"
-    signal-exit "^3.0.7"
+    signal-exit "^4.0.1"
 
 xtend@~4.0.1:
   version "4.0.2"
@@ -6132,17 +6247,12 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml@^1.10.0:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
-  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
-
 yargs-parser@>=5.0.0-security.0:
   version "21.0.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.1.tgz#0267f286c877a4f0f728fceb6f8a3e4cb95c6e35"
   integrity sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==
 
-yargs-parser@^20.2.2, yargs-parser@^20.2.3:
+yargs-parser@^20.2.2, yargs-parser@^20.2.9:
   version "20.2.9"
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==


### PR DESCRIPTION
## Description

- Upgrade stylelint to [15](https://stylelint.io/migration-guide/to-15/)
- switch to 'stylelint-config-standard-less'  (which itself extends 'stylelint-config-standard')
- removed deprecated stylelint rules (most of them are now handled by default prettier config like the "case" rules)
- removed a few duplicate variable declarations (found by stylelint 15 ;) )
- removed/fixed selector-no-vendor-prefix rule

Breaking change as 
- Use `inset` and 2 values overflow property shorthand 
does not work in IE11 and needs modern browsers (2021+, iOS 14.1+)