### PR TITLE
feat(chore): adjust minimum browser support to 2021+ features

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,12 @@ Fomantic includes an interactive installer to help setup your project.
 
 ### 💻 Browser Support
 
-* Last 2 Versions of Firefox, Chrome, Safari Mac, Edge
-* Last 4 Versions of Android, Chrome for Android, iOS Safari[^1]
-
-[^1]: Fomantic-UI should basically still work in iOS Safari 11+, Android 7+, but, starting from v2.9.0, we won't support them anymore if anything works different than in recent versions.
+* [![Chrome](https://cdnjs.cloudflare.com/ajax/libs/browser-logos/75.0.1/chrome/chrome_16x16.png)]() Chrome >= 88
+* [![Edge](https://cdnjs.cloudflare.com/ajax/libs/browser-logos/75.0.1/edge/edge_16x16.png)]() Edge >= 88
+* [![Safari](https://cdnjs.cloudflare.com/ajax/libs/browser-logos/75.0.1/archive/safari-ios_1-6/safari-ios_1-6_16x16.png)]() Safari >= 14.1
+* [![Firefox](https://cdnjs.cloudflare.com/ajax/libs/browser-logos/75.0.1/firefox/firefox_16x16.png)]() Firefox >= 82
+* [![iOS](https://img.shields.io/badge/-ffffff?logo=apple&logoColor=black)]() iOS >= 14.1
+* [![Android](https://img.shields.io/badge/-ffffff?logo=android&logoColor=43dd88)]() Android >= 8
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Fomantic includes an interactive installer to help setup your project.
 * [![Edge](https://cdnjs.cloudflare.com/ajax/libs/browser-logos/75.0.1/edge/edge_16x16.png)]() Edge >= 88
 * [![Safari](https://cdnjs.cloudflare.com/ajax/libs/browser-logos/75.0.1/archive/safari-ios_1-6/safari-ios_1-6_16x16.png)]() Safari >= 14.1
 * [![Firefox](https://cdnjs.cloudflare.com/ajax/libs/browser-logos/75.0.1/firefox/firefox_16x16.png)]() Firefox >= 82
+* [![Opera](https://cdnjs.cloudflare.com/ajax/libs/browser-logos/75.0.1/opera/opera_16x16.png)]() Opera >= 75
+* [![Saumsung Internet](https://cdnjs.cloudflare.com/ajax/libs/browser-logos/75.0.1/samsung-internet/samsung-internet_16x16.png)]() Samsung Internet >= 15
 * [![iOS](https://img.shields.io/badge/-ffffff?logo=apple&logoColor=black)]() iOS >= 14.1
 * [![Android](https://img.shields.io/badge/-ffffff?logo=android&logoColor=43dd88)]() Android >= 8
 

--- a/tasks/config/tasks.js
+++ b/tasks/config/tasks.js
@@ -10,12 +10,13 @@ const hasBrowserslistConfig = JSON.stringify(defaultBrowsers) !== JSON.stringify
 const prefix = config.prefix || {};
 if (!prefix.overrideBrowserslist && !hasBrowserslistConfig) {
     prefix.overrideBrowserslist = [
-        'last 2 Chrome versions',
-        'last 2 Firefox versions',
-        'last 2 Safari versions',
-        'last 4 iOS major versions',
-        'last 4 Android major versions',
-        'last 4 ChromeAndroid versions',
+        'chrome >= 88',
+        'edge >= 88',
+        'safari >= 14.1',
+        'firefox >= 82',
+        'ios >= 14.1',
+        'android >= 8',
+        '>0.3%',
     ];
 }
 

--- a/tasks/config/tasks.js
+++ b/tasks/config/tasks.js
@@ -14,6 +14,8 @@ if (!prefix.overrideBrowserslist && !hasBrowserslistConfig) {
         'edge >= 88',
         'safari >= 14.1',
         'firefox >= 82',
+        'opera >= 75',
+        'samsung >= 15',
         'ios >= 14.1',
         'android >= 8',
         '>0.3%',


### PR DESCRIPTION
## Description

Because of the recent (#3396) and upcoming changes, we need to clarify the browser support:

- Chrome >= 88
- Edge >= 88
- Safari >= 14.1
- Firefox >= 82
- Opera >= 75
- Samsung Internet >= 15
- iOS >= 14.1
- Android >= 8

See https://browsersl.ist/#q=chrome+%3E%3D+88%2C+edge+%3E%3D+88%2C+safari+%3E%3D+14.1%2C+firefox+%3E%3D+82%2C+ios+%3E%3D+14.1%2C+android+%3E%3D+8%2C+opera+%3E+75%2C+samsung+%3E%3D+15%2C+%3E0.3%25

According to the above seen statistics we could even raise this even more, but lets see how far the next version really goes :wink:

THis PR adjusts the readme and build tasks when using browsersList accordingly

## Related
#2854