### PR TITLE
fix(toast,modal,flyout): use body default on jquery shortcut

### DIFF
--- a/src/definitions/modules/flyout.js
+++ b/src/definitions/modules/flyout.js
@@ -20,12 +20,13 @@
         : globalThis;
 
     $.fn.flyout = function (...args) {
-        const $allModules = $(this);
         const $window = $(window);
         const $document = $(document);
-        const $html = $('html');
         const $head = $('head');
         const $body = $('body');
+        const $allModules = isFunction(this)
+            ? $body
+            : $(this);
 
         let time = Date.now();
         let performance = [];

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -20,10 +20,12 @@
         : globalThis;
 
     $.fn.modal = function (...args) {
-        const $allModules = $(this);
         const $window = $(window);
         const $document = $(document);
         const $body = $('body');
+        const $allModules = isFunction(this)
+            ? $body
+            : $(this);
 
         let time = Date.now();
         let performance = [];

--- a/src/definitions/modules/tab.js
+++ b/src/definitions/modules/tab.js
@@ -794,9 +794,7 @@
     };
 
     // shortcut for tabbed content with no defined navigation
-    $.tab = function (...args) {
-        $(window).tab.apply(this, args);
-    };
+    $.tab = $.fn.tab;
 
     $.fn.tab.settings = {
 

--- a/src/definitions/modules/toast.js
+++ b/src/definitions/modules/toast.js
@@ -20,8 +20,10 @@
         : globalThis;
 
     $.fn.toast = function (...args) {
-        const $allModules = $(this);
         const $body = $('body');
+        const $allModules = isFunction(this)
+            ? $body
+            : $(this);
 
         let time = Date.now();
         let performance = [];


### PR DESCRIPTION
## Description

Calling toast, flyout or modal without context using jquery shortcut notation (e.g. `$.toast()` instead of `$('body').toast()`) will be treated internally as `.ready()` call by jquery

The tab module was fetching this already but had an unnecessary additional function implementation (which lacked providing the return value), so i made it equal to all other usages (like for `$.api`), so tab now also returns the jquery object in that case just like all other modules.

I also removed the unused `$html` variable inside tab...  

## Fixes
#3421 