### PR TITLE
fix(build): make sure IE11 support is not fetched

### DIFF
--- a/tasks/config/tasks.js
+++ b/tasks/config/tasks.js
@@ -19,6 +19,7 @@ if (!prefix.overrideBrowserslist && !hasBrowserslistConfig) {
         'ios >= 14.1',
         'android >= 8',
         '>0.3%',
+        'not dead',
     ];
 }
 


### PR DESCRIPTION
## Description
Followup on #3400 
Make sure IE11 is not covered anymore (>0.3% wasnt clear enough)
See https://browsersl.ist/#q=chrome+%3E%3D+88%2C+edge+%3E%3D+88%2C+safari+%3E%3D+14.1%2C+firefox+%3E%3D+82%2C+ios+%3E%3D+14.1%2C+android+%3E%3D+8%2C+opera+%3E+75%2C+samsung+%3E%3D+15%2C+%3E0.3%25%2C+not+dead