### PR TITLE
fix(dropdown): escape search value when used for selection message

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -2747,7 +2747,7 @@
                         }
                         module.refreshItems();
                     },
-                    variables: function (message = '', term = module.get.query()) {
+                    variables: function (message = '', term = settings.templates.escape(module.get.query())) {
                         const hasCount = message.search('{count}') !== -1;
                         const hasMaxCount = message.search('{maxCount}') !== -1;
                         const hasTerm = message.search('{term}') !== -1;


### PR DESCRIPTION
## Description

In a very rare / theoretically case, a user search input might contain HTML which was identically supplied as a item value.
In such case and when the existing value is selected, the search value is used inside the selection message and needs to be escaped. 