### PR TITLE
fix(formvalidation): skip undefined identifiers

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1253,6 +1253,11 @@
                             return true;
                         }
                         const identifier = field.identifier || fieldName;
+                        if (!identifier) {
+                            module.debug('No identifier given. Skipping');
+
+                            return true;
+                        }
                         const $field = module.get.field(identifier);
                         const $fieldGroup = $field.closest($group);
                         const $dependsField = field.depends


### PR DESCRIPTION
## Description

Whenever a form contains input fields without any id or name attribute in a form, they cannot be identified automatically by the formvalidation when collecting form input fields and no manual validation rule is given. Such input elements should always be declared as "valid".

The current code already ignored them at least, but still tried to validate them and failed while trying to fetch the identifier as it wasnt found in any rule and also couldnt be fetched automatically from an id or name attribute.
Such "undefined" elements had an error logged in the console instead, which is unnecessary.

However, the whole validation still worked fine, only the console message could be mislead.

This was now adjusted, so such undefined identifiers will be declared as valid.

## Closes
#3443 