### PR TITLE
fix(ci): latest npm for nightly needs node 22+

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,7 +19,7 @@ jobs:
         ref: develop
     - uses: actions/setup-node@v6
       with:
-        node-version: 20
+        node-version: 24
         registry-url: https://registry.npmjs.org/
     # Ensure npm 11.5.1 or later is installed
     - name: Update npm


### PR DESCRIPTION
## Description
The nightly deploy script uses `npm@latest`, which, recently, needs node 22+.

So this PR raises the desired node version for the nightly deploy task 