### PR TITLE
fix(ci): npm 12 and setup node 7 breaks node_auth_token

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,7 +20,6 @@ jobs:
     - uses: actions/setup-node@v7
       with:
         node-version: 24
-        registry-url: https://registry.npmjs.org/
     # Ensure npm 11.5.1 or later is installed
     - name: Update npm
       run: npm install -g npm@latest


### PR DESCRIPTION
## Description
should fix the nightly workflow publish as npm latest uses v12 and using setup-node 7 breaks yarn install because NPM_AUTH_TOKEN isnt set and cannot be rewritten (See gh actions)

by removing the registry-url setting, there won't be a default .npmrc which does not require the node_auth_token to exist

See https://github.com/actions/setup-node/issues/1440 ff


